### PR TITLE
Fix link to rendezvous server repo in API doc

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -99,7 +99,8 @@ to the application source code or default config.
 
 This library includes the URL of a public rendezvous server run by the
 author. Application developers can use this one, or they can run their own
-(see the https://github.com/warner/magic-wormhole-mailbox-server repository)
+(see the [warner/magic-wormhole-mailbox-server
+](https://github.com/warner/magic-wormhole-mailbox-server) repository)
 and configure their clients to use it instead. The URL of the public
 rendevouz server is passed as a unicode string. Note that because the server
 actually speaks WebSockets, the URL starts with `ws:` instead of `http:`.


### PR DESCRIPTION
Fixes an issue where the link to the rendezvous server repository was being rendered as plain text in the docs.

I formatted the link weirdly to keep the line length down :shrug: 