### PR TITLE
update WrongPasswordError

### DIFF
--- a/src/wormhole/errors.py
+++ b/src/wormhole/errors.py
@@ -50,9 +50,8 @@ class LonelyError(WormholeError):
 class WrongPasswordError(WormholeError):
     """
     Key confirmation failed. Either you or your correspondent typed the code
-    wrong, or a would-be man-in-the-middle attacker guessed incorrectly. You
-    could try again, giving both your correspondent and the attacker another
-    chance.
+    wrong, or a would-be man-in-the-middle attacker guessed incorrectly. Try
+    sending the file again. 
     """
     # or the data blob was corrupted, and that's why decrypt failed
     pass


### PR DESCRIPTION
changed error message to say "Try to send file again" as discussed in issue #395 .
Not sure if the caution message about "your attacker may have another change to guess" should be added. It makes the message too long. 