### PR TITLE
add a --debug-state command-line option

### DIFF
--- a/src/wormhole/cli/cli.py
+++ b/src/wormhole/cli/cli.py
@@ -38,6 +38,30 @@ class Config(object):
         self.stdout = stdout
         self.stderr = stderr
         self.tor = False  # XXX?
+        self._debug_state = None
+
+    @property
+    def debug_state(self):
+        return self._debug_state
+
+    @debug_state.setter
+    def debug_state(self, debug_state):
+        if not debug_state:
+            return
+        valid_machines = [
+            'B', 'N', 'M', 'S', 'O', 'K', 'SK', 'R', 'RC', 'L', 'C', 'T'
+        ]
+        debug_state = debug_state.split(",")
+        invalid_machines = [
+            machine
+            for machine in debug_state
+            if machine not in valid_machines
+        ]
+        if invalid_machines:
+            raise click.UsageError(
+                "Cannot debug unknown machines: {}".format(" ".join(invalid_machines))
+            )
+        self._debug_state = debug_state
 
 
 def _compose(*decorators):
@@ -236,6 +260,19 @@ def help(context, **kwargs):
     default=False,
     is_flag=True,
     help="Don't raise an error if a file can't be read.")
+@click.option(
+    "--debug-state",
+    is_flag=False,
+    flag_value="B,N,M,S,O,K,SK,R,RC,L,C,T",
+    default=None,
+    metavar="MACHINES",
+    help=(
+        "Debug state-machine transitions. "
+        "Possible machines to debug are accepted as a comma-separated list "
+        "and the default is all of them. Valid machines are "
+        "any of: B,N,M,S,O,K,SK,R,RC,L,C,T"
+    )
+)
 @click.argument("what", required=False, type=click.Path(path_type=type(u"")))
 @click.pass_obj
 def send(cfg, **kwargs):
@@ -276,6 +313,21 @@ def go(f, cfg):
     metavar="FILENAME|DIRNAME",
     help=("The file or directory to create, overriding the name suggested"
           " by the sender."),
+)
+# --debug-state might be better at the top-level but Click can't parse
+# an option like "--debug-state <optional-value>" if there's a subcommand name next
+@click.option(
+    "--debug-state",
+    is_flag=False,
+    flag_value="B,N,M,S,O,K,SK,R,RC,L,C,T",
+    default=None,
+    metavar="MACHINES",
+    help=(
+        "Debug state-machine transitions. "
+        "Possible machines to debug are accepted as a comma-separated list "
+        "and the default is all of them. Valid machines are "
+        "any of: B,N,M,S,O,K,SK,R,RC,L,C,T"
+    )
 )
 @click.argument(
     "code",

--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -84,6 +84,8 @@ class Receiver:
             self._reactor,
             tor=self._tor,
             timing=self.args.timing)
+        if self.args.debug_state:
+            w.debug_set_trace("recv", which=" ".join(self.args.debug_state), file=self.args.stdout)
         self._w = w  # so tests can wait on events too
 
         # I wanted to do this instead:

--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -69,6 +69,8 @@ class Sender:
             self._reactor,
             tor=self._tor,
             timing=self._timing)
+        if self._args.debug_state:
+            w.debug_set_trace("send", which=" ".join(self._args.debug_state), file=self._args.stdout)
         d = self._go(w)
 
         # if we succeed, we should close and return the w.close results


### PR DESCRIPTION
This exposes set_trace functionality for debugging
state-machine transitions in the various state machines.