### PR TITLE
Send empty directories in `wormhole send` too

### DIFF
--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -248,9 +248,9 @@ class Sender:
         ts = self._transit_sender
         ts.add_connection_hints(receiver_transit.get("hints-v1", []))
 
-    def _add_zip_entry(self, zip_file, basename, local_path, entry_name):
+    def _add_zip_entry(self, zip_file, base_path, local_path, entry_name):
         archive_path = os.path.join(*tuple(local_path + [entry_name]))
-        local_entry_path = os.path.join(basename, entry_name)
+        local_entry_path = os.path.join(base_path, entry_name)
 
         num_bytes = 0
         try:
@@ -296,12 +296,12 @@ class Sender:
                 local_path = list(path.split(os.sep)[tostrip:])
                 for dir_name in dirs:
                     num_bytes += self._add_zip_entry(
-                        zf, basename, local_path, dir_name
+                        zf, path, local_path, dir_name
                     )
 
                 for file_name in files:
                     num_bytes += self._add_zip_entry(
-                        zf, basename, local_path, file_name
+                        zf, path, local_path, file_name
                     )
                     num_files += 1
         fd_to_send.seek(0, 2)

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@
 
 [tox]
 # useful envs: py27-nodilate, py35, py36, py37, py38, pypy, flake8
-envlist = {py27-nodilate,py35,py36,py37,py38}
+envlist = {py27-nodilate,py35,py36,py37,py38,py39}
 skip_missing_interpreters = True
 minversion = 2.4.0
 


### PR DESCRIPTION
Closes #232 

Hello! Obligatory thanks for the great tool, it makes sending directories between computers work like a dream

I ended up running #232 which confused me for a bit since I wasn't expecting empty directories to be silently excluded.

This change ended up touching more than I was expecting, but reusing the logic for adding files or directories to the zipfile required pulling some things out to separate functions.

In regards to styling I  couldn't find any documentation listing style guidelines or formatters used, so I just kept changes to an 80 character line limit (and it looks like `cmd_send.py` accidentally got auto-formatted without me realizing it).

The changes do pass the test suite for me (python 3.9 on linux), and beyond that everything seemed to work fine when testing manually. I didn't test any other versions since I don't have any other python interpreters installed and this is my first time dealing with Python 2 code, so any subtle issues there may have slipped by me.

I'd also like to note that this does change the message on the uncompressed size since it's now including directories too which are typically 4KiB each. I think this would be fine since the message is talking about the uncompressed size, but if you want it to just be for the size of files then I'm fine with changing things around to better conform to how things used to be.