### PR TITLE
Fix extraction of ssh key comments containing spaces

### DIFF
--- a/src/wormhole/cli/cmd_ssh.py
+++ b/src/wormhole/cli/cmd_ssh.py
@@ -56,7 +56,7 @@ def find_public_key(hint=None):
     else:
         with open(join(hint, pubkeys[0]), 'r') as f:
             pubkey = f.read()
-    parts = pubkey.strip().split()
+    parts = pubkey.strip().split(maxsplit=2)
     kind = parts[0]
     keyid = 'unknown' if len(parts) <= 2 else parts[2]
 

--- a/src/wormhole/test/test_ssh.py
+++ b/src/wormhole/test/test_ssh.py
@@ -63,3 +63,21 @@ class FindPubkey(unittest.TestCase):
         self.assertEqual(kind, "ssh-rsa")
         self.assertEqual(keyid, "email@host")
         self.assertEqual(pubkey, pubkey_data)
+
+    def test_comment_with_spaces(self):
+        files = OTHERS + ["id_ed25519.pub", "id_ed25519"]
+        pubkey_data = u"ssh-ed25519 AAAAkeystuff comment with spaces"
+        pubkey_file = io.StringIO(pubkey_data)
+
+        with mock.patch("wormhole.cli.cmd_ssh.exists", return_value=True):
+            with mock.patch("os.listdir", return_value=files) as ld:
+                with mock.patch(
+                        "wormhole.cli.cmd_ssh.open", return_value=pubkey_file):
+                    res = cmd_ssh.find_public_key()
+        self.assertEqual(ld.mock_calls,
+                         [mock.call(os.path.expanduser("~/.ssh/"))])
+        self.assertEqual(len(res), 3, res)
+        kind, keyid, pubkey = res
+        self.assertEqual(kind, "ssh-ed25519")
+        self.assertEqual(keyid, "comment with spaces")
+        self.assertEqual(pubkey, pubkey_data)


### PR DESCRIPTION
This PR fixes the extraction of ssh public key comments that contain spaces and introduces a new test case for that.
Therefore this also makes the output of `wormhole ssh accept` show the correct keyid.

Fixes #432.