### PR TITLE
More standard HKDF

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@ User-visible changes in "magic-wormhole":
 
 * Python 3.5 and 3.6 are past their EOL date and support is dropped (#448)
 * Fix intermittant failing test (#458)
+* Use the HKDF primitive from "cryptography" (#462)
 
 ## Release 0.12.0 (04-Apr-2020)
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(name="magic-wormhole",
           "twisted[tls] >= 17.5.0", # 17.5.0 adds failAfterFailures=
           "autobahn[twisted] >= 0.14.1",
           "automat",
-          "hkdf",
+          "cryptography",
           "tqdm >= 4.13.0", # 4.13.0 fixes crash on NetBSD
           "click",
           "humanize",

--- a/src/wormhole/test/test_hkdf.py
+++ b/src/wormhole/test/test_hkdf.py
@@ -3,7 +3,8 @@ from __future__ import print_function, unicode_literals
 import unittest
 from binascii import unhexlify  # , hexlify
 
-from hkdf import Hkdf
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hashes
 
 # def generate_KAT():
 #     print("KAT = [")
@@ -38,8 +39,12 @@ class TestKAT(unittest.TestCase):
         for (salt, context, skm, expected_hexout) in KAT:
             expected_out = unhexlify(expected_hexout)
             for outlen in range(0, len(expected_out)):
-                out = Hkdf(salt.encode("ascii"), skm.encode("ascii")).expand(
-                    context.encode("ascii"), outlen)
+                out = HKDF(
+                    algorithm=hashes.SHA256(),
+                    length=outlen,
+                    salt=salt.encode("ascii"),
+                    info=context.encode("ascii"),
+                ).derive(skm.encode("ascii"))
                 self.assertEqual(out, expected_out[:outlen])
 
 

--- a/src/wormhole/test/test_hkdf.py
+++ b/src/wormhole/test/test_hkdf.py
@@ -6,6 +6,8 @@ from binascii import unhexlify  # , hexlify
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives import hashes
 
+from .. import util
+
 # def generate_KAT():
 #     print("KAT = [")
 #     for salt in (b"", b"salt"):
@@ -45,6 +47,18 @@ class TestKAT(unittest.TestCase):
                     salt=salt.encode("ascii"),
                     info=context.encode("ascii"),
                 ).derive(skm.encode("ascii"))
+                self.assertEqual(out, expected_out[:outlen])
+
+    def test_util(self):
+        for (salt, context, skm, expected_hexout) in KAT:
+            expected_out = unhexlify(expected_hexout)
+            for outlen in range(0, len(expected_out)):
+                out = util.HKDF(
+                    skm.encode("ascii"),
+                    outlen,
+                    salt.encode("ascii"),
+                    context.encode("ascii"),
+                )
                 self.assertEqual(out, expected_out[:outlen])
 
 

--- a/src/wormhole/util.py
+++ b/src/wormhole/util.py
@@ -16,7 +16,7 @@ def HKDF(skm, outlen, salt=None, CTXinfo=b""):
     :param bytes skm: the input key material
     :param int outlen: output length, in bytes
     :param bytes salt: optional salt value (None for no salt)
-    :param bytes CTXinfo: contexct / application specific string (defaults to empty)
+    :param bytes CTXinfo: context / application-specific string (default is empty)
 
     :return bytes: the derived key material
     """

--- a/src/wormhole/util.py
+++ b/src/wormhole/util.py
@@ -3,11 +3,29 @@ import json
 import os
 import unicodedata
 from binascii import hexlify, unhexlify
-from hkdf import Hkdf
+from cryptography.hazmat.primitives.kdf import hkdf
+from cryptography.hazmat.primitives import hashes
 
 
 def HKDF(skm, outlen, salt=None, CTXinfo=b""):
-    return Hkdf(salt, skm).expand(CTXinfo, outlen)
+    """
+    Return the RFC5869 'HMAC-based Key Derivation Function' result of
+    using the given `salt`, tag from `CTXinfo` and secret from `skm`
+    with a SHA256 hash.
+
+    :param bytes skm: the input key material
+    :param int outlen: output length, in bytes
+    :param bytes salt: optional salt value (None for no salt)
+    :param bytes CTXinfo: contexct / application specific string (defaults to empty)
+
+    :return bytes: the derived key material
+    """
+    return hkdf.HKDF(
+        hashes.SHA256(),
+        outlen,
+        salt,
+        CTXinfo,
+    ).derive(skm)
 
 def to_bytes(u):
     return unicodedata.normalize("NFC", u).encode("utf-8")


### PR DESCRIPTION
Fixes #462 

Use the "cryptography" library for HKDF primitive.