### PR TITLE
fix failing test

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@ User-visible changes in "magic-wormhole":
 ## Upcoming Release
 
 * Python 3.5 and 3.6 are past their EOL date and support is dropped (#448)
+* Fix intermittant failing test (#458)
 
 ## Release 0.12.0 (04-Apr-2020)
 

--- a/src/wormhole/eventual.py
+++ b/src/wormhole/eventual.py
@@ -25,8 +25,7 @@ class EventualQueue(object):
         return d
 
     def _turn(self):
-        to_call = self._calls
-        self._calls = []
+        self._calls, to_call = [], self._calls
         for f, args, kwargs in to_call:
             try:
                 f(*args, **kwargs)

--- a/src/wormhole/eventual.py
+++ b/src/wormhole/eventual.py
@@ -38,7 +38,7 @@ class EventualQueue(object):
         # (i.e. by the calls we just ran) only run in the _next_ turn
         # (as Foolscap does). Not doing this leads to some unexpected
         # dependency of the tests on the precise order things are run
-        # in a single turn, which defaults the purpose of this
+        # in a single turn, which defeats the purpose of this
         # "eventual queue".
         if len(self._calls):
             self._timer = self._clock.callLater(0, self._turn)

--- a/src/wormhole/eventual.py
+++ b/src/wormhole/eventual.py
@@ -25,16 +25,28 @@ class EventualQueue(object):
         return d
 
     def _turn(self):
-        while self._calls:
-            (f, args, kwargs) = self._calls.pop(0)
+        to_call = self._calls
+        self._calls = []
+        for f, args, kwargs in to_call:
             try:
                 f(*args, **kwargs)
             except Exception:
                 log.err()
         self._timer = None
-        d, self._flush_d = self._flush_d, None
-        if d:
-            d.callback(None)
+
+        # Since the only guidance about semantics is the comment about
+        # Foolscap, we make sure that any calls added by the above
+        # (i.e. by the calls we just ran) only run in the _next_ turn
+        # (as Foolscap does). Not doing this leads to some unexpected
+        # dependency of the tests on the precise order things are run
+        # in a single turn, which defaults the purpose of this
+        # "eventual queue".
+        if len(self._calls):
+            self._timer = self._clock.callLater(0, self._turn)
+        else:
+            d, self._flush_d = self._flush_d, None
+            if d:
+                d.callback(None)
 
     def flush_sync(self):
         # if you have control over the Clock, this will synchronously flush the

--- a/src/wormhole/test/test_wormhole.py
+++ b/src/wormhole/test/test_wormhole.py
@@ -501,8 +501,11 @@ class Wormholes(ServerBase, unittest.TestCase):
         w2 = wormhole.create(APPID, self.relayurl, reactor)
         w2.set_code("123-NOT")
         yield self.assertFailure(w1.get_verifier(), WrongPasswordError)
-
         yield self.assertFailure(w1.get_welcome(), WrongPasswordError)  # late
+
+        # we have to ensure w2 receives a "bad" message from w1 before
+        # the w2.close() assertion below will actually fail
+        yield self.assertFailure(w2.get_verifier(), WrongPasswordError)
 
         yield self.assertFailure(w1.close(), WrongPasswordError)
         yield self.assertFailure(w2.close(), WrongPasswordError)


### PR DESCRIPTION
Fixes #458 

The "EventualQueue" claims to come from Foolscap, but doesn't match Foolscap semantics when processing events: calls added during "this" turn get run. This leads to, I believe, the behavior observed in the tests where a "timeout" of `0` for the notification sometimes doesn't get run in time (because the eventual queue gets to run "first" and ends up cancelling the notification).