### PR TITLE
Parse IPv6 address in TCP hint (--transit-helper argument)

### DIFF
--- a/src/wormhole/_hints.py
+++ b/src/wormhole/_hints.py
@@ -50,7 +50,8 @@ def parse_hint_argv(hint, stderr=sys.stderr):
               file=stderr)
         return None
     hint_value = mo.group(2)
-    pieces = hint_value.split(":")
+    # Find all pieces that either match an IPv6 address in square brackets, or pieces that follow or are followed by a colon:
+    pieces = re.findall(r"(?<=\[)[a-fA-F0-9:]+(?=\])|[^:\[\]]+(?=:)|(?<=:)[^:\[\]]+", hint_value)
     if len(pieces) < 2:
         print("unparseable TCP hint (need more colons) '%s'" % (hint, ),
               file=stderr)

--- a/src/wormhole/_hints.py
+++ b/src/wormhole/_hints.py
@@ -40,22 +40,20 @@ def parse_hint_argv(hint, stderr=sys.stderr):
     assert isinstance(hint, type(u""))
     # return tuple or None for an unparseable hint
     priority = 0.0
-    # parse hint type ('tcp' or 'tcp6')
+    # parse hint type
     mo = re.search(r'^([a-zA-Z0-9]+):(.*)$', hint)
     if not mo:
         print("unparseable hint '%s'" % (hint, ), file=stderr)
         return None
     hint_type = mo.group(1)
-    if not hint_type in ("tcp", "tcp6"):
+    if hint_type != "tcp":
         print("unknown hint type '%s' in '%s'" % (hint_type, hint),
               file=stderr)
         return None
     hint_value = mo.group(2)
-    # declare vars
     hint_host = ""
-    hint_port = -1
     pieces = []  # hint_value split into pieces
-    # check for IPv6 address (must have square brackets)
+    # parse IPv6 address (must have square brackets)
     mo = re.search(r'^\[([a-zA-Z0-9:]+)\]:(.*)$', hint_value)
     if mo:
         hint_host = mo.group(1)
@@ -72,17 +70,13 @@ def parse_hint_argv(hint, stderr=sys.stderr):
                   file=stderr)
             return None
         hint_host = pieces[0]
-        if isIPAddress(hint_host) and hint_type == "tcp6":
-            print("expected IPv6 address or hostname, got IPv4 address in TCP6 hint '%s'" % (hint, ),
-                  file=stderr)
-            return None
     # parse the port:
     mo = re.search(r'^(\d+)$', pieces[1])
     if not mo:
         print("non-numeric port in TCP hint '%s'" % (hint, ), file=stderr)
         return None
     hint_port = int(pieces[1])
-    # parse the rest, such as "priority=float"
+    # parse the rest ("priority=float")
     for more in pieces[2:]:
         if more.startswith("priority="):
             more_pieces = more.split("=")

--- a/src/wormhole/test/test_hints.py
+++ b/src/wormhole/test/test_hints.py
@@ -152,29 +152,25 @@ class Hints(unittest.TestCase):
             stderr,
             "non-float priority= in TCP hint 'tcp:host:1234:priority=bad'\n")
 
+        h, stderr = p("tcp:[2001:0db8:85a3::8a2e:0370:7334]")
+        self.assertEqual(h, None)
+        self.assertEqual(
+            stderr, "non-numeric port in TCP hint 'tcp:[2001:0db8:85a3::8a2e:0370:7334]'\n")
+
         h, stderr = p("tcp:[2001:0db8:85a3::8a2e:0370:7334]:1234")
         self.assertEqual(h, DirectTCPV1Hint(
             "2001:0db8:85a3::8a2e:0370:7334", 1234, 0.0))
         self.assertEqual(stderr, "")
 
-        h, stderr = p("tcp6:[2001:0db8:85a3::8a2e:0370:7334]:1234")
+        h, stderr = p("tcp:[2001:0db8:85a3::8a2e:0370:7334]:1234:priority=2.6")
         self.assertEqual(h, DirectTCPV1Hint(
-            "2001:0db8:85a3::8a2e:0370:7334", 1234, 0.0))
+            "2001:0db8:85a3::8a2e:0370:7334", 1234, 2.6))
         self.assertEqual(stderr, "")
 
-        h, stderr = p("tcp6:[abc::xyz]:1234")
+        h, stderr = p("tcp:[abc::xyz]:1234")
         self.assertEqual(h, None)
         self.assertEqual(
-            stderr, "invalid IPv6 address in TCP hint 'tcp6:[abc::xyz]:1234'\n")
-
-        h, stderr = p("tcp6:host:1234")
-        self.assertEqual(h, DirectTCPV1Hint("host", 1234, 0.0))
-        self.assertEqual(stderr, "")
-
-        h, stderr = p("tcp6:172.0.0.1:1234")
-        self.assertEqual(h, None)
-        self.assertEqual(
-            stderr, "expected IPv6 address or hostname, got IPv4 address in TCP6 hint 'tcp6:172.0.0.1:1234'\n")
+            stderr, "invalid IPv6 address in TCP hint 'tcp:[abc::xyz]:1234'\n")
 
     def test_describe_hint_obj(self):
         d = describe_hint_obj


### PR DESCRIPTION
I tried pointing to my own transit-relay server by using `wormhole --transit-helper=tcp:[1111:2222:3333:4444:cccc:dddd:eeee:ffff]:4001 send "./example.file"`, however I got:
```
non-numeric port in TCP hint 'tcp:[1111:2222:3333:4444:cccc:dddd:eeee:ffff]:4001'
```

Not using brackets didn't work either:
```
non-numeric port in TCP hint 'tcp:1111:2222:3333:4444:cccc:dddd:eeee:ffff:4001'
```

I dug around and replaced a line in `parse_hint_argv` in file `_hints.py`.
Once parsing IPv6 addresses worked, I was able to use my transit-relay server to send/receive files over IPv6:

```
Sending (->relay:tcp:1111:2222:3333:4444:cccc:dddd:eeee:ffff:4001)..
100%|██████████████████████████████████████| 13.3k/13.3k [00:00<00:00, 5.00MB/s]
File sent.. waiting for confirmation
Confirmation received. Transfer complete.
```

(An IPv6 address has to be within square brackets, otherwise it isn't recognized.)

It might not be the most elegant solution to use a complicated regex string, but it does the trick. Hostnames, IPv4, and IPv6 addresses are recognized.