### PR TITLE
Document magic-wormhole's removal in Fedora 37

### DIFF
--- a/docs/welcome.md
+++ b/docs/welcome.md
@@ -66,6 +66,10 @@ $ sudo apt install magic-wormhole
 
 ### Linux (Fedora)
 
+Note: magic-wormhole [was removed from
+Fedora](https://bugzilla.redhat.com/show_bug.cgi?id=2073777) starting in Fedora
+37. So this command will only work on Fedora 36 and earlier.
+
 ```
 $ sudo dnf install magic-wormhole
 ```


### PR DESCRIPTION
magic-wormhole was removed in Fedora 37. This PR updates the documentation to reflect that.

* Source 1: https://bugzilla.redhat.com/show_bug.cgi?id=2073777
* Source 2: https://src.fedoraproject.org/rpms/python-magic-wormhole/c/f1352b970b9d289948e137528468ef40bf2e52ba?branch=rawhide