### PR TITLE
Dilation version

### DIFF
--- a/src/wormhole/_dilation/manager.py
+++ b/src/wormhole/_dilation/manager.py
@@ -434,14 +434,13 @@ class Manager(object):
 
     @m.output()
     def send_please(self):
-        assert self._dilation_version is not None, "Incompatible or missing dilation_version"
-        self.send_dilation_phase(
-            **{
-                "type": "please",
-                "side": self._my_side,
-                "use-version": self._dilation_version,  # only version that exists currently
-            }
-        )
+        msg = {
+            "type": "please",
+            "side": self._my_side,
+        }
+        if self._dilation_version is not None:
+            msg["use-version"] = self._dilation_version
+        self.send_dilation_phase(**msg)
 
     @m.output()
     def choose_role(self, message):

--- a/src/wormhole/_dilation/manager.py
+++ b/src/wormhole/_dilation/manager.py
@@ -32,7 +32,7 @@ from .outbound import Outbound
 
 
 # exported to Wormhole() for inclusion in versions message
-DILATION_VERSIONS = ["1"]
+DILATION_VERSIONS = [1]
 
 
 class OldPeerCannotDilateError(Exception):
@@ -74,7 +74,7 @@ def make_side():
 # * PLEASE includes a dilation-specific "side" (independent of the "side"
 #    used by mailbox messages)
 # * higher "side" is Leader, lower is Follower
-# * PLEASE includes can-dilate list of version integers, requires overlap
+# * PLEASE includes the selection of a version from the "can-dilate" list of versions integers, requires overlap
 #    "1" is current
 
 # * we start dilation after both w.dilate() and receiving VERSION, putting us
@@ -120,6 +120,7 @@ class Manager(object):
     _tor = None  # TODO
     _timing = None  # TODO
     _next_subchannel_id = None  # initialized in choose_role
+    _dilation_version = None  # initialized in got_wormhole_versions
 
     m = MethodicalMachine()
     set_trace = getattr(m, "_setTrace", lambda self, f: None)  # pragma: no cover
@@ -173,17 +174,17 @@ class Manager(object):
 
     def got_wormhole_versions(self, their_wormhole_versions):
         # this always happens before received_dilation_message
-        dilation_version = None
+        self._dilation_version = None
         their_dilation_versions = set(their_wormhole_versions.get("can-dilate", []))
         my_versions = set(DILATION_VERSIONS)
         shared_versions = my_versions.intersection(their_dilation_versions)
-        if "1" in shared_versions:
-            dilation_version = "1"
+        if 1 in shared_versions:
+            self._dilation_version = 1
 
         # dilation_version is the best mutually-compatible version we have
         # with the peer, or None if we have nothing in common
 
-        if not dilation_version:  # "1" or None
+        if not self._dilation_version:  # 1 or None
             # TODO: be more specific about the error. dilation_version==None
             # means we had no version in common with them, which could either
             # be because they're so old they don't dilate at all, or because
@@ -433,7 +434,14 @@ class Manager(object):
 
     @m.output()
     def send_please(self):
-        self.send_dilation_phase(type="please", side=self._my_side)
+        assert self._dilation_version is not None, "Incompatible or missing dilation_version"
+        self.send_dilation_phase(
+            **{
+                "type": "please",
+                "side": self._my_side,
+                "use-version": self._dilation_version,  # only version that exists currently
+            }
+        )
 
     @m.output()
     def choose_role(self, message):

--- a/src/wormhole/test/dilate/test_connect.py
+++ b/src/wormhole/test/dilate/test_connect.py
@@ -55,13 +55,13 @@ class Connect(unittest.TestCase):
         d_left = manager.Dilator(reactor, eq, cooperator)
         d_left.wire(send_left, t_left)
         d_left.got_key(key)
-        d_left.got_wormhole_versions({"can-dilate": ["1"]})
+        d_left.got_wormhole_versions({"can-dilate": [1]})
         send_left.dilator = d_left
 
         d_right = manager.Dilator(reactor, eq, cooperator)
         d_right.wire(send_right, t_right)
         d_right.got_key(key)
-        d_right.got_wormhole_versions({"can-dilate": ["1"]})
+        d_right.got_wormhole_versions({"can-dilate": [1]})
         send_right.dilator = d_right
 
         with mock.patch("wormhole._dilation.connector.ipaddrs.find_addresses",

--- a/src/wormhole/test/dilate/test_manager.py
+++ b/src/wormhole/test/dilate/test_manager.py
@@ -245,7 +245,7 @@ class TestManager(unittest.TestCase):
         m.got_wormhole_versions({"can-dilate": [1]})
         self.assertEqual(h.send.mock_calls, [
             mock.call.send("dilate-0",
-                           dict_to_bytes({"type": "please", "side": LEADER}))
+                           dict_to_bytes({"type": "please", "side": LEADER, "use-version": 1}))
             ])
         clear_mock_calls(h.send)
 
@@ -444,7 +444,7 @@ class TestManager(unittest.TestCase):
         m.got_wormhole_versions({"can-dilate": [1]})
         self.assertEqual(h.send.mock_calls, [
             mock.call.send("dilate-0",
-                           dict_to_bytes({"type": "please", "side": FOLLOWER}))
+                           dict_to_bytes({"type": "please", "side": FOLLOWER, "use-version": 1}))
             ])
         clear_mock_calls(h.send)
         clear_mock_calls(h.inbound)

--- a/src/wormhole/test/dilate/test_manager.py
+++ b/src/wormhole/test/dilate/test_manager.py
@@ -242,7 +242,7 @@ class TestManager(unittest.TestCase):
         self.assertTrue(hasattr(eps, "connect"))
         self.assertEqual(eps.listen, h.listen_ep)
 
-        m.got_wormhole_versions({"can-dilate": ["1"]})
+        m.got_wormhole_versions({"can-dilate": [1]})
         self.assertEqual(h.send.mock_calls, [
             mock.call.send("dilate-0",
                            dict_to_bytes({"type": "please", "side": LEADER}))
@@ -441,7 +441,7 @@ class TestManager(unittest.TestCase):
     def test_follower(self):
         m, h = make_manager(leader=False)
 
-        m.got_wormhole_versions({"can-dilate": ["1"]})
+        m.got_wormhole_versions({"can-dilate": [1]})
         self.assertEqual(h.send.mock_calls, [
             mock.call.send("dilate-0",
                            dict_to_bytes({"type": "please", "side": FOLLOWER}))


### PR DESCRIPTION
Make the implementation in line with https://github.com/magic-wormhole/magic-wormhole-protocols/pull/38 which means:

- change the versions to integers in `"can-dilate"`
- actually send the used version in `"use-version"` 

See also https://github.com/magic-wormhole/magic-wormhole-protocols/issues/37