### PR TITLE
remove add_relay event handling from the state machine

### DIFF
--- a/src/wormhole/_dilation/connector.py
+++ b/src/wormhole/_dilation/connector.py
@@ -148,12 +148,6 @@ class Connector(object):
 
     # TODO: unify the tense of these method-name verbs
 
-    # add_relay() and got_hints() are called by the Manager as it receives
-    # messages from our peer. stop() is called when the Manager shuts down
-    @m.input()
-    def add_relay(self, hint_objs):
-        pass
-
     @m.input()
     def got_hints(self, hint_objs):
         pass
@@ -250,8 +244,6 @@ class Connector(object):
         self._winning_connection = None
 
     connecting.upon(listener_ready, enter=connecting, outputs=[publish_hints])
-    connecting.upon(add_relay, enter=connecting, outputs=[use_hints,
-                                                          publish_hints])
     connecting.upon(got_hints, enter=connecting, outputs=[use_hints])
     connecting.upon(add_candidate, enter=connecting, outputs=[consider])
     connecting.upon(accept, enter=connected, outputs=[
@@ -260,7 +252,6 @@ class Connector(object):
 
     # once connected, we ignore everything except stop
     connected.upon(listener_ready, enter=connected, outputs=[])
-    connected.upon(add_relay, enter=connected, outputs=[])
     connected.upon(got_hints, enter=connected, outputs=[])
     # TODO: tell them to disconnect? will they hang out forever? I *think*
     # they'll drop this once they get a KCM on the winning connection.

--- a/src/wormhole/test/dilate/test_connector.py
+++ b/src/wormhole/test/dilate/test_connector.py
@@ -327,28 +327,6 @@ class TestConnector(unittest.TestCase):
                          [mock.call(0.0, DirectTCPV1Hint("foo", 55, 0.0),
                                     is_relay=True)])
 
-    def test_add_relay(self):
-        c, h = make_connector(listen=False, relay=None, role=roles.LEADER)
-        c._schedule_connection = mock.Mock()
-        c.start()
-        self.assertEqual(h.manager.mock_calls, [])
-        self.assertEqual(c._schedule_connection.mock_calls, [])
-        hint = RelayV1Hint([DirectTCPV1Hint("foo", 55, 0.0)])
-        c.add_relay([hint])
-        self.assertEqual(h.manager.mock_calls,
-                         [mock.call.send_hints([{"type": "relay-v1",
-                                                 "hints": [
-                                                     {"type": "direct-tcp-v1",
-                                                      "hostname": "foo",
-                                                      "port": 55,
-                                                      "priority": 0.0
-                                                      },
-                                                     ],
-                                                 }])])
-        self.assertEqual(c._schedule_connection.mock_calls,
-                         [mock.call(0.0, DirectTCPV1Hint("foo", 55, 0.0),
-                                    is_relay=True)])
-
     def test_tor_no_manager(self):
         # tor hints should be ignored if we don't have a Tor manager to use them
         c, h = make_connector(listen=False, role=roles.LEADER)


### PR DESCRIPTION
The associated test code has been removed as well.

Closes #489 