### PR TITLE
Implement streaming zipfile creation for sending directories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,8 @@ setup(name="magic-wormhole",
           "click",
           "humanize",
           "txtorcon >= 18.0.2", # 18.0.2 fixes py3.4 support
+          "zipstream-ng >= 1.7.1, <2.0.0",
+          "iterable-io >= 1.0.0, <2.0.0",
       ],
       extras_require={
           ':sys_platform=="win32"': ["pywin32"],

--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -329,7 +329,7 @@ class Receiver:
     def _handle_directory(self, them_d):
         file_data = them_d["directory"]
         zipmode = file_data["mode"]
-        if zipmode != "zipfile/deflated":
+        if not zipmode.startswith("zipfile"):
             self._msg(u"Error: unknown directory-transfer mode '%s'" %
                       (zipmode, ))
             raise RespondError("unknown mode")
@@ -465,7 +465,7 @@ class Receiver:
 
         self._msg(u"Unpacking zipfile..")
         with self.args.timing.add("unpack zip"):
-            with zipfile.ZipFile(f, "r", zipfile.ZIP_DEFLATED) as zf:
+            with zipfile.ZipFile(f, "r") as zf:
                 for info in zf.infolist():
                     self._extract_file(zf, info, self.abs_destname)
 

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -149,11 +149,9 @@ class OfferData(unittest.TestCase):
         self.assertIn("numbytes", d["directory"])
         self.assertIsInstance(d["directory"]["numbytes"], six.integer_types)
 
-        self.assertEqual(fd_to_send.tell(), 0)
-        zdata = fd_to_send.read()
+        zdata = b"".join(fd_to_send)
         self.assertEqual(len(zdata), d["directory"]["zipsize"])
-        fd_to_send.seek(0, 0)
-        with zipfile.ZipFile(fd_to_send, "r", zipfile.ZIP_DEFLATED) as zf:
+        with zipfile.ZipFile(io.BytesIO(zdata), "r", zipfile.ZIP_DEFLATED) as zf:
             zipnames = zf.namelist()
             self.assertEqual(list(sorted(ponies)), list(sorted(zipnames)))
             for name in zipnames:

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -144,14 +144,14 @@ class OfferData(unittest.TestCase):
         self.assertNotIn("file", d)
         self.assertIn("directory", d)
         self.assertEqual(d["directory"]["dirname"], send_dir)
-        self.assertEqual(d["directory"]["mode"], "zipfile/deflated")
+        assert d["directory"]["mode"].startswith("zipfile")
         self.assertEqual(d["directory"]["numfiles"], 5)
         self.assertIn("numbytes", d["directory"])
         self.assertIsInstance(d["directory"]["numbytes"], six.integer_types)
 
         zdata = b"".join(fd_to_send)
         self.assertEqual(len(zdata), d["directory"]["zipsize"])
-        with zipfile.ZipFile(io.BytesIO(zdata), "r", zipfile.ZIP_DEFLATED) as zf:
+        with zipfile.ZipFile(io.BytesIO(zdata), "r") as zf:
             zipnames = zf.namelist()
             self.assertEqual(list(sorted(ponies)), list(sorted(zipnames)))
             for name in zipnames:


### PR DESCRIPTION
Instead of creating a temporary zip file on disk to send when transferring a directory, this commit uses the [zipstream-ng](https://github.com/pR0Ps/zipstream-ng) library to generate the zip file on the fly. This results in no disk usage, a much shorter startup time, and minimal memory usage.

For adding files to the stream from the directory, the `walk` function the `zipstream-ng` package provides was used since it preserves empty directories (obsoletes #422) as well as follows symlinks. Since files aren't actually read until they're about to be transferred, an `os.access` check is done to make sure that unreadable files are not added to the stream (which would cause it to crash mid-transfer).

I tested sending ~90GB and the transfer started immediately and finished successfully with minimal memory usage. Transfer speed was about the same as sending a non-zipped file.

(This is a cleaned up implementation of the proof of concept originally proposed here: https://github.com/magic-wormhole/magic-wormhole/issues/58#issuecomment-1672468894)