### PR TITLE
skip failing test if noiseprotocol unavailable

### DIFF
--- a/src/wormhole/test/dilate/test_record.py
+++ b/src/wormhole/test/dilate/test_record.py
@@ -3,7 +3,7 @@ from unittest import mock
 from zope.interface import alsoProvides
 from twisted.trial import unittest
 from twisted.internet.interfaces import ITransport
-from ..._dilation._noise import NoiseInvalidMessage
+from ..._dilation._noise import NoiseInvalidMessage, NoiseConnection
 from ..._dilation.connection import (IFramer, Frame, Prologue,
                                      _Record, Handshake, KCM,
                                      Disconnect, Ping, _Framer, Data)
@@ -282,6 +282,8 @@ class Record(unittest.TestCase):
         Noise only allows 64KiB message, but the API allows up to 4GiB
         frames
         """
+        if not NoiseConnection:
+            raise unittest.SkipTest("noiseprotocol unavailable")
         # XXX could really benefit from some Hypothesis style
         # exploration of more cases .. but we don't already depend on
         # that library, so a future improvement


### PR DESCRIPTION
This test fails in the Debian package (which doesn't currently have noiseprotocol packaged) and instead of being properly skipped like the other noise tests, it crashes the test suite:

```
Traceback (most recent call last):
  File "/<<PKGBUILDDIR>>/.pybuild/cpython3_3.11_magic-wormhole/build/wormhole/test/dilate/test_record.py", line 307, in test_large_frame
    noise0 = build_noise()
  File "/<<PKGBUILDDIR>>/.pybuild/cpython3_3.11_magic-wormhole/build/wormhole/_dilation/connector.py", line 45, in build_noise
    return NoiseConnection.from_name(NOISEPROTO)
builtins.AttributeError: 'NoneType' object has no attribute 'from_name'

wormhole.test.dilate.test_record.Record.test_large_frame
```