### PR TITLE
Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within setup.cfg
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/NEWS.md
+++ b/NEWS.md
@@ -624,7 +624,7 @@ import wormhole must be updated.
 ## Release 0.3.0 (24-Jun-2015)
 
 Add preliminary Twisted support, only for symmetric endpoints (no
-initator/receiver distinction). Lacks code-entry tab-completion. May still
+initiator/receiver distinction). Lacks code-entry tab-completion. May still
 leave timers lingering. Add test suite (only for Twisted, so far).
 
 Use a sqlite database for Relay server state, to survive reboots with less

--- a/docs/api-example.py
+++ b/docs/api-example.py
@@ -52,7 +52,7 @@ async def example_responder(reactor, code):
     versions = await w.get_versions()
 
     # our simple protocol is: the responder sends a single
-    # message. the flow of messgaes after "versions" is exchanged is
+    # message. the flow of messages after "versions" is exchanged is
     # up to application requirements
     w.send_message(b"privacy is a human right")
     result = await w.close()

--- a/docs/attacks.rst
+++ b/docs/attacks.rst
@@ -14,7 +14,7 @@ partner to connect to them instead of you. By passing, observing, and
 possibly modifying messages between these two connections, they could
 perform an MitM (Man In The Middle) attack.
 
-If the server refused to re-use the same channel id (aka “nameplate”)
+If the server refused to reuse the same channel id (aka “nameplate”)
 right away (issue #31), a network attacker would be unable to set up the
 second connection, cutting this attack in half. An attacker who controls
 the server would not be affected.

--- a/docs/dilation-protocol.rst
+++ b/docs/dilation-protocol.rst
@@ -18,7 +18,7 @@ Dilation was conceived during development of a “next-generation”
 file-transfer protocol now called “`Dilated File
 Transfer <https://github.com/magic-wormhole/magic-wormhole-protocols/pull/23>`__”.
 
-This document asssumes you are familiar with the core Mailbox protocol
+This document assumes you are familiar with the core Mailbox protocol
 and the general promises of Magic Wormhole. For more information see
 `the Server Protocol <server-protocol.md>`__.
 
@@ -459,7 +459,7 @@ pattern, and the reaction to receiving the handshake message / ephemeral
 key (for which only the Follower sends an empty KCM message).
 
 After that, the ``DilatedConnectionProtocol`` notifies the management
-obects in three situations:
+objects in three situations:
 
 -  the Noise session produces a valid KCM message (``Connector``
    notified with ``add_candidate()``).

--- a/docs/ecosystem.rst
+++ b/docs/ecosystem.rst
@@ -121,7 +121,7 @@ Unless otherwise noted, these "inherit" any limitations of their langauge's libr
 Library and CLI
 ~~~~~~~~~~~~~~~
 
-* `magic-wormhole <https://github.com/magic-wormhole/magic-wormhole>`_ the Python reference implementation and CLI (the command-line progam is called ``wormhole`` in most distributions)
+* `magic-wormhole <https://github.com/magic-wormhole/magic-wormhole>`_ the Python reference implementation and CLI (the command-line program is called ``wormhole`` in most distributions)
 * `wormhole-william <https://github.com/psanford/wormhole-william>`_ is a Go library and CLI for file-transfer
 * `magic-wormhole.rs <https://github.com/magic-wormhole/magic-wormhole.rs/>`_ provides a library and CLI for file-transfer
 * `haskell-magic-wormhole <https://github.com/LeastAuthority/haskell-magic-wormhole>`_ and `wormhole-client <https://github.com/LeastAuthority/wormhole-client>`_ are a library and CLI for file-transfer in Haskell
@@ -132,7 +132,7 @@ GUIs for Desktop, Mobile, Web
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * `Warp <https://apps.gnome.org/Warp/>`_ is a GNOME GUI written in Rust
-* `Winden <https://winden.app/>`_ is a Web client and deployment (using the Go implemtation via WASM)
+* `Winden <https://winden.app/>`_ is a Web client and deployment (using the Go implementation via WASM)
 * `Destiny <https://f-droid.org/packages/com.leastauthority.destiny/>`_ is an Android (and iOS) app using Flutter (with the Go implementation for wormhole). Also on proprietary app stores.
 * `Wormhole <https://gitlab.com/lukas-heiligenbrunner/wormhole>`_ for Android. Based on the Rust implementation.
 * `Mobile Wormhole <https://github.com/pavelsof/mobile-wormhole>`_ for Android (also `on f-droid <https://github.com/pavelsof/mobile-wormhole>`_. Based on the Python implementation, using Kivy

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,4 +13,4 @@ max-line-length = 120
 skip = .git*,*.svg,versioneer.py,*.css,wormhole.exe.spec,*.asc
 check-hidden = true
 # ignore-regex = 
-ignore-words-list = ans
+ignore-words-list = ans,recieve,unparseable

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,10 @@ parentdir_prefix = magic-wormhole
 
 [flake8]
 max-line-length = 120
+
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,*.svg,versioneer.py,*.css,wormhole.exe.spec,*.asc
+check-hidden = true
+# ignore-regex = 
+ignore-words-list = ans

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,5 +12,5 @@ max-line-length = 120
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
 skip = .git*,*.svg,versioneer.py,*.css,wormhole.exe.spec,*.asc
 check-hidden = true
-# ignore-regex = 
+ignore-regex = \bassertIn\b
 ignore-words-list = ans,recieve,unparseable


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.