### PR TITLE
Fix pylint warning `unspecified-encoding`

### DIFF
--- a/misc/dump-stats.py
+++ b/misc/dump-stats.py
@@ -4,7 +4,7 @@ import time, json
 # Run this as 'watch python misc/dump-stats.py' against a 'wormhole-server
 # start --stats-file=stats.json'
 
-with open("stats.json") as f:
+with open("stats.json", "r", encoding="utf-8") as f:
     data_s = f.read()
 
 now = time.time()

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ trove_classifiers = [
 setup(name="magic-wormhole",
       version=versioneer.get_version(),
       description="Securely transfer data between computers",
-      long_description=open('README.md', 'r').read(),
+      long_description=open('README.md', 'r', encoding='utf-8').read(),
       long_description_content_type='text/markdown',
       author="Brian Warner",
       author_email="warner-magic-wormhole@lothar.com",

--- a/src/wormhole/_version.py
+++ b/src/wormhole/_version.py
@@ -162,7 +162,7 @@ def git_get_keywords(versionfile_abs: str) -> Dict[str, str]:
     # _version.py.
     keywords: Dict[str, str] = {}
     try:
-        with open(versionfile_abs, "r") as fobj:
+        with open(versionfile_abs, "r", encoding="utf-8") as fobj:
             for line in fobj:
                 if line.strip().startswith("git_refnames ="):
                     mo = re.search(r'=\s*"(.*)"', line)

--- a/src/wormhole/cli/cmd_ssh.py
+++ b/src/wormhole/cli/cmd_ssh.py
@@ -48,13 +48,13 @@ def find_public_key(hint=None):
                     ans = None
                 else:
                     got_key = True
-                    with open(join(hint, pubkeys[ans]), 'r') as f:
+                    with open(join(hint, pubkeys[ans]), 'r', encoding='utf-8') as f:
                         pubkey = f.read()
 
             except Exception:
                 got_key = False
     else:
-        with open(join(hint, pubkeys[0]), 'r') as f:
+        with open(join(hint, pubkeys[0]), 'r', encoding='utf-8') as f:
             pubkey = f.read()
     parts = pubkey.strip().split(maxsplit=2)
     kind = parts[0]
@@ -97,7 +97,7 @@ def invite(cfg, reactor=reactor):
             print("      '{}' doesn't exist either".format(ssh_path))
     else:
         try:
-            open(auth_key_path, 'a').close()
+            open(auth_key_path, 'a', encoding='utf-8').close()
         except OSError:
             print("No write permission on '{}'".format(auth_key_path))
             return
@@ -125,7 +125,7 @@ def invite(cfg, reactor=reactor):
     if not exists(auth_key_path):
         if not exists(ssh_path):
             os.mkdir(ssh_path, mode=0o700)
-    with open(auth_key_path, 'a', 0o600) as f:
+    with open(auth_key_path, 'a', 0o600, encoding='utf-8') as f:
         f.write('{}\n'.format(pubkey.strip()))
     print("Appended key type='{kind}' id='{key_id}' to '{auth_file}'".format(
         kind=kind, key_id=keyid, auth_file=auth_key_path))

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -446,7 +446,7 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
             if mode == "empty-file":
                 message = ""
             send_filename = u"testfil\u00EB"  # e-with-diaeresis
-            with open(os.path.join(send_dir, send_filename), "w") as f:
+            with open(os.path.join(send_dir, send_filename), "w", encoding="utf-8") as f:
                 f.write(message)
             send_cfg.what = send_filename
             receive_filename = send_filename
@@ -457,7 +457,7 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
             if overwrite:
                 recv_cfg.output_file = receive_filename
                 existing_file = os.path.join(receive_dir, receive_filename)
-                with open(existing_file, 'w') as f:
+                with open(existing_file, 'w', encoding='utf-8') as f:
                     f.write('pls overwrite me')
 
         elif mode == "directory":
@@ -480,7 +480,7 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
             modes = {}
             for i in range(5):
                 path = os.path.join(source_dir, str(i))
-                with open(path, "w") as f:
+                with open(path, "w", encoding="utf-8") as f:
                     f.write(message(i))
                 if i == 3:
                     os.chmod(path, 0o755)
@@ -711,7 +711,7 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
             self.failUnlessIn(u"Received file written to ", receive_stderr)
             fn = os.path.join(receive_dir, receive_filename)
             self.failUnless(os.path.exists(fn))
-            with open(fn, "r") as f:
+            with open(fn, "r", encoding="utf-8") as f:
                 self.failUnlessEqual(f.read(), message)
         elif mode == "directory":
             self.failUnlessEqual(receive_stdout, "")
@@ -727,7 +727,7 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
             self.failUnless(os.path.exists(fn), fn)
             for i in range(5):
                 fn = os.path.join(receive_dir, receive_dirname, str(i))
-                with open(fn, "r") as f:
+                with open(fn, "r", encoding="utf-8") as f:
                     self.failUnlessEqual(f.read(), message(i))
                 self.failUnlessEqual(modes[i], stat.S_IMODE(
                     os.stat(fn).st_mode))
@@ -810,7 +810,7 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
             message = "test message\n"
             send_cfg.what = receive_name = send_filename = "testfile"
             fn = os.path.join(send_dir, send_filename)
-            with open(fn, "w") as f:
+            with open(fn, "w", encoding="utf-8") as f:
                 f.write(message)
             size = os.stat(fn).st_size
 
@@ -827,14 +827,14 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
             os.mkdir(os.path.join(send_dir, send_dirname))
             for i in range(5):
                 path = os.path.join(send_dir, send_dirname, str(i))
-                with open(path, "w") as f:
+                with open(path, "w", encoding="utf-8") as f:
                     f.write("test message %d\n" % i)
                 size += os.stat(path).st_size
 
         if failmode == "noclobber":
             PRESERVE = "don't clobber me\n"
             clobberable = os.path.join(receive_dir, receive_name)
-            with open(clobberable, "w") as f:
+            with open(clobberable, "w", encoding="utf-8") as f:
                 f.write(PRESERVE)
 
         send_cfg.cwd = send_dir
@@ -935,7 +935,7 @@ class PregeneratedCode(ServerBase, ScriptsBase, unittest.TestCase):
         if failmode == "noclobber":
             fn = os.path.join(receive_dir, receive_name)
             self.failUnless(os.path.exists(fn))
-            with open(fn, "r") as f:
+            with open(fn, "r", encoding="utf-8") as f:
                 self.failUnlessEqual(f.read(), PRESERVE)
 
     def test_fail_file_noclobber(self):

--- a/src/wormhole/timing.py
+++ b/src/wormhole/timing.py
@@ -52,7 +52,7 @@ class DebugTiming:
         return ev
 
     def write(self, fn, stderr):
-        with open(fn, "wt") as f:
+        with open(fn, "wt", encoding="utf-8") as f:
             data = [
                 dict(
                     name=e._name,

--- a/versioneer.py
+++ b/versioneer.py
@@ -411,7 +411,7 @@ def get_config_from_root(root: str) -> VersioneerConfig:
             print("Try to load it from setup.cfg")
     if not section:
         parser = configparser.ConfigParser()
-        with open(setup_cfg) as cfg_file:
+        with open(setup_cfg, "r", encoding='utf-8') as cfg_file:
             parser.read_file(cfg_file)
         parser.get("versioneer", "VCS")  # raise error if missing
 
@@ -1200,7 +1200,7 @@ def git_get_keywords(versionfile_abs: str) -> Dict[str, str]:
     # _version.py.
     keywords: Dict[str, str] = {}
     try:
-        with open(versionfile_abs, "r") as fobj:
+        with open(versionfile_abs, "r", encoding="utf-8") as fobj:
             for line in fobj:
                 if line.strip().startswith("git_refnames ="):
                     mo = re.search(r'=\s*"(.*)"', line)
@@ -1448,7 +1448,7 @@ def do_vcs_install(versionfile_source: str, ipy: Optional[str]) -> None:
         files.append(versioneer_file)
     present = False
     try:
-        with open(".gitattributes", "r") as fobj:
+        with open(".gitattributes", "r", encoding="utf-8") as fobj:
             for line in fobj:
                 if line.strip().startswith(versionfile_source):
                     if "export-subst" in line.strip().split()[1:]:
@@ -1457,7 +1457,7 @@ def do_vcs_install(versionfile_source: str, ipy: Optional[str]) -> None:
     except OSError:
         pass
     if not present:
-        with open(".gitattributes", "a+") as fobj:
+        with open(".gitattributes", "a+", encoding="utf-8") as fobj:
             fobj.write(f"{versionfile_source} export-subst\n")
         files.append(".gitattributes")
     run_command(GITS, ["add", "--"] + files)
@@ -1512,7 +1512,7 @@ def get_versions():
 def versions_from_file(filename: str) -> Dict[str, Any]:
     """Try to determine the version from _version.py if present."""
     try:
-        with open(filename) as f:
+        with open(filename, "r", encoding='utf-8') as f:
             contents = f.read()
     except OSError:
         raise NotThisMethod("unable to read _version.py")
@@ -1530,7 +1530,7 @@ def write_to_version_file(filename: str, versions: Dict[str, Any]) -> None:
     """Write the given version number to the given _version.py file."""
     contents = json.dumps(versions, sort_keys=True,
                           indent=1, separators=(",", ": "))
-    with open(filename, "w") as f:
+    with open(filename, "w", encoding="utf-8") as f:
         f.write(SHORT_VERSION_PY % contents)
 
     print("set %s to '%s'" % (filename, versions["version"]))
@@ -2013,7 +2013,7 @@ def get_cmdclass(cmdclass: Optional[Dict[str, Any]] = None):
 
                 _build_exe.run(self)
                 os.unlink(target_versionfile)
-                with open(cfg.versionfile_source, "w") as f:
+                with open(cfg.versionfile_source, "w", encoding="utf-8") as f:
                     LONG = LONG_VERSION_PY[cfg.VCS]
                     f.write(LONG %
                             {"DOLLAR": "$",
@@ -2042,7 +2042,7 @@ def get_cmdclass(cmdclass: Optional[Dict[str, Any]] = None):
 
                 _py2exe.run(self)
                 os.unlink(target_versionfile)
-                with open(cfg.versionfile_source, "w") as f:
+                with open(cfg.versionfile_source, "w", encoding="utf-8") as f:
                     LONG = LONG_VERSION_PY[cfg.VCS]
                     f.write(LONG %
                             {"DOLLAR": "$",
@@ -2085,7 +2085,7 @@ def get_cmdclass(cmdclass: Optional[Dict[str, Any]] = None):
                           for f in self.filelist.files]
 
             manifest_filename = os.path.join(self.egg_info, 'SOURCES.txt')
-            with open(manifest_filename, 'w') as fobj:
+            with open(manifest_filename, 'w', encoding='utf-8') as fobj:
                 fobj.write('\n'.join(normalized))
 
     cmds['egg_info'] = cmd_egg_info
@@ -2180,13 +2180,13 @@ def do_setup() -> int:
         if isinstance(e, (OSError, configparser.NoSectionError)):
             print("Adding sample versioneer config to setup.cfg",
                   file=sys.stderr)
-            with open(os.path.join(root, "setup.cfg"), "a") as f:
+            with open(os.path.join(root, "setup.cfg"), "a", encoding="utf-8") as f:
                 f.write(SAMPLE_CONFIG)
         print(CONFIG_ERROR, file=sys.stderr)
         return 1
 
     print(" creating %s" % cfg.versionfile_source)
-    with open(cfg.versionfile_source, "w") as f:
+    with open(cfg.versionfile_source, "w", encoding="utf-8") as f:
         LONG = LONG_VERSION_PY[cfg.VCS]
         f.write(LONG % {"DOLLAR": "$",
                         "STYLE": cfg.style,
@@ -2200,7 +2200,7 @@ def do_setup() -> int:
     maybe_ipy: Optional[str] = ipy
     if os.path.exists(ipy):
         try:
-            with open(ipy, "r") as f:
+            with open(ipy, "r", encoding="utf-8") as f:
                 old = f.read()
         except OSError:
             old = ""
@@ -2208,11 +2208,11 @@ def do_setup() -> int:
         snippet = INIT_PY_SNIPPET.format(module)
         if OLD_SNIPPET in old:
             print(" replacing boilerplate in %s" % ipy)
-            with open(ipy, "w") as f:
+            with open(ipy, "w", encoding="utf-8") as f:
                 f.write(old.replace(OLD_SNIPPET, snippet))
         elif snippet not in old:
             print(" appending to %s" % ipy)
-            with open(ipy, "a") as f:
+            with open(ipy, "a", encoding="utf-8") as f:
                 f.write(snippet)
         else:
             print(" %s unmodified" % ipy)
@@ -2232,7 +2232,7 @@ def scan_setup_py() -> int:
     found = set()
     setters = False
     errors = 0
-    with open("setup.py", "r") as f:
+    with open("setup.py", "r", encoding="utf-8") as f:
         for line in f.readlines():
             if "import versioneer" in line:
                 found.add("import")


### PR DESCRIPTION
Changes Made:

- Applied automated fixes for the pylint warning unspecified-encoding.
"It is better to specify an encoding when opening documents. Using the system default implicitly can create problems on other operating systems. See [https://peps.python.org/pep-0597/](https://peps.python.org/pep-0597/)"

Note:
This pull request is part of a research project conducted by researchers from TU Delft, titled "PyWarnFixer: Using ML to Fix Pylint Warnings." The goal of this study is to investigate the perceptions and practices of code quality among developers in Python open-source projects and to develop a tool that uses AI to automatically fix pylint warnings.

### Research Study Information:
This pull request is part of a research project. For more information about the study, please visit the [project's information page](https://github.com/RatishT/PyWarnFixer/blob/main/README.md).

### Consent to Participate:
If you review this pull request, you are invited to participate in our study. Your participation is voluntary. To provide your consent, just open an issue in our repository with the provided template using the following link: [consent issue template](https://github.com/RatishT/PyWarnFixer/issues/new/choose) .

---

Thank you for considering participation in our research. Your feedback is crucial and highly valued. If you have any questions or concerns, please contact the Responsible Researcher at R.K.Thakoersingh@student.tudelft.nl.