### PR TITLE
Refactor api-example.py for Issue #558

### DIFF
--- a/docs/api-example.py
+++ b/docs/api-example.py
@@ -4,6 +4,7 @@ from wormhole.cli import public_relay
 from twisted.internet.defer import ensureDeferred
 from twisted.internet.task import react
 
+# To run this api locally try: relay_url = "ws://localhost:4000/v1"
 
 async def go():
     w = wormhole.create(appid, relay_url, reactor)
@@ -18,7 +19,7 @@ async def go():
 async def example_initiator(reactor):
     appid = "lothar.com/example"
     relay_url = public_relay.RENDEZVOUS_RELAY
-    relay_url = "ws://localhost:4000/v1"
+    
     w = wormhole.create(appid, relay_url, reactor)
     w.allocate_code()
 

--- a/docs/api-example.py
+++ b/docs/api-example.py
@@ -6,7 +6,7 @@ from twisted.internet.task import react
 
 # Run api-example.py in 2 different processes:
 #   1 -- entering 0 arguments will initiate a wormhole send with a hidden msg
-#   2 -- enter the sender's code to inititiate a wormhole receive
+#   2 -- entering the sender's code will inititiate a wormhole receive
 
 # The api can be set up to use a different relay like a websocket
 # relay_url = "ws://localhost:4000/v1"

--- a/docs/api-example.py
+++ b/docs/api-example.py
@@ -4,49 +4,27 @@ from wormhole.cli import public_relay
 from twisted.internet.defer import ensureDeferred
 from twisted.internet.task import react
 
-# To run this api locally try: relay_url = "ws://localhost:4000/v1"
+# Run api-example.py in 2 different processes:
+#   1 -- entering 0 arguments will initiate a wormhole send with a hidden msg
+#   2 -- enter the sender's code to inititiate a wormhole receive
 
-async def go():
-    w = wormhole.create(appid, relay_url, reactor)
-    w.allocate_code()
-    code = await w.get_code()
-    print(f"code: {code}")
-    w.send_message(b"outbound data")
-    inbound = await w.get_message()
-    await w.close()
+# The api can be set up to use a different relay like a websocket
+# relay_url = "ws://localhost:4000/v1"
 
 
-async def example_initiator(reactor):
+async def example_sender(reactor):
+    """Our sender protocol is simple: send a message. After "versions" is exchanged
+    the flow of messages is up to application requirements.
+    """
     appid = "lothar.com/example"
     relay_url = public_relay.RENDEZVOUS_RELAY
-    
+
     w = wormhole.create(appid, relay_url, reactor)
     w.allocate_code()
 
     code = await w.get_code()
     print(f"code: {code}")
-
-    # another peer needs to consume the above code (thereby
-    # connecting) and send a single message before the below will
-    # proceed
-
-    # we can confirm a viable communiction channel with "await
-    # w.get_versions()" here but in this case we simply wait for the
-    # other side to send its sole message; other protocols may choose
-    # more complex arrangements.
-
-    msg = await w.get_message() # gets exactly one message
-    print(f"got msg: {len(msg)} bytes")
-    result = await w.close()
-    print(f"closed: {result}")
-
-
-async def example_responder(reactor, code):
-    appid = "lothar.com/example"
-    relay_url = public_relay.RENDEZVOUS_RELAY
-    relay_url = "ws://localhost:4000/v1"
-    w = wormhole.create(appid, relay_url, reactor)
-    w.set_code(code)
+    # another peer needs to consume the above code (thereby connecting)
 
     # once we get the "versions" message we have a viable
     # communication channel with shared encryption key
@@ -60,12 +38,34 @@ async def example_responder(reactor, code):
     print(f"closed: {result}")
 
 
+async def example_receiver(reactor, code):
+    """Our receiver protocol is simple: complete a viable communication channel
+    and wait for a message.
+    """
+    appid = "lothar.com/example"
+    relay_url = public_relay.RENDEZVOUS_RELAY
+
+    w = wormhole.create(appid, relay_url, reactor)
+    w.set_code(code)
+
+    # we can confirm a viable communication channel with "await
+    # w.get_versions()" here but in this case we simply wait for the
+    # other side to send its sole message; other protocols may choose
+    # more complex arrangements.
+
+    msg = await w.get_message()  # gets exactly one message
+    print(f"got msg: {len(msg)} bytes")
+    print(f"msg: {msg.decode("utf8")}")
+    result = await w.close()
+    print(f"closed: {result}")
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1:
         react(lambda reactor: ensureDeferred(
-            example_responder(reactor, sys.argv[1])
+            example_receiver(reactor, sys.argv[1])
         ))
     else:
         react(lambda reactor: ensureDeferred(
-            example_initiator(reactor)
+            example_sender(reactor)
         ))


### PR DESCRIPTION
Changes made to let api-example.py run out of the box and have it act like the `wormhole send` `wormhole receive` pattern.

- `example_initiator()` is now `example_sender()`. It will send out a message to the receiver.
- `example_responder()` is now `example_receiver()`. It will receive and print out the whole message now, not just byte length
- moved the extra websocket `relay_url` from out of the functions and to the top as an example 
- moved comments around (kept the wording as much as possible) to fit the new pattern
- added some intro instructions at the top:

```python
# Run api-example.py in 2 different processes:
#   1 -- entering 0 arguments will initiate a wormhole send with a hidden msg
#   2 -- entering the sender's code will inititiate a wormhole receive

# The api can be set up to use a different relay like a websocket
# relay_url = "ws://localhost:4000/v1"
``` 

<!-- readthedocs-preview magic-wormhole start -->
Please see the rendered documentation: https://magic-wormhole--562.org.readthedocs.build/en/562/
<!-- readthedocs-preview magic-wormhole end -->