### PR TITLE
Stop using twisted.internet.defer.returnValue

### DIFF
--- a/src/wormhole/_dilation/subchannel.py
+++ b/src/wormhole/_dilation/subchannel.py
@@ -2,7 +2,7 @@ from collections import deque
 from attr import attrs, attrib
 from attr.validators import instance_of
 from zope.interface import implementer
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from twisted.internet.interfaces import (ITransport, IProducer, IConsumer,
                                          IAddress, IListeningPort,
                                          IHalfCloseableProtocol,
@@ -347,7 +347,7 @@ class ControlEndpoint(object):
         # this sets p.transport and calls p.connectionMade()
         p.makeConnection(self._subchannel_zero)
         self._subchannel_zero._deliver_queued_data()
-        returnValue(p)
+        return p
 
 
 @implementer(IStreamClientEndpoint)
@@ -381,7 +381,7 @@ class SubchannelConnectorEndpoint(object):
         p = protocolFactory.buildProtocol(peer_addr)
         sc._set_protocol(p)
         p.makeConnection(sc)  # set p.transport = sc and call connectionMade()
-        returnValue(p)
+        return p
 
 
 @implementer(IStreamServerEndpoint)
@@ -426,8 +426,7 @@ class SubchannelListenerEndpoint(object):
         while self._pending_opens:
             (t, peer_addr) = self._pending_opens.popleft()
             self._connect(t, peer_addr)
-        lp = SubchannelListeningPort(self._host_addr)
-        returnValue(lp)
+        return SubchannelListeningPort(self._host_addr)
 
 
 @implementer(IListeningPort)

--- a/src/wormhole/_rlcompleter.py
+++ b/src/wormhole/_rlcompleter.py
@@ -2,7 +2,7 @@ import traceback
 from sys import stderr
 
 from attr import attrib, attrs
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from twisted.internet.threads import blockingCallFromThread, deferToThread
 
 from .errors import AlreadyInputNameplateError, KeyFormatError
@@ -213,4 +213,4 @@ def input_with_completion(prompt, input_helper, reactor):
     used_completion = yield deferToThread(_input_code_with_completion, prompt,
                                           input_helper, reactor)
     reactor.removeSystemEventTrigger(t)
-    returnValue(used_completion)
+    return used_completion

--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -9,7 +9,7 @@ from humanize import naturalsize
 from qrcode import QRCode
 from tqdm import tqdm
 from twisted.internet import reactor
-from twisted.internet.defer import inlineCallbacks, returnValue, Deferred
+from twisted.internet.defer import inlineCallbacks, Deferred
 from twisted.protocols import basic
 from twisted.python import log
 from wormhole import __version__, create
@@ -78,7 +78,7 @@ class Sender:
         @inlineCallbacks
         def _good(res):
             yield w.close()  # wait for ack
-            returnValue(res)
+            return res
 
         # if we raise an error, we should close and then return the original
         # error (the close might give us an error, but it isn't as important
@@ -89,7 +89,7 @@ class Sender:
                 yield w.close()  # might be an error too
             except Exception:
                 pass
-            returnValue(f)
+            return f
 
         d.addCallbacks(_good, _bad)
         yield d
@@ -237,7 +237,7 @@ class Sender:
                     raise TransferError("duplicate answer")
                 want_answer = True
                 yield self._handle_answer(them_d[u"answer"])
-                returnValue(None)
+                return None
             if not recognized:
                 log.msg("unrecognized message %r" % (them_d, ))
 
@@ -400,7 +400,7 @@ class Sender:
         if self._fd_to_send is None:
             if them_answer["message_ack"] == "ok":
                 print(u"text message sent", file=self._args.stderr)
-                returnValue(None)  # terminates this function
+                return None
             raise TransferError("error sending text: %r" % (them_answer, ))
 
         if them_answer.get("file_ack") != "ok":

--- a/src/wormhole/test/common.py
+++ b/src/wormhole/test/common.py
@@ -106,7 +106,7 @@ class ServerBase:
         if not tp.working:
             yield self.sp.stopService()
             yield task.deferLater(reactor, 0.1, lambda: None)
-            defer.returnValue(None)
+            return None
         # disconnect all callers
         d = defer.maybeDeferred(self.sp.stopService)
         d.addBoth(lambda _: self._transit_server.stopFactory())

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -11,7 +11,7 @@ from click import UsageError
 from click.testing import CliRunner
 from humanize import naturalsize
 from twisted.internet import endpoints, reactor
-from twisted.internet.defer import gatherResults, inlineCallbacks, returnValue, CancelledError
+from twisted.internet.defer import gatherResults, inlineCallbacks, CancelledError
 from twisted.internet.error import ConnectionRefusedError
 from twisted.internet.utils import getProcessOutputAndValue
 from twisted.python import log, procutils
@@ -258,12 +258,12 @@ class LocaleFinder:
     @inlineCallbacks
     def find_utf8_locale(self):
         if sys.platform == "win32":
-            returnValue("en_US.UTF-8")
+            return "en_US.UTF-8"
         if self._run_once:
-            returnValue(self._best_locale)
+            return self._best_locale
         self._best_locale = yield self._find_utf8_locale()
         self._run_once = True
-        returnValue(self._best_locale)
+        return self._best_locale
 
     @inlineCallbacks
     def _find_utf8_locale(self):
@@ -278,7 +278,7 @@ class LocaleFinder:
         if rc != 0:
             log.msg("error running 'locale -a', rc=%s" % (rc, ))
             log.msg("stderr: %s" % (err, ))
-            returnValue(None)
+            return None
         out = out.decode("utf-8")  # make sure we get a string
         utf8_locales = {}
         for locale in out.splitlines():
@@ -287,10 +287,10 @@ class LocaleFinder:
                 utf8_locales[locale.lower()] = locale
         for wanted in ["C.utf8", "C.UTF-8", "en_US.utf8", "en_US.UTF-8"]:
             if wanted.lower() in utf8_locales:
-                returnValue(utf8_locales[wanted.lower()])
+                return utf8_locales[wanted.lower()]
         if utf8_locales:
-            returnValue(list(utf8_locales.values())[0])
-        returnValue(None)
+            return list(utf8_locales.values())[0]
+        return None
 
 
 locale_finder = LocaleFinder()
@@ -346,7 +346,7 @@ class ScriptsBase:
             log.msg("err", err)
             log.msg("rc", rc)
             raise unittest.SkipTest("wormhole is not runnable in this tree")
-        returnValue(locale_env)
+        return locale_env
 
 
 class ScriptVersion(ServerBase, ScriptsBase, unittest.TestCase):

--- a/src/wormhole/test/test_wormhole.py
+++ b/src/wormhole/test/test_wormhole.py
@@ -2,7 +2,7 @@ import io
 import re
 
 from twisted.internet import reactor
-from twisted.internet.defer import gatherResults, inlineCallbacks, returnValue
+from twisted.internet.defer import gatherResults, inlineCallbacks
 from twisted.internet.error import ConnectionRefusedError
 from twisted.trial import unittest
 
@@ -675,7 +675,7 @@ class InitialFailure(unittest.TestCase):
         f = self.failureResultOf(d, ServerConnectionError)
         inner = f.value.reason
         self.assertIsInstance(inner, innerType)
-        returnValue(inner)
+        return inner
 
     @inlineCallbacks
     def test_bad_dns(self):
@@ -699,7 +699,7 @@ class InitialFailure(unittest.TestCase):
         e = yield self.assertFailure(d, ServerConnectionError)
         inner = e.reason
         self.assertIsInstance(inner, innerType)
-        returnValue(inner)
+        return inner
 
     @inlineCallbacks
     def test_no_connection(self):

--- a/src/wormhole/timing.py
+++ b/src/wormhole/timing.py
@@ -25,18 +25,7 @@ class Event:
         return self
 
     def __exit__(self, exc_type, exc_value, exc_tb):
-        if exc_type:
-            # inlineCallbacks uses a special exception (defer._DefGen_Return)
-            # to deliver returnValue(), so if returnValue is used inside our
-            # with: block, we'll mistakenly think it means something broke.
-            # I've moved all returnValue() calls outside the 'with
-            # timing.add()' blocks to avoid this, but if a new one
-            # accidentally pops up, it'll get marked as an error. I used to
-            # catch-and-release _DefGen_Return to avoid this, but removed it
-            # because it requires referencing defer.py's private class
-            self.finish(exception=str(exc_type))
-        else:
-            self.finish()
+        self.finish()
 
 
 @implementer(ITiming)

--- a/src/wormhole/tor_manager.py
+++ b/src/wormhole/tor_manager.py
@@ -1,7 +1,7 @@
 import sys
 
 from attr import attrib, attrs
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from twisted.internet.endpoints import clientFromString
 from zope.interface.declarations import directlyProvides
 
@@ -113,4 +113,4 @@ def get_tor(reactor,
                     file=stderr)
                 tor = SocksOnlyTor(reactor)
     directlyProvides(tor, _interfaces.ITorManager)
-    returnValue(tor)
+    return tor

--- a/src/wormhole/transit.py
+++ b/src/wormhole/transit.py
@@ -8,7 +8,7 @@ from collections import deque
 from nacl.secret import SecretBox
 from twisted.internet import (address, defer, endpoints, error, interfaces,
                               protocol, task)
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 from twisted.protocols import policies
 from twisted.python import log
 from twisted.python.runtime import platformType
@@ -627,7 +627,7 @@ class Common:
                     u"port": rh.port
                 })
             hints.append(rhint)
-        returnValue(hints)
+        return hints
 
     def _get_direct_hints(self):
         if self._listener:
@@ -767,7 +767,7 @@ class Common:
             # connections, so those connections will know what to say when
             # they connect
             winner = yield self._connect()
-        returnValue(winner)
+        return winner
 
     def _connect(self):
         # It might be nice to wire this so that a failure in the direct hints

--- a/src/wormhole/xfer_util.py
+++ b/src/wormhole/xfer_util.py
@@ -1,6 +1,6 @@
 import json
 
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks
 
 from . import wormhole
 from .tor_manager import get_tor
@@ -72,7 +72,7 @@ def receive(reactor,
         raise Exception("Unknown offer type: {}".format(offer.keys()))
 
     yield wh.close()
-    returnValue(msg)
+    return msg
 
 
 @inlineCallbacks
@@ -128,6 +128,6 @@ def send(reactor,
     answer = data.get('answer', None)
     yield wh.close()
     if answer:
-        returnValue(None)
+        return None
     else:
         raise Exception("Unknown answer: {}".format(data))


### PR DESCRIPTION
`defer.returnValue` was only needed in Python 2; in Python 3, a simple `return` is fine.

`twisted.internet.defer.returnValue` is deprecated as of Twisted 24.7.0.