### PR TITLE
Add WORMHOLE_ACCEPT_FILE environment variable

### DIFF
--- a/src/wormhole/cli/cli.py
+++ b/src/wormhole/cli/cli.py
@@ -308,6 +308,7 @@ def go(f, cfg):
 @click.option(
     "--accept-file",
     is_flag=True,
+    envvar="WORMHOLE_ACCEPT_FILE",
     help="accept file transfer without asking for confirmation",
 )
 @click.option(

--- a/src/wormhole/test/test_args.py
+++ b/src/wormhole/test/test_args.py
@@ -191,6 +191,11 @@ class Receive(unittest.TestCase):
             cfg = config("--transit-helper", transit_url_2, "receive")
         self.assertEqual(cfg.transit_helper, transit_url_2)
 
+    def test_accept_file_env_var(self):
+        with mock.patch.dict(os.environ, WORMHOLE_ACCEPT_FILE="true"):
+            cfg = config("receive")
+        self.assertEqual(cfg.accept_file, True)
+
 
 class Config(unittest.TestCase):
     def test_send(self):


### PR DESCRIPTION
If set to a string value that Click considers truthy, file transfers will be accepted without confirmation. https://click.palletsprojects.com/en/stable/parameters/#parameter-types

This commit resolves #569.