### PR TITLE
morally correct but imperfect nameplate deallocation notification

### DIFF
--- a/src/wormhole/_nameplate.py
+++ b/src/wormhole/_nameplate.py
@@ -156,6 +156,8 @@ class Nameplate(object):
 
     @m.output()
     def T_nameplate_done(self):
+        # feedback API is the most right way to do this, but there's also a config object with stdout
+        print("mailbox communication established, nameplate deallocated",self._args.stdout)
         self._T.nameplate_done()
 
     S0A.upon(_set_nameplate, enter=S1A, outputs=[record_nameplate])


### PR DESCRIPTION
This is a morally correct but imperfect PR for #575 
From talking to @meejah I think it's likely I need to get stdout from the `Config` object somehow, so tests can check the output. 