### PR TITLE
Add minimal pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=64.0.0", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Closes #577.

This changeset adds a minimal `pyproject.toml` the _only_ declares the build requirements and that `setuptools` is the build backend.

Note that I was not able to reproduce the deprecation warning described in #577 (I tried a few combinations of `pip` version, `setuptools` version, etc.), but based on the linked upstream issue I'm pretty confident this is the resolution. And even if it isn't, it's standards-compliant.

The lower bound on the `setuptools` version is meant to exclude versions of `setuptools` that don't support PEP 660.