### PR TITLE
Fix tests with Click 8.2

### DIFF
--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -1456,7 +1456,7 @@ class Help(unittest.TestCase):
             ["receive", "--code-length", "3", "2-foo-bar"]
         )
         self.assertNotEqual(result.exit_code, 0)
-        self.assertIn("Must use --allocate", result.stdout)
+        self.assertIn("Must use --allocate", result.output)
 
     def test_inconsistent_receive_allocate(self):
         """
@@ -1467,4 +1467,4 @@ class Help(unittest.TestCase):
             ["receive", "--allocate", "2-foo-bar"]
         )
         self.assertNotEqual(result.exit_code, 0)
-        self.assertIn("Cannot specify a code", result.stdout)
+        self.assertIn("Cannot specify a code", result.output)


### PR DESCRIPTION
https://github.com/pallets/click/pull/2523 introduced changes to `click.testing.Result` that broke a couple of unit tests in magic-wormhole.  Although this Click version hasn't been fully released yet, this adjusts magic-wormhole to work with both old and new versions.