### PR TITLE
docs: fix broken links and add linkcheck

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -110,7 +110,7 @@ generally baked-in to the application source code or default config.
 This library includes the URL of a public mailbox server run by the
 author. Application developers can use this one, or they can run their
 own (see the
-`warner/magic-wormhole-mailbox-server <https://github.com/warner/magic-wormhole-mailbox-server>`__
+`magic-wormhole/magic-wormhole-mailbox-server <https://github.com/magic-wormhole/magic-wormhole-mailbox-server>`__
 repository) and configure their clients to use it instead. The URL of
 the public mailbox server is passed as a unicode string. Note that
 because the server actually speaks WebSockets, the URL starts with

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,3 +185,8 @@ texinfo_documents = [
      author, 'Magic-Wormhole', 'One line description of project.',
      'Miscellaneous'),
 ]
+
+# -- Options for linkcheck ------------------------------------------------
+
+# Skip checking validity of #anchors in links.
+linkcheck_anchors = False

--- a/docs/dilation-protocol.rst
+++ b/docs/dilation-protocol.rst
@@ -9,13 +9,13 @@ separate streams as the application protocol requires. Multiple ways to
 connect are supported, via “hints”. These exist for direct TCP, TCP via
 Tor, and TCP to a central Transit helper (see also “Canonical hint
 encodings” in the `Transit
-documentation <https://github.com/magic-wormhole/magic-wormhole-protocols/transit.md>`__
+documentation <https://github.com/magic-wormhole/magic-wormhole-protocols/blob/main/transit.md>`__
 ).
 
 These building-blocks allow “application” protocols to be simpler by
 not having to deal with re-connection attempts and network problems.
 Dilation was conceived during development of a “next-generation”
-file-transfer protocol now called “`Dilated File
+file-transfer protocol now called “ `Dilated File
 Transfer <https://github.com/magic-wormhole/magic-wormhole-protocols/pull/23>`__”.
 
 This document assumes you are familiar with the core Mailbox protocol

--- a/docs/dilation-protocol.rst
+++ b/docs/dilation-protocol.rst
@@ -20,7 +20,7 @@ Transfer <https://github.com/magic-wormhole/magic-wormhole-protocols/pull/23>`__
 
 This document assumes you are familiar with the core Mailbox protocol
 and the general promises of Magic Wormhole. For more information see
-`the Server Protocol <server-protocol.md>`__.
+:doc:`the Server Protocol <server-protocol>`.
 
 Dilation Internals
 ==================

--- a/docs/ecosystem.rst
+++ b/docs/ecosystem.rst
@@ -155,7 +155,7 @@ Other Uses
 Some other interesting uses of Magic Wormhole that don't directly use the file-transfer protocol.
 If you know of others, please send them along!
 
-* Port-forwarding: over the classic Transit protocol in the `rust implementation <https://github.com/magic-wormhole/magic-wormhole.rs/blob/e6ddc75c63ba030d5681cac04ca3e5a2262acc50/src/forwarding.rs#L1>`_ and over the Dilation protocol in Python as `fow <https://github.com/meejah/fow>`_ (foward-over-wormhole).
+* Port-forwarding: over the classic Transit protocol in the `rust implementation <https://github.com/magic-wormhole/magic-wormhole.rs/blob/e6ddc75c63ba030d5681cac04ca3e5a2262acc50/src/forwarding.rs#L1>`_ and over the Dilation protocol in Python as `fow <https://github.com/meejah/fowl>`_ (foward-over-wormhole).
 
 * Invite / key-exchange: `Magic Folder <https://magic-folder.readthedocs.io/en/latest/invites.html>`_ implements a custom protocol to do "introduction" / key-exchange.
 

--- a/docs/welcome.rst
+++ b/docs/welcome.rst
@@ -144,7 +144,7 @@ find it on your ``$PATH``.
 
 You probably *don’t* want to use ``sudo`` when you run ``pip``. This
 tends to create
-`conflicts <https://github.com/warner/magic-wormhole/issues/336>`__ with
+`conflicts <https://github.com/magic-wormhole/magic-wormhole/issues/336>`__ with
 the system python libraries.
 
 On OS X, you may need to pre-install ``pip``, and run
@@ -247,7 +247,7 @@ desire more reliability can easily run their own relay and configure
 their clients to use it instead. Code for the Mailbox Server is in a
 separate package named ``magic-wormhole-mailbox-server`` and has
 documentation
-`here <https://github.com/warner/magic-wormhole-mailbox-server/blob/master/docs/welcome.md>`__.
+`here <https://github.com/magic-wormhole/magic-wormhole-mailbox-server/blob/master/docs/welcome.md>`__.
 Both clients must use the same mailbox server. The default can be
 overridden with the ``--relay-url`` option.
 
@@ -261,7 +261,7 @@ using the transit relay. As before, the host/port of a public server is
 baked into the library, and should be sufficient to handle moderate
 traffic. Code for the Transit Relay is provided a separate package named
 ``magic-wormhole-transit-relay`` with instructions
-`here <https://github.com/warner/magic-wormhole-transit-relay/blob/master/docs/running.md>`__.
+`here <https://github.com/magic-wormhole/magic-wormhole-transit-relay/blob/master/docs/running.md>`__.
 The clients exchange transit relay information during connection
 negotiation, so they can be configured to use different ones without
 problems. Use the ``--transit-helper`` option to override the default.
@@ -293,7 +293,7 @@ If you desire shell tab-completion on sub-commands, we include generated
 files `from
 Click <https://click.palletsprojects.com/en/8.1.x/shell-completion/>`__
 for Bash, Zsh and Fish shells in
-`wormhole_completion.bash <https://github.com/magic-wormhole/magic-wormhole/blob/master/wormhole_completion.bash>`__
+`wormhole_completion.bash <https://github.com/magic-wormhole/magic-wormhole/blob/master/wormhole_complete.bash>`__
 (or ``.zsh``, ``.fish``). Put this file in your favourite location and
 add a line like ``source ~/wormhole_completion.bash`` to ``~/.bashrc``
 (or similar for ``zsh`` and ``fish`` shells).
@@ -318,7 +318,7 @@ Development
 -----------
 
 -  Bugs and patches at the `GitHub project
-   page <https://github.com/warner/magic-wormhole>`__.
+   page <https://github.com/magic-wormhole/magic-wormhole>`__.
 -  Chat via `IRC <irc://irc.libera.chat/#magic-wormhole>`__:
    #magic-wormhole on irc.libera.chat
 -  Chat via `Matrix <https://matrix.to/#/#magic-wormhole:matrix.org>`__:

--- a/tox.ini
+++ b/tox.ini
@@ -45,6 +45,14 @@ max-complexity = 40
 deps = flake8
 commands = flake8 --select=E901,E999,F821,F822,F823 src/wormhole
 
+[testenv:linkcheck]
+deps =
+     sphinx
+     sphinxcontrib-seqdiag
+skip_install = True
+commands =
+         sphinx-build -b linkcheck -d {toxinidir}/docs/_build/doctrees {toxinidir}/docs {toxinidir}/docs/_build/linkcheck
+
 [testenv:docs]
 deps =
      sphinx


### PR DESCRIPTION
- add sphinx linkcheck to tox.ini and fix broken external links
- replace internal links with sphinx cross-references

Fixes #583 

<!-- readthedocs-preview magic-wormhole start -->
Please see the rendered documentation: https://magic-wormhole--588.org.readthedocs.build/en/588/
<!-- readthedocs-preview magic-wormhole end -->