### PR TITLE
Convert to pytest

### DIFF
--- a/src/wormhole/_hints.py
+++ b/src/wormhole/_hints.py
@@ -73,7 +73,7 @@ def parse_hint_argv(hint, stderr=sys.stderr):
     # parse the port:
     mo = re.search(r'^(\d+)$', pieces[1])
     if not mo:
-        print("non-numeric port in TCP hint '%s' %s" % (hint, pieces[1]), file=stderr)
+        print("non-numeric port in TCP hint '%s'" % (hint, ), file=stderr)
         return None
     hint_port = int(pieces[1])
     # parse the rest ("priority=float")

--- a/src/wormhole/_hints.py
+++ b/src/wormhole/_hints.py
@@ -73,7 +73,7 @@ def parse_hint_argv(hint, stderr=sys.stderr):
     # parse the port:
     mo = re.search(r'^(\d+)$', pieces[1])
     if not mo:
-        print("non-numeric port in TCP hint '%s'" % (hint, ), file=stderr)
+        print("non-numeric port in TCP hint '%s' %s" % (hint, pieces[1]), file=stderr)
         return None
     hint_port = int(pieces[1])
     # parse the rest ("priority=float")

--- a/src/wormhole/test/common.py
+++ b/src/wormhole/test/common.py
@@ -73,7 +73,7 @@ async def setup_mailbox(reactor, advertise_version=None, error=None):
     """
     db = create_channel_db(":memory:")
     usage_db = create_usage_db(":memory:")
-    rendezvous = make_server(db, usage_db=usage_db)
+    rendezvous = make_server(db, usage_db=usage_db, signal_error=error)
     ep = endpoints.TCP4ServerEndpoint(reactor, 0, interface="127.0.0.1")
     site = make_web_server(rendezvous, log_requests=False)
     port = await ep.listen(site)

--- a/src/wormhole/test/common.py
+++ b/src/wormhole/test/common.py
@@ -56,6 +56,7 @@ class Mailbox:
     web: PrivacyEnhancedSite
     url: str
     service: internet.StreamServerEndpointService
+    port: object  # IPort ?
 
 
 def setup_mailbox(reactor, advertise_version=None, error=None):
@@ -77,7 +78,7 @@ def setup_mailbox(reactor, advertise_version=None, error=None):
     port = pytest_twisted.blockon(ep.listen(site))
     service = internet.StreamServerEndpointService(ep, site)
     relay_url = f"ws://127.0.0.1:{port._realPortNumber}/v1"  # XXX private API
-    return Mailbox(db, usage_db, rendezvous, site, relay_url, service)
+    return Mailbox(db, usage_db, rendezvous, site, relay_url, service, port)
 
 
 def setup_transit_relay(reactor):

--- a/src/wormhole/test/common.py
+++ b/src/wormhole/test/common.py
@@ -72,7 +72,12 @@ async def setup_mailbox(reactor, advertise_version=None, error=None):
     """
     db = create_channel_db(":memory:")
     usage_db = create_usage_db(":memory:")
-    rendezvous = make_server(db, usage_db=usage_db, signal_error=error)
+    rendezvous = make_server(
+        db,
+        usage_db=usage_db,
+        advertise_version=advertise_version,
+        signal_error=error,
+    )
     ep = endpoints.TCP4ServerEndpoint(reactor, 0, interface="127.0.0.1")
     site = make_web_server(rendezvous, log_requests=False)
     port = await ep.listen(site)

--- a/src/wormhole/test/common.py
+++ b/src/wormhole/test/common.py
@@ -75,11 +75,9 @@ async def setup_mailbox(reactor, advertise_version=None, error=None):
     rendezvous = make_server(db, usage_db=usage_db, signal_error=error)
     ep = endpoints.TCP4ServerEndpoint(reactor, 0, interface="127.0.0.1")
     site = make_web_server(rendezvous, log_requests=False)
-    print("MAKE WEBSERVER", site)
     port = await ep.listen(site)
     service = internet.StreamServerEndpointService(ep, site)
     relay_url = f"ws://127.0.0.1:{port._realPortNumber}/v1"  # XXX private API
-    print("CREATING MAILBOX", port)
     return Mailbox(db, usage_db, rendezvous, site, relay_url, service, port, site)
 
 
@@ -94,7 +92,6 @@ def setup_transit_relay(reactor):
     transit_server.log_requests = False
     transit_server.transit = Transit(usage, reactor.seconds)
     service = internet.StreamServerEndpointService(ep, transit_server)
-    print("TRANSIT!", endpoint)
     return client_endpoint, service
 
 
@@ -104,7 +101,6 @@ class ServerBase:
         await self._setup_relay(None)
 
     async def _setup_relay(self, error, advertise_version=None):
-        print("\n\nSETUP RELAY\n\n")
         self.sp = service.MultiService()
         self.sp.startService()
         # need to talk to twisted team about only using unicode in

--- a/src/wormhole/test/common.py
+++ b/src/wormhole/test/common.py
@@ -75,9 +75,11 @@ async def setup_mailbox(reactor, advertise_version=None, error=None):
     rendezvous = make_server(db, usage_db=usage_db, signal_error=error)
     ep = endpoints.TCP4ServerEndpoint(reactor, 0, interface="127.0.0.1")
     site = make_web_server(rendezvous, log_requests=False)
+    print("MAKE WEBSERVER", site)
     port = await ep.listen(site)
     service = internet.StreamServerEndpointService(ep, site)
     relay_url = f"ws://127.0.0.1:{port._realPortNumber}/v1"  # XXX private API
+    print("CREATING MAILBOX", port)
     return Mailbox(db, usage_db, rendezvous, site, relay_url, service, port, site)
 
 
@@ -92,6 +94,7 @@ def setup_transit_relay(reactor):
     transit_server.log_requests = False
     transit_server.transit = Transit(usage, reactor.seconds)
     service = internet.StreamServerEndpointService(ep, transit_server)
+    print("TRANSIT!", endpoint)
     return client_endpoint, service
 
 
@@ -101,6 +104,7 @@ class ServerBase:
         await self._setup_relay(None)
 
     async def _setup_relay(self, error, advertise_version=None):
+        print("\n\nSETUP RELAY\n\n")
         self.sp = service.MultiService()
         self.sp.startService()
         # need to talk to twisted team about only using unicode in

--- a/src/wormhole/test/common.py
+++ b/src/wormhole/test/common.py
@@ -85,7 +85,7 @@ def setup_transit_relay(reactor):
     endpoint = f"tcp:{transitport}:interface=127.0.0.1"
     ep = endpoints.serverFromString(reactor, endpoint)
     usage = create_usage_tracker(blur_usage=None, log_file=None, usage_db=None)
-    transit_server = ServerFactory()
+    transit_server = protocol.ServerFactory()
     transit_server.protocol = TransitConnection
     transit_server.log_requests = False
     transit_server.transit = Transit(usage, reactor.seconds)

--- a/src/wormhole/test/common.py
+++ b/src/wormhole/test/common.py
@@ -57,9 +57,10 @@ class Mailbox:
     url: str
     service: internet.StreamServerEndpointService
     port: object  # IPort ?
+    site: object  # ??
 
 
-def setup_mailbox(reactor, advertise_version=None, error=None):
+async def setup_mailbox(reactor, advertise_version=None, error=None):
     """
     Set up an in-memory Mailbox server.
 
@@ -75,10 +76,10 @@ def setup_mailbox(reactor, advertise_version=None, error=None):
     rendezvous = make_server(db, usage_db=usage_db)
     ep = endpoints.TCP4ServerEndpoint(reactor, 0, interface="127.0.0.1")
     site = make_web_server(rendezvous, log_requests=False)
-    port = pytest_twisted.blockon(ep.listen(site))
+    port = await ep.listen(site)
     service = internet.StreamServerEndpointService(ep, site)
     relay_url = f"ws://127.0.0.1:{port._realPortNumber}/v1"  # XXX private API
-    return Mailbox(db, usage_db, rendezvous, site, relay_url, service, port)
+    return Mailbox(db, usage_db, rendezvous, site, relay_url, service, port, site)
 
 
 def setup_transit_relay(reactor):

--- a/src/wormhole/test/common.py
+++ b/src/wormhole/test/common.py
@@ -2,7 +2,7 @@
 from attrs import define
 from click.testing import CliRunner
 from twisted.application import internet, service
-from twisted.internet import defer, endpoints, reactor, task, protocol
+from twisted.internet import defer, endpoints, reactor, protocol
 from twisted.python import log
 
 from unittest import mock

--- a/src/wormhole/test/common.py
+++ b/src/wormhole/test/common.py
@@ -85,6 +85,7 @@ async def setup_mailbox(reactor, advertise_version=None, error=None):
 def setup_transit_relay(reactor):
     transitport = allocate_tcp_port()
     endpoint = f"tcp:{transitport}:interface=127.0.0.1"
+    client_endpoint = f"tcp:127.0.0.1:{transitport}"
     ep = endpoints.serverFromString(reactor, endpoint)
     usage = create_usage_tracker(blur_usage=None, log_file=None, usage_db=None)
     transit_server = protocol.ServerFactory()
@@ -92,9 +93,7 @@ def setup_transit_relay(reactor):
     transit_server.log_requests = False
     transit_server.transit = Transit(usage, reactor.seconds)
     service = internet.StreamServerEndpointService(ep, transit_server)
-    return endpoint, service
-
-
+    return client_endpoint, service
 class ServerBase:
 
     async def setUp(self):

--- a/src/wormhole/test/common.py
+++ b/src/wormhole/test/common.py
@@ -12,7 +12,6 @@ from wormhole_mailbox_server.web import make_web_server, PrivacyEnhancedSite
 from wormhole_transit_relay.transit_server import Transit, TransitConnection
 from wormhole_transit_relay.usage import create_usage_tracker
 
-import pytest_twisted
 import sqlite3
 
 from ..cli import cli
@@ -94,6 +93,8 @@ def setup_transit_relay(reactor):
     transit_server.transit = Transit(usage, reactor.seconds)
     service = internet.StreamServerEndpointService(ep, transit_server)
     return client_endpoint, service
+
+
 class ServerBase:
 
     async def setUp(self):

--- a/src/wormhole/test/conftest.py
+++ b/src/wormhole/test/conftest.py
@@ -49,11 +49,17 @@ class Observer:
             self.failures.append(event_dict["failure"])
 
     def flush(self, klass):
+        flushed = [
+            f
+            for f in self.failures
+            if isinstance(f.value, klass)
+        ]
         self.failures = [
             f
             for f in self.failures
             if not isinstance(f.value, klass)
         ]
+        return flushed
 
     def assert_empty(self):
         assert [] == self.failures

--- a/src/wormhole/test/conftest.py
+++ b/src/wormhole/test/conftest.py
@@ -19,7 +19,11 @@ def reactor():
 
 @pytest.fixture(scope="session")
 def mailbox(reactor):
-    mb = pytest_twisted.blockon(ensureDeferred(setup_mailbox(reactor)))
+    mb = pytest_twisted.blockon(
+        ensureDeferred(
+            setup_mailbox(reactor, advertise_version="1.2.3")
+        )
+    )
     mb.service.startService()
     yield mb
     pytest_twisted.blockon(mb.service.stopService())

--- a/src/wormhole/test/conftest.py
+++ b/src/wormhole/test/conftest.py
@@ -1,19 +1,7 @@
-from twisted.internet import endpoints
-from twisted.internet.protocol import ServerFactory
-from twisted.application.internet import StreamServerEndpointService
 from twisted.internet.defer import ensureDeferred
-
-from wormhole_mailbox_server.database import create_channel_db, create_usage_db
-from wormhole_mailbox_server.server import make_server
-from wormhole_mailbox_server.web import make_web_server
-from wormhole_transit_relay.transit_server import Transit, TransitConnection
-from wormhole_transit_relay.usage import create_usage_tracker
-
 
 import pytest
 import pytest_twisted
-
-from ..transit import allocate_tcp_port
 
 
 @pytest.fixture(scope="session")

--- a/src/wormhole/test/conftest.py
+++ b/src/wormhole/test/conftest.py
@@ -6,6 +6,10 @@ import pytest_twisted
 
 from .common import setup_mailbox, setup_transit_relay
 
+# from kyle altendorf
+# see also https://github.com/pytest-dev/pytest-twisted/issues/4
+import gc
+
 
 @pytest.fixture(scope="session")
 def reactor():
@@ -33,9 +37,6 @@ def transit_relay(reactor):
 
 
 
-# from kyle altendorf
-# see also https://github.com/pytest-dev/pytest-twisted/issues/4
-import gc
 
 
 class Observer:

--- a/src/wormhole/test/conftest.py
+++ b/src/wormhole/test/conftest.py
@@ -1,4 +1,5 @@
 from twisted.internet.defer import ensureDeferred
+from twisted.python import log
 
 import pytest
 import pytest_twisted
@@ -59,11 +60,10 @@ class Observer:
 @pytest.fixture
 def observe_errors():
     observer = Observer()
-    twisted.logger.globalLogPublisher.addObserver(observer)
+    log.startLoggingWithObserver(observer, 0)
 
     yield observer
 
     gc.collect()
-    twisted.logger.globalLogPublisher.removeObserver(observer)
-
+    log.removeObserver(observer)
     observer.assert_empty()

--- a/src/wormhole/test/conftest.py
+++ b/src/wormhole/test/conftest.py
@@ -36,7 +36,6 @@ def transit_relay(reactor):
 # from kyle altendorf
 # see also https://github.com/pytest-dev/pytest-twisted/issues/4
 import gc
-import twisted.logger
 
 
 class Observer:

--- a/src/wormhole/test/conftest.py
+++ b/src/wormhole/test/conftest.py
@@ -43,15 +43,15 @@ class Observer:
 
     def __call__(self, event_dict):
         is_error = event_dict.get('isError')
-        s = 'Unhandled error in Deferred'.casefold()
-        is_unhandled = s in event_dict.get('log_format', '').casefold()
-
-        if is_error and is_unhandled:
-            self.failures.append(event_dict)
+        if is_error:
+            self.failures.append(event_dict["failure"])
 
     def flush(self, klass):
-        for f in self.failures:
-            print(f, klass)
+        self.failures = [
+            f
+            for f in self.failures
+            if not isinstance(f.value, klass)
+        ]
 
     def assert_empty(self):
         assert [] == self.failures

--- a/src/wormhole/test/conftest.py
+++ b/src/wormhole/test/conftest.py
@@ -27,3 +27,47 @@ def transit_relay(reactor):
     service.startService()
     yield url
     pytest_twisted.blockon(service.stopService())
+
+
+
+# from kyle altendorf
+# see also https://github.com/pytest-dev/pytest-twisted/issues/4
+import gc
+import twisted.logger
+
+
+class Observer:
+    def __init__(self):
+        self.failures = []
+
+    def __call__(self, event_dict):
+        is_error = event_dict.get('isError')
+        s = 'Unhandled error in Deferred'.casefold()
+        is_unhandled = s in event_dict.get('log_format', '').casefold()
+
+        if is_error and is_unhandled:
+            self.failures.append(event_dict)
+
+    def flush(self, klass):
+        for f in self.failures:
+            print(f, klass)
+
+    def assert_empty(self):
+        assert [] == self.failures
+
+
+@pytest.fixture
+def observe_errors():
+    observer = Observer()
+    twisted.logger.globalLogPublisher.addObserver(observer)
+
+    yield observer
+
+    gc.collect()
+    gc.collect()
+    gc.collect()
+    gc.collect()
+    gc.collect()
+    twisted.logger.globalLogPublisher.removeObserver(observer)
+
+    observer.assert_empty()

--- a/src/wormhole/test/conftest.py
+++ b/src/wormhole/test/conftest.py
@@ -1,6 +1,7 @@
 from twisted.internet import endpoints
 from twisted.internet.protocol import ServerFactory
 from twisted.application.internet import StreamServerEndpointService
+from twisted.internet.defer import ensureDeferred
 
 from wormhole_mailbox_server.database import create_channel_db, create_usage_db
 from wormhole_mailbox_server.server import make_server
@@ -25,7 +26,7 @@ from .common import setup_mailbox, setup_transit_relay
 
 @pytest.fixture(scope="session")
 def mailbox(reactor):
-    mb = setup_mailbox(reactor)
+    mb = pytest_twisted.blockon(ensureDeferred(setup_mailbox(reactor)))
     mb.service.startService()
     yield mb
     pytest_twisted.blockon(mb.service.stopService())

--- a/src/wormhole/test/conftest.py
+++ b/src/wormhole/test/conftest.py
@@ -64,10 +64,6 @@ def observe_errors():
     yield observer
 
     gc.collect()
-    gc.collect()
-    gc.collect()
-    gc.collect()
-    gc.collect()
     twisted.logger.globalLogPublisher.removeObserver(observer)
 
     observer.assert_empty()

--- a/src/wormhole/test/conftest.py
+++ b/src/wormhole/test/conftest.py
@@ -33,7 +33,7 @@ def mailbox(reactor):
 
 @pytest.fixture(scope="session")
 def transit_relay(reactor):
-    url, service = setup_transit_relay()
+    url, service = setup_transit_relay(reactor)
     pytest_twisted.blockon(service.startService())
     yield url
     pytest_twisted.blockon(service.stopService())

--- a/src/wormhole/test/conftest.py
+++ b/src/wormhole/test/conftest.py
@@ -18,6 +18,7 @@ def mailbox(reactor):
     mb.service.startService()
     yield mb
     pytest_twisted.blockon(mb.service.stopService())
+    mb.site.stopFactory()
 
 
 @pytest.fixture(scope="session")

--- a/src/wormhole/test/conftest.py
+++ b/src/wormhole/test/conftest.py
@@ -19,7 +19,9 @@ def mailbox(reactor):
     mb.service.startService()
     yield mb
     pytest_twisted.blockon(mb.service.stopService())
-    mb.site.stopFactory()
+    pytest_twisted.blockon(mb.port.stopListening())
+    ##from twisted.internet import task
+    ##pytest_twisted.blockon(task.deferLater(reactor, 0.1, lambda: None))
 
 
 @pytest.fixture(scope="session")

--- a/src/wormhole/test/conftest.py
+++ b/src/wormhole/test/conftest.py
@@ -34,6 +34,6 @@ def mailbox(reactor):
 @pytest.fixture(scope="session")
 def transit_relay(reactor):
     url, service = setup_transit_relay(reactor)
-    pytest_twisted.blockon(service.startService())
+    service.startService()
     yield url
     pytest_twisted.blockon(service.stopService())

--- a/src/wormhole/test/conftest.py
+++ b/src/wormhole/test/conftest.py
@@ -3,13 +3,13 @@ from twisted.internet.defer import ensureDeferred
 import pytest
 import pytest_twisted
 
+from .common import setup_mailbox, setup_transit_relay
+
 
 @pytest.fixture(scope="session")
 def reactor():
     from twisted.internet import reactor
     yield reactor
-
-from .common import setup_mailbox, setup_transit_relay
 
 
 @pytest.fixture(scope="session")

--- a/src/wormhole/test/dilate/test_api.py
+++ b/src/wormhole/test/dilate/test_api.py
@@ -1,5 +1,4 @@
 from twisted.internet import reactor
-from twisted.trial import unittest
 from twisted.internet.task import deferLater
 from attrs import evolve
 
@@ -12,10 +11,9 @@ from ...eventual import EventualQueue
 from ..._dilation._noise import NoiseConnection
 from ..._status import Connecting, Connected, Disconnected, WormholeStatus, NoKey, AllegedSharedKey, ConfirmedKey, DilationStatus, NoPeer, ConnectedPeer, ConnectingPeer
 
-from ..common import ServerBase
-
 
 @pytest_twisted.ensureDeferred()
+@pytest.mark.skipif(not NoiseConnection, reason="noiseprotocol required")
 async def test_on_status_error(reactor, mailbox):
     """
     Our user code raises an exception during status processing
@@ -45,10 +43,8 @@ async def test_on_status_error(reactor, mailbox):
             pass
 
 @pytest_twisted.ensureDeferred()
+@pytest.mark.skipif(not NoiseConnection, reason="noiseprotocol required")
 async def test_dilation_status(reactor, mailbox):
-    if not NoiseConnection:
-        raise unittest.SkipTest("noiseprotocol unavailable")
-
     eq = EventualQueue(reactor)
 
     status0 = []

--- a/src/wormhole/test/dilate/test_api.py
+++ b/src/wormhole/test/dilate/test_api.py
@@ -3,7 +3,8 @@ from twisted.trial import unittest
 from twisted.internet.task import deferLater
 from attrs import evolve
 
-from pytest_twisted import ensureDeferred
+import pytest
+import pytest_twisted
 
 from ...wormhole import create
 from ...errors import LonelyError
@@ -14,154 +15,146 @@ from ..._status import Connecting, Connected, Disconnected, WormholeStatus, NoKe
 from ..common import ServerBase
 
 
-class API(ServerBase, unittest.TestCase):
+@pytest_twisted.ensureDeferred()
+async def test_on_status_error(reactor, mailbox):
+    """
+    Our user code raises an exception during status processing
+    """
+    eq = EventualQueue(reactor)
 
-    @ensureDeferred()
-    async def test_on_status_error(self):
-        """
-        Our user code raises an exception during status processing
-        """
-        eq = EventualQueue(reactor)
+    class FakeError(Exception):
+        pass
 
-        class FakeError(Exception):
-            pass
-
-        def on_status(_):
-            raise FakeError()
-        with self.assertRaises(FakeError):
-            w = create(
-                "appid", self.relayurl,
-                reactor,
-                versions={"fun": "quux"},
-                _eventual_queue=eq,
-                _enable_dilate=True,
-                on_status_update=on_status,
-            )
-            await w.allocate_code()
-            code = await w.get_code()
-            print(code)
-            try:
-                await w.close()
-            except LonelyError:
-                pass
-
-    @ensureDeferred()
-    async def test_dilation_status(self):
-        if not NoiseConnection:
-            raise unittest.SkipTest("noiseprotocol unavailable")
-
-        eq = EventualQueue(reactor)
-
-        status0 = []
-        status1 = []
-
-        wormhole_status0 = []
-        wormhole_status1 = []
-
-        w0 = create(
-            "appid", self.relayurl,
+    def on_status(_):
+        raise FakeError()
+    with pytest.raises(FakeError):
+        w = create(
+            "appid", mailbox.url,
             reactor,
             versions={"fun": "quux"},
             _eventual_queue=eq,
             _enable_dilate=True,
-            on_status_update=wormhole_status0.append,
+            on_status_update=on_status,
         )
+        await w.allocate_code()
+        code = await w.get_code()
+        print(code)
+        try:
+            await w.close()
+        except LonelyError:
+            pass
 
-        w1 = create(
-            "appid", self.relayurl,
-            reactor,
-            versions={"bar": "baz"},
-            _eventual_queue=eq,
-            _enable_dilate=True,
-            on_status_update=wormhole_status1.append,
-        )
+@pytest_twisted.ensureDeferred()
+async def test_dilation_status(reactor, mailbox):
+    if not NoiseConnection:
+        raise unittest.SkipTest("noiseprotocol unavailable")
 
-        w0.allocate_code()
-        code = await w0.get_code()
+    eq = EventualQueue(reactor)
 
-        w1.set_code(code)
+    status0 = []
+    status1 = []
 
-        w0.dilate(on_status_update=status0.append)
-        w1.dilate(on_status_update=status1.append)
+    wormhole_status0 = []
+    wormhole_status1 = []
 
-        # we should see the _other side's_ app-versions
-        v0 = await w1.get_versions()
-        v1 = await w0.get_versions()
-        self.assertEqual(v0, {"fun": "quux"})
-        self.assertEqual(v1, {"bar": "baz"})
+    w0 = create(
+        "appid", mailbox.url,
+        reactor,
+        versions={"fun": "quux"},
+        _eventual_queue=eq,
+        _enable_dilate=True,
+        on_status_update=wormhole_status0.append,
+    )
 
-        @ensureDeferred()
-        async def wait_for_peer():
-            while True:
-                await deferLater(reactor, 0.001, lambda: None)
-                peers = [
-                    st
-                    for st in status0
-                    if isinstance(st.peer_connection, ConnectedPeer)
-                ]
-                if peers:
-                    return
-        await wait_for_peer()
+    w1 = create(
+        "appid", mailbox.url,
+        reactor,
+        versions={"bar": "baz"},
+        _eventual_queue=eq,
+        _enable_dilate=True,
+        on_status_update=wormhole_status1.append,
+    )
 
-        # we don't actually do anything, just disconnect after we have
-        # our peer
-        await w0.close()
-        await w1.close()
+    w0.allocate_code()
+    code = await w0.get_code()
 
-        # check that the wormhole status messages are what we expect
-        def normalize_timestamp(status):
-            if isinstance(status.mailbox_connection, Connecting):
-                return evolve(
-                    status,
-                    mailbox_connection=evolve(status.mailbox_connection, last_attempt=1),
-                )
-            return status
+    w1.set_code(code)
 
-        processed = [
-            normalize_timestamp(status)
-            for status in wormhole_status0
-        ]
+    w0.dilate(on_status_update=status0.append)
+    w1.dilate(on_status_update=status1.append)
 
-        self.assertEqual(
-            processed,
-            [
-                WormholeStatus(Connecting(self.relayurl, 1), NoKey()),
-                WormholeStatus(Connected(self.relayurl), NoKey()),
-                WormholeStatus(Connected(self.relayurl), AllegedSharedKey()),
-                WormholeStatus(Connected(self.relayurl), ConfirmedKey()),
-                WormholeStatus(Disconnected(), NoKey()),
+    # we should see the _other side's_ app-versions
+    v0 = await w1.get_versions()
+    v1 = await w0.get_versions()
+    assert v0 == {"fun": "quux"}
+    assert v1 == {"bar": "baz"}
+
+    @pytest_twisted.ensureDeferred()
+    async def wait_for_peer():
+        while True:
+            await deferLater(reactor, 0.001, lambda: None)
+            peers = [
+                st
+                for st in status0
+                if isinstance(st.peer_connection, ConnectedPeer)
             ]
-        )
+            if peers:
+                return
+    await wait_for_peer()
 
-        # we are "normalizing" all the timestamps to be "0" because we
-        # are using the real reactor and therefore it is difficult to
-        # predict what they'll be. Removing the "real reactor" is
-        # itself kind of a deep problem due to the "eventually()"
-        # usage (among some other reasons).
+    # we don't actually do anything, just disconnect after we have
+    # our peer
+    await w0.close()
+    await w1.close()
 
-        def normalize_peer(st):
-            typ = type(st.peer_connection)
-            peer = st.peer_connection
-            if typ == ConnectingPeer:
-                peer = evolve(peer, last_attempt=0)
-            elif typ == ConnectedPeer:
-                peer = evolve(peer, connected_at=0, expires_at=0, hint_description="hint")
-            return evolve(st, peer_connection=peer)
+    # check that the wormhole status messages are what we expect
+    def normalize_timestamp(status):
+        if isinstance(status.mailbox_connection, Connecting):
+            return evolve(
+                status,
+                mailbox_connection=evolve(status.mailbox_connection, last_attempt=1),
+            )
+        return status
 
-        normalized = [normalize_peer(st) for st in status0]
+    processed = [
+        normalize_timestamp(status)
+        for status in wormhole_status0
+    ]
 
-        # for n in normalized: print(n)
+    assert processed == [
+        WormholeStatus(Connecting(mailbox.url, 1), NoKey()),
+        WormholeStatus(Connected(mailbox.url), NoKey()),
+        WormholeStatus(Connected(mailbox.url), AllegedSharedKey()),
+        WormholeStatus(Connected(mailbox.url), ConfirmedKey()),
+        WormholeStatus(Disconnected(), NoKey()),
+    ]
 
-        # check that the Dilation status messages are correct
-        self.assertEqual(
-            normalized,
-            [
-                DilationStatus(WormholeStatus(Connected(self.relayurl), AllegedSharedKey()), 0, NoPeer()),
-                DilationStatus(WormholeStatus(Connected(self.relayurl), AllegedSharedKey()), 0, NoPeer()),
-                DilationStatus(WormholeStatus(Connected(self.relayurl), ConfirmedKey()), 0, NoPeer()),
-                DilationStatus(WormholeStatus(Connected(self.relayurl), ConfirmedKey()), 0, ConnectingPeer(0)),
-                DilationStatus(WormholeStatus(Connected(self.relayurl), ConfirmedKey()), 0, ConnectedPeer(0, 0, hint_description="hint")),
-                DilationStatus(WormholeStatus(Disconnected(), NoKey()), 0, ConnectedPeer(0, 0, hint_description="hint")),
-                DilationStatus(WormholeStatus(Disconnected(), NoKey()), 0, NoPeer()),
-            ]
-        )
+    # we are "normalizing" all the timestamps to be "0" because we
+    # are using the real reactor and therefore it is difficult to
+    # predict what they'll be. Removing the "real reactor" is
+    # itself kind of a deep problem due to the "eventually()"
+    # usage (among some other reasons).
+
+    def normalize_peer(st):
+        typ = type(st.peer_connection)
+        peer = st.peer_connection
+        if typ == ConnectingPeer:
+            peer = evolve(peer, last_attempt=0)
+        elif typ == ConnectedPeer:
+            peer = evolve(peer, connected_at=0, expires_at=0, hint_description="hint")
+        return evolve(st, peer_connection=peer)
+
+    normalized = [normalize_peer(st) for st in status0]
+
+    # for n in normalized: print(n)
+
+    # check that the Dilation status messages are correct
+    assert normalized == [
+        DilationStatus(WormholeStatus(Connected(mailbox.url), AllegedSharedKey()), 0, NoPeer()),
+        DilationStatus(WormholeStatus(Connected(mailbox.url), AllegedSharedKey()), 0, NoPeer()),
+        DilationStatus(WormholeStatus(Connected(mailbox.url), ConfirmedKey()), 0, NoPeer()),
+        DilationStatus(WormholeStatus(Connected(mailbox.url), ConfirmedKey()), 0, ConnectingPeer(0)),
+        DilationStatus(WormholeStatus(Connected(mailbox.url), ConfirmedKey()), 0, ConnectedPeer(0, 0, hint_description="hint")),
+        DilationStatus(WormholeStatus(Disconnected(), NoKey()), 0, ConnectedPeer(0, 0, hint_description="hint")),
+        DilationStatus(WormholeStatus(Disconnected(), NoKey()), 0, NoPeer()),
+    ]

--- a/src/wormhole/test/dilate/test_api.py
+++ b/src/wormhole/test/dilate/test_api.py
@@ -1,4 +1,3 @@
-from twisted.internet import reactor
 from twisted.internet.task import deferLater
 from attrs import evolve
 

--- a/src/wormhole/test/dilate/test_connect.py
+++ b/src/wormhole/test/dilate/test_connect.py
@@ -1,11 +1,11 @@
 import re
 from unittest import mock
 from twisted.internet import reactor
-from twisted.trial import unittest
 from twisted.internet.task import Cooperator
 from twisted.internet.defer import Deferred
 from zope.interface import implementer
 
+import pytest
 from pytest_twisted import ensureDeferred
 
 from ... import _interfaces
@@ -42,54 +42,52 @@ class FakeTerminator(object):
         self.d.callback(None)
 
 
-class Connect(unittest.TestCase):
-    @ensureDeferred
-    async def test1(self):
-        if not NoiseConnection:
-            raise unittest.SkipTest("noiseprotocol unavailable")
-        # print()
-        send_left = MySend("left")
-        send_right = MySend("right")
-        send_left.peer = send_right
-        send_right.peer = send_left
-        key = b"\x00"*32
-        eq = EventualQueue(reactor)
-        cooperator = Cooperator(scheduler=eq.eventually)
+@ensureDeferred
+@pytest.mark.skipif(not NoiseConnection, reason="noiseprotocol required")
+async def test1():
+    # print()
+    send_left = MySend("left")
+    send_right = MySend("right")
+    send_left.peer = send_right
+    send_right.peer = send_left
+    key = b"\x00"*32
+    eq = EventualQueue(reactor)
+    cooperator = Cooperator(scheduler=eq.eventually)
 
-        t_left = FakeTerminator()
-        t_right = FakeTerminator()
+    t_left = FakeTerminator()
+    t_right = FakeTerminator()
 
-        def get_current_wormhole_status():
-            return "fake wormhole status"
+    def get_current_wormhole_status():
+        return "fake wormhole status"
 
-        d_left = manager.Dilator(reactor, eq, cooperator, get_current_wormhole_status)
-        d_left.wire(send_left, t_left)
-        d_left.got_key(key)
-        d_left.got_wormhole_versions({"can-dilate": ["1"]})
-        send_left.dilator = d_left
+    d_left = manager.Dilator(reactor, eq, cooperator, get_current_wormhole_status)
+    d_left.wire(send_left, t_left)
+    d_left.got_key(key)
+    d_left.got_wormhole_versions({"can-dilate": ["1"]})
+    send_left.dilator = d_left
 
-        d_right = manager.Dilator(reactor, eq, cooperator, get_current_wormhole_status)
-        d_right.wire(send_right, t_right)
-        d_right.got_key(key)
-        d_right.got_wormhole_versions({"can-dilate": ["1"]})
-        send_right.dilator = d_right
+    d_right = manager.Dilator(reactor, eq, cooperator, get_current_wormhole_status)
+    d_right.wire(send_right, t_right)
+    d_right.got_key(key)
+    d_right.got_wormhole_versions({"can-dilate": ["1"]})
+    send_right.dilator = d_right
 
-        with mock.patch("wormhole._dilation.connector.ipaddrs.find_addresses",
-                        return_value=["127.0.0.1"]):
-            eps_left = d_left.dilate(no_listen=True)
-            eps_right = d_right.dilate()
+    with mock.patch("wormhole._dilation.connector.ipaddrs.find_addresses",
+                    return_value=["127.0.0.1"]):
+        eps_left = d_left.dilate(no_listen=True)
+        eps_right = d_right.dilate()
 
-        # print("left connected", eps_left)
-        # print("right connected", eps_right)
+    # print("left connected", eps_left)
+    # print("right connected", eps_right)
 
-        control_ep_left, connect_ep_left, listen_ep_left = eps_left
-        control_ep_right, connect_ep_right, listen_ep_right = eps_right
+    control_ep_left, connect_ep_left, listen_ep_left = eps_left
+    control_ep_right, connect_ep_right, listen_ep_right = eps_right
 
-        # we normally shut down with w.close(), which calls Dilator.stop(),
-        # which calls Terminator.stoppedD(), which (after everything else is
-        # done) calls Boss.stopped
-        d_left.stop()
-        d_right.stop()
+    # we normally shut down with w.close(), which calls Dilator.stop(),
+    # which calls Terminator.stoppedD(), which (after everything else is
+    # done) calls Boss.stopped
+    d_left.stop()
+    d_right.stop()
 
-        await t_left.d
-        await t_right.d
+    await t_left.d
+    await t_right.d

--- a/src/wormhole/test/dilate/test_connection.py
+++ b/src/wormhole/test/dilate/test_connection.py
@@ -97,7 +97,7 @@ def _test_no_relay(role):
             mock.call.read_message(b"handshake2")]
         assert connector.mock_calls == []
         assert t.mock_calls == []
-        assert c._manager == None
+        assert c._manager is None
     else:
         # we're the follower, so we send our Noise handshake, then
         # encrypt and send the KCM immediately
@@ -110,7 +110,7 @@ def _test_no_relay(role):
         assert t.mock_calls == [
             mock.call.write(exp_handshake),
             mock.call.write(exp_kcm)]
-        assert c._manager == None
+        assert c._manager is None
     clear_mock_calls(n, connector, t, m)
 
     c.dataReceived(b"\x00\x00\x00\x03KCM")
@@ -279,7 +279,7 @@ def test_follower_combined():
     assert t.mock_calls == [
         mock.call.write(exp_handshake),
         mock.call.write(exp_kcm)]
-    assert c._manager == None
+    assert c._manager is None
     clear_mock_calls(n, connector, t, m)
 
     # the leader will select a connection, send the KCM, and then

--- a/src/wormhole/test/dilate/test_connection.py
+++ b/src/wormhole/test/dilate/test_connection.py
@@ -1,8 +1,9 @@
 from unittest import mock
 from zope.interface import alsoProvides
-from twisted.trial import unittest
 from twisted.internet.task import Clock
 from twisted.internet.interfaces import ITransport
+import pytest_twisted
+
 from ...eventual import EventualQueue
 from ..._interfaces import IDilationConnector
 from ..._dilation.roles import LEADER, FOLLOWER
@@ -27,282 +28,286 @@ def make_con(role, use_relay=False):
     return c, n, connector, t, eq
 
 
-class Connection(unittest.TestCase):
-    def test_hashable(self):
-        c, n, connector, t, eq = make_con(LEADER)
-        hash(c)
+def test_hashable():
+    c, n, connector, t, eq = make_con(LEADER)
+    hash(c)
 
-    def test_bad_prologue(self):
-        c, n, connector, t, eq = make_con(LEADER)
-        c.makeConnection(t)
-        d = c.when_disconnected()
-        self.assertEqual(n.mock_calls, [mock.call.start_handshake()])
-        self.assertEqual(connector.mock_calls, [])
-        self.assertEqual(t.mock_calls, [mock.call.write(b"outbound_prologue\n")])
-        clear_mock_calls(n, connector, t)
+@pytest_twisted.ensureDeferred
+async def test_bad_prologue():
+    c, n, connector, t, eq = make_con(LEADER)
+    c.makeConnection(t)
+    d = c.when_disconnected()
+    assert n.mock_calls == [mock.call.start_handshake()]
+    assert connector.mock_calls == []
+    assert t.mock_calls == [mock.call.write(b"outbound_prologue\n")]
+    clear_mock_calls(n, connector, t)
 
-        c.dataReceived(b"prologue\n")
-        self.assertEqual(n.mock_calls, [])
-        self.assertEqual(connector.mock_calls, [])
-        self.assertEqual(t.mock_calls, [mock.call.loseConnection()])
+    c.dataReceived(b"prologue\n")
+    assert n.mock_calls == []
+    assert connector.mock_calls == []
+    assert t.mock_calls == [mock.call.loseConnection()]
 
-        eq.flush_sync()
-        self.assertNoResult(d)
-        c.connectionLost(b"why")
-        eq.flush_sync()
-        self.assertIdentical(self.successResultOf(d), c)
+    eq.flush_sync()
+    assert not d.called
+    c.connectionLost(b"why")
+    eq.flush_sync()
+    conn = await d
+    assert conn is c
 
-    def _test_no_relay(self, role):
-        c, n, connector, t, eq = make_con(role)
-        t_kcm = KCM()
-        t_open = Open(seqnum=1, scid=0x11223344)
-        t_ack = Ack(resp_seqnum=2)
-        n.decrypt = mock.Mock(side_effect=[
-            encode_record(t_kcm),
-            encode_record(t_open),
-        ])
-        exp_kcm = b"\x00\x00\x00\x03kcm"
-        n.encrypt = mock.Mock(side_effect=[b"kcm", b"ack1"])
-        m = mock.Mock()  # Manager
+def _test_no_relay(role):
+    c, n, connector, t, eq = make_con(role)
+    t_kcm = KCM()
+    t_open = Open(seqnum=1, scid=0x11223344)
+    t_ack = Ack(resp_seqnum=2)
+    n.decrypt = mock.Mock(side_effect=[
+        encode_record(t_kcm),
+        encode_record(t_open),
+    ])
+    exp_kcm = b"\x00\x00\x00\x03kcm"
+    n.encrypt = mock.Mock(side_effect=[b"kcm", b"ack1"])
+    m = mock.Mock()  # Manager
 
-        c.makeConnection(t)
-        self.assertEqual(n.mock_calls, [mock.call.start_handshake()])
-        self.assertEqual(connector.mock_calls, [])
-        self.assertEqual(t.mock_calls, [mock.call.write(b"outbound_prologue\n")])
-        clear_mock_calls(n, connector, t, m)
+    c.makeConnection(t)
+    assert n.mock_calls == [mock.call.start_handshake()]
+    assert connector.mock_calls == []
+    assert t.mock_calls == [mock.call.write(b"outbound_prologue\n")]
+    clear_mock_calls(n, connector, t, m)
 
-        c.dataReceived(b"inbound_prologue\n")
+    c.dataReceived(b"inbound_prologue\n")
 
-        exp_handshake = b"\x00\x00\x00\x09handshake"
-        if role is LEADER:
-            # the LEADER sends the Noise handshake message immediately upon
-            # receipt of the prologue
-            self.assertEqual(n.mock_calls, [mock.call.write_message()])
-            self.assertEqual(t.mock_calls, [mock.call.write(exp_handshake)])
-        else:
-            # however the FOLLOWER waits until receiving the leader's
-            # handshake before sending their own
-            self.assertEqual(n.mock_calls, [])
-            self.assertEqual(t.mock_calls, [])
-        self.assertEqual(connector.mock_calls, [])
-
-        clear_mock_calls(n, connector, t, m)
-
-        c.dataReceived(b"\x00\x00\x00\x0Ahandshake2")
-        if role is LEADER:
-            # we're the leader, so we don't send the KCM right away
-            self.assertEqual(n.mock_calls, [
-                mock.call.read_message(b"handshake2")])
-            self.assertEqual(connector.mock_calls, [])
-            self.assertEqual(t.mock_calls, [])
-            self.assertEqual(c._manager, None)
-        else:
-            # we're the follower, so we send our Noise handshake, then
-            # encrypt and send the KCM immediately
-            self.assertEqual(n.mock_calls, [
-                mock.call.read_message(b"handshake2"),
-                mock.call.write_message(),
-                mock.call.encrypt(encode_record(t_kcm)),
-            ])
-            self.assertEqual(connector.mock_calls, [])
-            self.assertEqual(t.mock_calls, [
-                mock.call.write(exp_handshake),
-                mock.call.write(exp_kcm)])
-            self.assertEqual(c._manager, None)
-        clear_mock_calls(n, connector, t, m)
-
-        c.dataReceived(b"\x00\x00\x00\x03KCM")
-        # leader: inbound KCM means we add the candidate
-        # follower: inbound KCM means we've been selected.
-        # in both cases we notify Connector.add_candidate(), and the Connector
-        # decides if/when to call .select()
-
-        self.assertEqual(n.mock_calls, [mock.call.decrypt(b"KCM")])
-        self.assertEqual(connector.mock_calls, [mock.call.add_candidate(c)])
-        self.assertEqual(t.mock_calls, [])
-        clear_mock_calls(n, connector, t, m)
-
-        # now pretend this connection wins (either the Leader decides to use
-        # this one among all the candidates, or we're the Follower and the
-        # Connector is reacting to add_candidate() by recognizing we're the
-        # only candidate there is)
-        c.select(m)
-        self.assertIdentical(c._manager, m)
-        if role is LEADER:
-            # TODO: currently Connector.select_and_stop_remaining() is
-            # responsible for sending the KCM just before calling c.select()
-            # iff we're the LEADER, therefore Connection.select won't send
-            # anything. This should be moved to c.select().
-            self.assertEqual(n.mock_calls, [])
-            self.assertEqual(connector.mock_calls, [])
-            self.assertEqual(t.mock_calls, [])
-            # there's a call to .have_peer(...) but we don't really care?
-            self.assertEqual(len(m.mock_calls), 1)##[])
-
-            c.send_record(KCM())
-            self.assertEqual(n.mock_calls, [
-                mock.call.encrypt(encode_record(t_kcm)),
-            ])
-            self.assertEqual(connector.mock_calls, [])
-            self.assertEqual(t.mock_calls, [mock.call.write(exp_kcm)])
-            self.assertEqual(len(m.mock_calls), 1)  ##[]) .have_peer() call
-        else:
-            # follower: we already sent the KCM, do nothing
-            self.assertEqual(n.mock_calls, [])
-            self.assertEqual(connector.mock_calls, [])
-            self.assertEqual(t.mock_calls, [])
-            self.assertEqual(len(m.mock_calls), 1)  # have_peer()
-        clear_mock_calls(n, connector, t, m)
-
-        c.dataReceived(b"\x00\x00\x00\x04msg1")
-        self.assertEqual(n.mock_calls, [mock.call.decrypt(b"msg1")])
-        self.assertEqual(connector.mock_calls, [])
-        self.assertEqual(t.mock_calls, [])
-        self.assertEqual(m.mock_calls, [mock.call.got_record(t_open)])
-        clear_mock_calls(n, connector, t, m)
-
-        c.send_record(t_ack)
-        exp_ack = b"\x06\x00\x00\x00\x02"
-        self.assertEqual(n.mock_calls, [mock.call.encrypt(exp_ack)])
-        self.assertEqual(connector.mock_calls, [])
-        self.assertEqual(t.mock_calls, [mock.call.write(b"\x00\x00\x00\x04ack1")])
-        self.assertEqual(m.mock_calls, [])
-        clear_mock_calls(n, connector, t, m)
-
-        c.disconnect()
-        self.assertEqual(n.mock_calls, [])
-        self.assertEqual(connector.mock_calls, [])
-        self.assertEqual(t.mock_calls, [mock.call.loseConnection()])
-        self.assertEqual(m.mock_calls, [])
-        clear_mock_calls(n, connector, t, m)
-
-    def test_no_relay_leader(self):
-        return self._test_no_relay(LEADER)
-
-    def test_no_relay_follower(self):
-        return self._test_no_relay(FOLLOWER)
-
-    def test_relay(self):
-        c, n, connector, t, eq = make_con(LEADER, use_relay=True)
-
-        c.makeConnection(t)
-        self.assertEqual(n.mock_calls, [mock.call.start_handshake()])
-        self.assertEqual(connector.mock_calls, [])
-        self.assertEqual(t.mock_calls, [mock.call.write(b"relay_handshake\n")])
-        clear_mock_calls(n, connector, t)
-
-        c.dataReceived(b"ok\n")
-        self.assertEqual(n.mock_calls, [])
-        self.assertEqual(connector.mock_calls, [])
-        self.assertEqual(t.mock_calls, [mock.call.write(b"outbound_prologue\n")])
-        clear_mock_calls(n, connector, t)
-
-        c.dataReceived(b"inbound_prologue\n")
-        self.assertEqual(n.mock_calls, [mock.call.write_message()])
-        self.assertEqual(connector.mock_calls, [])
-        exp_handshake = b"\x00\x00\x00\x09handshake"
-        self.assertEqual(t.mock_calls, [mock.call.write(exp_handshake)])
-        clear_mock_calls(n, connector, t)
-
-    def test_relay_jilted(self):
-        c, n, connector, t, eq = make_con(LEADER, use_relay=True)
-        d = c.when_disconnected()
-
-        c.makeConnection(t)
-        self.assertEqual(n.mock_calls, [mock.call.start_handshake()])
-        self.assertEqual(connector.mock_calls, [])
-        self.assertEqual(t.mock_calls, [mock.call.write(b"relay_handshake\n")])
-        clear_mock_calls(n, connector, t)
-
-        c.connectionLost(b"why")
-        eq.flush_sync()
-        self.assertIdentical(self.successResultOf(d), c)
-
-    def test_relay_bad_response(self):
-        c, n, connector, t, eq = make_con(LEADER, use_relay=True)
-
-        c.makeConnection(t)
-        self.assertEqual(n.mock_calls, [mock.call.start_handshake()])
-        self.assertEqual(connector.mock_calls, [])
-        self.assertEqual(t.mock_calls, [mock.call.write(b"relay_handshake\n")])
-        clear_mock_calls(n, connector, t)
-
-        c.dataReceived(b"not ok\n")
-        self.assertEqual(n.mock_calls, [])
-        self.assertEqual(connector.mock_calls, [])
-        self.assertEqual(t.mock_calls, [mock.call.loseConnection()])
-        clear_mock_calls(n, connector, t)
-
-    def test_follower_combined(self):
-        c, n, connector, t, eq = make_con(FOLLOWER)
-        t_kcm = KCM()
-        t_open = Open(seqnum=1, scid=0x11223344)
-        n.decrypt = mock.Mock(side_effect=[
-            encode_record(t_kcm),
-            encode_record(t_open),
-        ])
-        exp_kcm = b"\x00\x00\x00\x03kcm"
-        n.encrypt = mock.Mock(side_effect=[b"kcm", b"ack1"])
-        m = mock.Mock()  # Manager
-
-        c.makeConnection(t)
-        self.assertEqual(n.mock_calls, [mock.call.start_handshake()])
-        self.assertEqual(connector.mock_calls, [])
-        self.assertEqual(t.mock_calls, [mock.call.write(b"outbound_prologue\n")])
-        clear_mock_calls(n, connector, t, m)
-
-        c.dataReceived(b"inbound_prologue\n")
-
-        exp_handshake = b"\x00\x00\x00\x09handshake"
+    exp_handshake = b"\x00\x00\x00\x09handshake"
+    if role is LEADER:
+        # the LEADER sends the Noise handshake message immediately upon
+        # receipt of the prologue
+        assert n.mock_calls == [mock.call.write_message()]
+        assert t.mock_calls == [mock.call.write(exp_handshake)]
+    else:
         # however the FOLLOWER waits until receiving the leader's
         # handshake before sending their own
-        self.assertEqual(n.mock_calls, [])
-        self.assertEqual(t.mock_calls, [])
-        self.assertEqual(connector.mock_calls, [])
+        assert n.mock_calls == []
+        assert t.mock_calls == []
+    assert connector.mock_calls == []
 
-        clear_mock_calls(n, connector, t, m)
+    clear_mock_calls(n, connector, t, m)
 
-        c.dataReceived(b"\x00\x00\x00\x0Ahandshake2")
+    c.dataReceived(b"\x00\x00\x00\x0Ahandshake2")
+    if role is LEADER:
+        # we're the leader, so we don't send the KCM right away
+        assert n.mock_calls == [
+            mock.call.read_message(b"handshake2")]
+        assert connector.mock_calls == []
+        assert t.mock_calls == []
+        assert c._manager == None
+    else:
         # we're the follower, so we send our Noise handshake, then
         # encrypt and send the KCM immediately
-        self.assertEqual(n.mock_calls, [
+        assert n.mock_calls == [
             mock.call.read_message(b"handshake2"),
             mock.call.write_message(),
             mock.call.encrypt(encode_record(t_kcm)),
-        ])
-        self.assertEqual(connector.mock_calls, [])
-        self.assertEqual(t.mock_calls, [
+        ]
+        assert connector.mock_calls == []
+        assert t.mock_calls == [
             mock.call.write(exp_handshake),
-            mock.call.write(exp_kcm)])
-        self.assertEqual(c._manager, None)
-        clear_mock_calls(n, connector, t, m)
+            mock.call.write(exp_kcm)]
+        assert c._manager == None
+    clear_mock_calls(n, connector, t, m)
 
-        # the leader will select a connection, send the KCM, and then
-        # immediately send some more data
+    c.dataReceived(b"\x00\x00\x00\x03KCM")
+    # leader: inbound KCM means we add the candidate
+    # follower: inbound KCM means we've been selected.
+    # in both cases we notify Connector.add_candidate(), and the Connector
+    # decides if/when to call .select()
 
-        kcm_and_msg1 = (b"\x00\x00\x00\x03KCM" +
-                        b"\x00\x00\x00\x04msg1")
-        c.dataReceived(kcm_and_msg1)
+    assert n.mock_calls == [mock.call.decrypt(b"KCM")]
+    assert connector.mock_calls == [mock.call.add_candidate(c)]
+    assert t.mock_calls == []
+    clear_mock_calls(n, connector, t, m)
 
-        # follower: inbound KCM means we've been selected.
-        # in both cases we notify Connector.add_candidate(), and the Connector
-        # decides if/when to call .select()
+    # now pretend this connection wins (either the Leader decides to use
+    # this one among all the candidates, or we're the Follower and the
+    # Connector is reacting to add_candidate() by recognizing we're the
+    # only candidate there is)
+    c.select(m)
+    assert c._manager is m
+    if role is LEADER:
+        # TODO: currently Connector.select_and_stop_remaining() is
+        # responsible for sending the KCM just before calling c.select()
+        # iff we're the LEADER, therefore Connection.select won't send
+        # anything. This should be moved to c.select().
+        assert n.mock_calls == []
+        assert connector.mock_calls == []
+        assert t.mock_calls == []
+        # there's a call to .have_peer(...) but we don't really care?
+        assert len(m.mock_calls) == 1##[])
 
-        self.assertEqual(n.mock_calls, [mock.call.decrypt(b"KCM"),
-                                        mock.call.decrypt(b"msg1")])
-        self.assertEqual(connector.mock_calls, [mock.call.add_candidate(c)])
-        self.assertEqual(t.mock_calls, [])
-        clear_mock_calls(n, connector, t, m)
-
-        # now pretend this connection wins (either the Leader decides to use
-        # this one among all the candidates, or we're the Follower and the
-        # Connector is reacting to add_candidate() by recognizing we're the
-        # only candidate there is)
-        c.select(m)
-        self.assertIdentical(c._manager, m)
+        c.send_record(KCM())
+        assert n.mock_calls == [
+            mock.call.encrypt(encode_record(t_kcm)),
+        ]
+        assert connector.mock_calls == []
+        assert t.mock_calls == [mock.call.write(exp_kcm)]
+        assert len(m.mock_calls) == 1  ##[]) .have_peer() call
+    else:
         # follower: we already sent the KCM, do nothing
-        self.assertEqual(n.mock_calls, [])
-        self.assertEqual(connector.mock_calls, [])
-        self.assertEqual(t.mock_calls, [])
-        self.assertEqual(m.mock_calls[1:], [mock.call.got_record(t_open)])
-        clear_mock_calls(n, connector, t, m)
+        assert n.mock_calls == []
+        assert connector.mock_calls == []
+        assert t.mock_calls == []
+        assert len(m.mock_calls) == 1  # have_peer()
+    clear_mock_calls(n, connector, t, m)
+
+    c.dataReceived(b"\x00\x00\x00\x04msg1")
+    assert n.mock_calls == [mock.call.decrypt(b"msg1")]
+    assert connector.mock_calls == []
+    assert t.mock_calls == []
+    assert m.mock_calls == [mock.call.got_record(t_open)]
+    clear_mock_calls(n, connector, t, m)
+
+    c.send_record(t_ack)
+    exp_ack = b"\x06\x00\x00\x00\x02"
+    assert n.mock_calls == [mock.call.encrypt(exp_ack)]
+    assert connector.mock_calls == []
+    assert t.mock_calls == [mock.call.write(b"\x00\x00\x00\x04ack1")]
+    assert m.mock_calls == []
+    clear_mock_calls(n, connector, t, m)
+
+    c.disconnect()
+    assert n.mock_calls == []
+    assert connector.mock_calls == []
+    assert t.mock_calls == [mock.call.loseConnection()]
+    assert m.mock_calls == []
+    clear_mock_calls(n, connector, t, m)
+
+def test_no_relay_leader():
+    return _test_no_relay(LEADER)
+
+def test_no_relay_follower():
+    return _test_no_relay(FOLLOWER)
+
+def test_relay():
+    c, n, connector, t, eq = make_con(LEADER, use_relay=True)
+
+    c.makeConnection(t)
+    assert n.mock_calls == [mock.call.start_handshake()]
+    assert connector.mock_calls == []
+    assert t.mock_calls == [mock.call.write(b"relay_handshake\n")]
+    clear_mock_calls(n, connector, t)
+
+    c.dataReceived(b"ok\n")
+    assert n.mock_calls == []
+    assert connector.mock_calls == []
+    assert t.mock_calls == [mock.call.write(b"outbound_prologue\n")]
+    clear_mock_calls(n, connector, t)
+
+    c.dataReceived(b"inbound_prologue\n")
+    assert n.mock_calls == [mock.call.write_message()]
+    assert connector.mock_calls == []
+    exp_handshake = b"\x00\x00\x00\x09handshake"
+    assert t.mock_calls == [mock.call.write(exp_handshake)]
+    clear_mock_calls(n, connector, t)
+
+
+@pytest_twisted.ensureDeferred
+async def test_relay_jilted():
+    c, n, connector, t, eq = make_con(LEADER, use_relay=True)
+    d = c.when_disconnected()
+
+    c.makeConnection(t)
+    assert n.mock_calls == [mock.call.start_handshake()]
+    assert connector.mock_calls == []
+    assert t.mock_calls == [mock.call.write(b"relay_handshake\n")]
+    clear_mock_calls(n, connector, t)
+
+    c.connectionLost(b"why")
+    eq.flush_sync()
+    conn = await d
+    assert conn is c
+
+def test_relay_bad_response():
+    c, n, connector, t, eq = make_con(LEADER, use_relay=True)
+
+    c.makeConnection(t)
+    assert n.mock_calls == [mock.call.start_handshake()]
+    assert connector.mock_calls == []
+    assert t.mock_calls == [mock.call.write(b"relay_handshake\n")]
+    clear_mock_calls(n, connector, t)
+
+    c.dataReceived(b"not ok\n")
+    assert n.mock_calls == []
+    assert connector.mock_calls == []
+    assert t.mock_calls == [mock.call.loseConnection()]
+    clear_mock_calls(n, connector, t)
+
+def test_follower_combined():
+    c, n, connector, t, eq = make_con(FOLLOWER)
+    t_kcm = KCM()
+    t_open = Open(seqnum=1, scid=0x11223344)
+    n.decrypt = mock.Mock(side_effect=[
+        encode_record(t_kcm),
+        encode_record(t_open),
+    ])
+    exp_kcm = b"\x00\x00\x00\x03kcm"
+    n.encrypt = mock.Mock(side_effect=[b"kcm", b"ack1"])
+    m = mock.Mock()  # Manager
+
+    c.makeConnection(t)
+    assert n.mock_calls == [mock.call.start_handshake()]
+    assert connector.mock_calls == []
+    assert t.mock_calls == [mock.call.write(b"outbound_prologue\n")]
+    clear_mock_calls(n, connector, t, m)
+
+    c.dataReceived(b"inbound_prologue\n")
+
+    exp_handshake = b"\x00\x00\x00\x09handshake"
+    # however the FOLLOWER waits until receiving the leader's
+    # handshake before sending their own
+    assert n.mock_calls == []
+    assert t.mock_calls == []
+    assert connector.mock_calls == []
+
+    clear_mock_calls(n, connector, t, m)
+
+    c.dataReceived(b"\x00\x00\x00\x0Ahandshake2")
+    # we're the follower, so we send our Noise handshake, then
+    # encrypt and send the KCM immediately
+    assert n.mock_calls == [
+        mock.call.read_message(b"handshake2"),
+        mock.call.write_message(),
+        mock.call.encrypt(encode_record(t_kcm)),
+    ]
+    assert connector.mock_calls == []
+    assert t.mock_calls == [
+        mock.call.write(exp_handshake),
+        mock.call.write(exp_kcm)]
+    assert c._manager == None
+    clear_mock_calls(n, connector, t, m)
+
+    # the leader will select a connection, send the KCM, and then
+    # immediately send some more data
+
+    kcm_and_msg1 = (b"\x00\x00\x00\x03KCM" +
+                    b"\x00\x00\x00\x04msg1")
+    c.dataReceived(kcm_and_msg1)
+
+    # follower: inbound KCM means we've been selected.
+    # in both cases we notify Connector.add_candidate(), and the Connector
+    # decides if/when to call .select()
+
+    assert n.mock_calls == [mock.call.decrypt(b"KCM"),
+                                    mock.call.decrypt(b"msg1")]
+    assert connector.mock_calls == [mock.call.add_candidate(c)]
+    assert t.mock_calls == []
+    clear_mock_calls(n, connector, t, m)
+
+    # now pretend this connection wins (either the Leader decides to use
+    # this one among all the candidates, or we're the Follower and the
+    # Connector is reacting to add_candidate() by recognizing we're the
+    # only candidate there is)
+    c.select(m)
+    assert c._manager is m
+    # follower: we already sent the KCM, do nothing
+    assert n.mock_calls == []
+    assert connector.mock_calls == []
+    assert t.mock_calls == []
+    assert m.mock_calls[1:] == [mock.call.got_record(t_open)]
+    clear_mock_calls(n, connector, t, m)

--- a/src/wormhole/test/dilate/test_connector.py
+++ b/src/wormhole/test/dilate/test_connector.py
@@ -1,9 +1,10 @@
 from unittest import mock
 from zope.interface import alsoProvides
-from twisted.trial import unittest
 from twisted.internet.task import Clock
 from twisted.internet.defer import Deferred
 from twisted.internet.address import IPv4Address, IPv6Address, HostnameAddress
+import pytest
+
 from ...eventual import EventualQueue
 from ..._interfaces import IDilationManager, IDilationConnector
 from ..._hints import DirectTCPV1Hint, RelayV1Hint, TorTCPV1Hint
@@ -21,59 +22,55 @@ from ..._dilation.connector import (Connector,
 from .common import clear_mock_calls
 
 
-class Handshake(unittest.TestCase):
-    def test_build(self):
-        key = b"k"*32
-        side = "12345678abcdabcd"
-        self.assertEqual(
-            build_sided_relay_handshake(key, side),
-            b"please relay 3f4147851dbd2589d25b654ee9fb35ed0d3e5f19c5c5403e8e6a195c70f0577a"
-            b" for side 12345678abcdabcd\n"
-        )
+def test_build():
+    key = b"k"*32
+    side = "12345678abcdabcd"
+    assert build_sided_relay_handshake(key, side) == \
+        b"please relay 3f4147851dbd2589d25b654ee9fb35ed0d3e5f19c5c5403e8e6a195c70f0577a" \
+        b" for side 12345678abcdabcd\n"
 
 
-class Outbound(unittest.TestCase):
-    def test_no_relay(self):
-        c = mock.Mock()
-        alsoProvides(c, IDilationConnector)
-        p0 = mock.Mock()
-        c.build_protocol = mock.Mock(return_value=p0)
-        relay_handshake = None
-        f = OutboundConnectionFactory(c, relay_handshake, "desc")
-        addr = object()
-        p = f.buildProtocol(addr)
-        self.assertIdentical(p, p0)
-        self.assertEqual(c.mock_calls, [mock.call.build_protocol(addr, "desc")])
-        self.assertEqual(p.mock_calls, [])
-        self.assertIdentical(p.factory, f)
-
-    def test_with_relay(self):
-        c = mock.Mock()
-        alsoProvides(c, IDilationConnector)
-        p0 = mock.Mock()
-        c.build_protocol = mock.Mock(return_value=p0)
-        relay_handshake = b"relay handshake"
-        f = OutboundConnectionFactory(c, relay_handshake, "desc")
-        addr = object()
-        p = f.buildProtocol(addr)
-        self.assertIdentical(p, p0)
-        self.assertEqual(c.mock_calls, [mock.call.build_protocol(addr, "desc")])
-        self.assertEqual(p.mock_calls, [mock.call.use_relay(relay_handshake)])
-        self.assertIdentical(p.factory, f)
+def test_no_relay():
+    c = mock.Mock()
+    alsoProvides(c, IDilationConnector)
+    p0 = mock.Mock()
+    c.build_protocol = mock.Mock(return_value=p0)
+    relay_handshake = None
+    f = OutboundConnectionFactory(c, relay_handshake, "desc")
+    addr = object()
+    p = f.buildProtocol(addr)
+    assert p is p0
+    assert c.mock_calls == [mock.call.build_protocol(addr, "desc")]
+    assert p.mock_calls == []
+    assert p.factory is f
 
 
-class Inbound(unittest.TestCase):
-    def test_build(self):
-        c = mock.Mock()
-        alsoProvides(c, IDilationConnector)
-        p0 = mock.Mock()
-        c.build_protocol = mock.Mock(return_value=p0)
-        f = InboundConnectionFactory(c)
-        addr = IPv4Address("TCP", "1.2.3.4", 55)
-        p = f.buildProtocol(addr)
-        self.assertIdentical(p, p0)
-        self.assertEqual(c.mock_calls, [mock.call.build_protocol(addr, "<-tcp:1.2.3.4:55")])
-        self.assertIdentical(p.factory, f)
+def test_with_relay():
+    c = mock.Mock()
+    alsoProvides(c, IDilationConnector)
+    p0 = mock.Mock()
+    c.build_protocol = mock.Mock(return_value=p0)
+    relay_handshake = b"relay handshake"
+    f = OutboundConnectionFactory(c, relay_handshake, "desc")
+    addr = object()
+    p = f.buildProtocol(addr)
+    assert p is p0
+    assert c.mock_calls == [mock.call.build_protocol(addr, "desc")]
+    assert p.mock_calls == [mock.call.use_relay(relay_handshake)]
+    assert p.factory is f
+
+
+def test_build_inbound():
+    c = mock.Mock()
+    alsoProvides(c, IDilationConnector)
+    p0 = mock.Mock()
+    c.build_protocol = mock.Mock(return_value=p0)
+    f = InboundConnectionFactory(c)
+    addr = IPv4Address("TCP", "1.2.3.4", 55)
+    p = f.buildProtocol(addr)
+    assert p is p0
+    assert c.mock_calls == [mock.call.build_protocol(addr, "<-tcp:1.2.3.4:55")]
+    assert p.factory is f
 
 
 def make_connector(listen=True, tor=False, relay=None, role=roles.LEADER):
@@ -98,364 +95,363 @@ def make_connector(listen=True, tor=False, relay=None, role=roles.LEADER):
     return c, h
 
 
-class TestConnector(unittest.TestCase):
-    def test_build(self):
-        c, h = make_connector()
-        c, h = make_connector(relay="tcp:host:1234")
+def test_build_connector():
+    c, h = make_connector()
+    c, h = make_connector(relay="tcp:host:1234")
 
-    def test_connection_abilities(self):
-        self.assertEqual(Connector.get_connection_abilities(),
-                         [{"type": "direct-tcp-v1"},
-                          {"type": "relay-v1"},
-                          ])
 
-    def test_build_noise(self):
-        if not NoiseConnection:
-            raise unittest.SkipTest("noiseprotocol unavailable")
-        build_noise()
+def test_connection_abilities():
+    assert Connector.get_connection_abilities() == \
+                     [{"type": "direct-tcp-v1"},
+                      {"type": "relay-v1"},
+                      ]
 
-    def test_build_protocol_leader(self):
-        c, h = make_connector(role=roles.LEADER)
-        n0 = mock.Mock()
-        p0 = mock.Mock()
-        addr = object()
-        with mock.patch("wormhole._dilation.connector.build_noise",
-                        return_value=n0) as bn:
-            with mock.patch("wormhole._dilation.connector.DilatedConnectionProtocol",
-                            return_value=p0) as dcp:
-                p = c.build_protocol(addr, "desc")
-        self.assertEqual(bn.mock_calls, [mock.call()])
-        self.assertEqual(n0.mock_calls, [mock.call.set_psks(h.dilation_key),
-                                         mock.call.set_as_initiator()])
-        self.assertIdentical(p, p0)
-        self.assertEqual(dcp.mock_calls,
-                         [mock.call(h.eq, h.role, "desc", c, n0,
-                                    PROLOGUE_LEADER, PROLOGUE_FOLLOWER)])
 
-    def test_build_protocol_follower(self):
-        c, h = make_connector(role=roles.FOLLOWER)
-        n0 = mock.Mock()
-        p0 = mock.Mock()
-        addr = object()
-        with mock.patch("wormhole._dilation.connector.build_noise",
-                        return_value=n0) as bn:
-            with mock.patch("wormhole._dilation.connector.DilatedConnectionProtocol",
-                            return_value=p0) as dcp:
-                p = c.build_protocol(addr, "desc")
-        self.assertEqual(bn.mock_calls, [mock.call()])
-        self.assertEqual(n0.mock_calls, [mock.call.set_psks(h.dilation_key),
-                                         mock.call.set_as_responder()])
-        self.assertIdentical(p, p0)
-        self.assertEqual(dcp.mock_calls,
-                         [mock.call(h.eq, h.role, "desc", c, n0,
-                                    PROLOGUE_FOLLOWER, PROLOGUE_LEADER)])
+@pytest.mark.skipif(not NoiseConnection, reason="noiseprotocol required")
+def test_build_noise():
+    build_noise()
 
-    def test_start_stop(self):
-        c, h = make_connector(listen=False, relay=None, role=roles.LEADER)
+
+def test_build_protocol_leader():
+    c, h = make_connector(role=roles.LEADER)
+    n0 = mock.Mock()
+    p0 = mock.Mock()
+    addr = object()
+    with mock.patch("wormhole._dilation.connector.build_noise",
+                    return_value=n0) as bn:
+        with mock.patch("wormhole._dilation.connector.DilatedConnectionProtocol",
+                        return_value=p0) as dcp:
+            p = c.build_protocol(addr, "desc")
+    assert bn.mock_calls == [mock.call()]
+    assert n0.mock_calls == [mock.call.set_psks(h.dilation_key),
+                                     mock.call.set_as_initiator()]
+    assert p is p0
+    assert dcp.mock_calls == \
+                     [mock.call(h.eq, h.role, "desc", c, n0,
+                                PROLOGUE_LEADER, PROLOGUE_FOLLOWER)]
+
+def test_build_protocol_follower():
+    c, h = make_connector(role=roles.FOLLOWER)
+    n0 = mock.Mock()
+    p0 = mock.Mock()
+    addr = object()
+    with mock.patch("wormhole._dilation.connector.build_noise",
+                    return_value=n0) as bn:
+        with mock.patch("wormhole._dilation.connector.DilatedConnectionProtocol",
+                        return_value=p0) as dcp:
+            p = c.build_protocol(addr, "desc")
+    assert bn.mock_calls == [mock.call()]
+    assert n0.mock_calls == [mock.call.set_psks(h.dilation_key),
+                                     mock.call.set_as_responder()]
+    assert p is p0
+    assert dcp.mock_calls == \
+                     [mock.call(h.eq, h.role, "desc", c, n0,
+                                PROLOGUE_FOLLOWER, PROLOGUE_LEADER)]
+
+def test_start_stop():
+    c, h = make_connector(listen=False, relay=None, role=roles.LEADER)
+    c.start()
+    # no relays, so it publishes no hints
+    assert h.manager.mock_calls == []
+    # and no listener, so nothing happens until we provide a hint
+    c.stop()
+    # we stop while we're connecting, so no connections must be stopped
+
+def test_empty():
+    c, h = make_connector(listen=False, relay=None, role=roles.LEADER)
+    c._schedule_connection = mock.Mock()
+    c.start()
+    # no relays, so it publishes no hints
+    assert h.manager.mock_calls == []
+    # and no listener, so nothing happens until we provide a hint
+    assert c._schedule_connection.mock_calls == []
+    c.stop()
+
+def test_basic():
+    c, h = make_connector(listen=False, relay=None, role=roles.LEADER)
+    c._schedule_connection = mock.Mock()
+    c.start()
+    # no relays, so it publishes no hints
+    assert h.manager.mock_calls == []
+    # and no listener, so nothing happens until we provide a hint
+    assert c._schedule_connection.mock_calls == []
+
+    hint = DirectTCPV1Hint("foo", 55, 0.0)
+    c.got_hints([hint])
+
+    # received hints don't get published
+    assert h.manager.mock_calls == []
+    # they just schedule a connection
+    assert c._schedule_connection.mock_calls == \
+                     [mock.call(0.0, DirectTCPV1Hint("foo", 55, 0.0),
+                                is_relay=False)]
+
+def test_listen_addresses():
+    c, h = make_connector(listen=True, role=roles.LEADER)
+    with mock.patch("wormhole.ipaddrs.find_addresses",
+                    return_value=["127.0.0.1", "1.2.3.4", "5.6.7.8"]):
+        assert c._get_listener_addresses() == \
+                         ["1.2.3.4", "5.6.7.8"]
+    with mock.patch("wormhole.ipaddrs.find_addresses",
+                    return_value=["127.0.0.1"]):
+        # some test hosts, including the appveyor VMs, *only* have
+        # 127.0.0.1, and the tests will hang badly if we remove it.
+        assert c._get_listener_addresses() == ["127.0.0.1"]
+
+def test_listen():
+    c, h = make_connector(listen=True, role=roles.LEADER)
+    c._start_listener = mock.Mock()
+    with mock.patch("wormhole.ipaddrs.find_addresses",
+                    return_value=["127.0.0.1", "1.2.3.4", "5.6.7.8"]):
         c.start()
-        # no relays, so it publishes no hints
-        self.assertEqual(h.manager.mock_calls, [])
-        # and no listener, so nothing happens until we provide a hint
-        c.stop()
-        # we stop while we're connecting, so no connections must be stopped
+    assert c._start_listener.mock_calls == \
+                     [mock.call(["1.2.3.4", "5.6.7.8"])]
 
-    def test_empty(self):
-        c, h = make_connector(listen=False, relay=None, role=roles.LEADER)
-        c._schedule_connection = mock.Mock()
+def test_start_listen():
+    c, h = make_connector(listen=True, role=roles.LEADER)
+    ep = mock.Mock()
+    d = Deferred()
+    ep.listen = mock.Mock(return_value=d)
+    with mock.patch("wormhole._dilation.connector.serverFromString",
+                    return_value=ep) as sfs:
+        c._start_listener(["1.2.3.4", "5.6.7.8"])
+    assert sfs.mock_calls == [mock.call(h.reactor, "tcp:0")]
+    lp = mock.Mock()
+    host = mock.Mock()
+    host.port = 66
+    lp.getHost = mock.Mock(return_value=host)
+    d.callback(lp)
+    assert h.manager.mock_calls == \
+                     [mock.call.send_hints([{"type": "direct-tcp-v1",
+                                             "hostname": "1.2.3.4",
+                                             "port": 66,
+                                             "priority": 0.0
+                                             },
+                                            {"type": "direct-tcp-v1",
+                                             "hostname": "5.6.7.8",
+                                             "port": 66,
+                                             "priority": 0.0
+                                             },
+                                            ])]
+
+def test_schedule_connection_no_relay():
+    c, h = make_connector(listen=True, role=roles.LEADER)
+    hint = DirectTCPV1Hint("foo", 55, 0.0)
+    ep = mock.Mock()
+    with mock.patch("wormhole._dilation.connector.endpoint_from_hint_obj",
+                    side_effect=[ep]) as efho:
+        c._schedule_connection(0.0, hint, False)
+    assert efho.mock_calls == [mock.call(hint, h.tor, h.reactor)]
+    assert ep.mock_calls == []
+    d = Deferred()
+    ep.connect = mock.Mock(side_effect=[d])
+    # direct hints are scheduled for T+0.0
+    f = mock.Mock()
+    with mock.patch("wormhole._dilation.connector.OutboundConnectionFactory",
+                    return_value=f) as ocf:
+        h.clock.advance(1.0)
+    assert ocf.mock_calls == [mock.call(c, None, "->tcp:foo:55")]
+    assert ep.connect.mock_calls == [mock.call(f)]
+    p = mock.Mock()
+    d.callback(p)
+    assert p.mock_calls == \
+                     [mock.call.when_disconnected(),
+                      mock.call.when_disconnected().addCallback(c._pending_connections.discard)]
+
+def test_schedule_connection_relay():
+    c, h = make_connector(listen=True, role=roles.LEADER)
+    hint = DirectTCPV1Hint("foo", 55, 0.0)
+    ep = mock.Mock()
+    with mock.patch("wormhole._dilation.connector.endpoint_from_hint_obj",
+                    side_effect=[ep]) as efho:
+        c._schedule_connection(0.0, hint, True)
+    assert efho.mock_calls == [mock.call(hint, h.tor, h.reactor)]
+    assert ep.mock_calls == []
+    d = Deferred()
+    ep.connect = mock.Mock(side_effect=[d])
+    # direct hints are scheduled for T+0.0
+    f = mock.Mock()
+    with mock.patch("wormhole._dilation.connector.OutboundConnectionFactory",
+                    return_value=f) as ocf:
+        h.clock.advance(1.0)
+    handshake = build_sided_relay_handshake(h.dilation_key, h.side)
+    assert ocf.mock_calls == [mock.call(c, handshake, "->relay:tcp:foo:55")]
+
+def test_listen_but_tor():
+    c, h = make_connector(listen=True, tor=True, role=roles.LEADER)
+    with mock.patch("wormhole.ipaddrs.find_addresses",
+                    return_value=["127.0.0.1", "1.2.3.4", "5.6.7.8"]) as fa:
         c.start()
-        # no relays, so it publishes no hints
-        self.assertEqual(h.manager.mock_calls, [])
-        # and no listener, so nothing happens until we provide a hint
-        self.assertEqual(c._schedule_connection.mock_calls, [])
-        c.stop()
+    # don't even look up addresses
+    assert fa.mock_calls == []
+    # no relays and the listener isn't ready yet, so no hints yet
+    assert h.manager.mock_calls == []
 
-    def test_basic(self):
-        c, h = make_connector(listen=False, relay=None, role=roles.LEADER)
-        c._schedule_connection = mock.Mock()
+def test_no_listen():
+    c, h = make_connector(listen=False, tor=False, role=roles.LEADER)
+    with mock.patch("wormhole.ipaddrs.find_addresses",
+                    return_value=["127.0.0.1", "1.2.3.4", "5.6.7.8"]) as fa:
         c.start()
-        # no relays, so it publishes no hints
-        self.assertEqual(h.manager.mock_calls, [])
-        # and no listener, so nothing happens until we provide a hint
-        self.assertEqual(c._schedule_connection.mock_calls, [])
+    # don't even look up addresses
+    assert fa.mock_calls == []
+    assert h.manager.mock_calls == []
 
-        hint = DirectTCPV1Hint("foo", 55, 0.0)
-        c.got_hints([hint])
+def test_relay_delay():
+    # given a direct connection and a relay, we should see the direct
+    # connection initiated at T+0 seconds, and the relay at T+RELAY_DELAY
+    c, h = make_connector(listen=True, relay=None, role=roles.LEADER)
+    c._schedule_connection = mock.Mock()
+    c._start_listener = mock.Mock()
+    c.start()
+    hint1 = DirectTCPV1Hint("foo", 55, 0.0)
+    hint2 = DirectTCPV1Hint("bar", 55, 0.0)
+    hint3 = RelayV1Hint([DirectTCPV1Hint("relay", 55, 0.0)])
+    c.got_hints([hint1, hint2, hint3])
+    assert c._schedule_connection.mock_calls == \
+                     [mock.call(0.0, hint1, is_relay=False),
+                      mock.call(0.0, hint2, is_relay=False),
+                      mock.call(c.RELAY_DELAY, hint3.hints[0], is_relay=True),
+                      ]
 
-        # received hints don't get published
-        self.assertEqual(h.manager.mock_calls, [])
-        # they just schedule a connection
-        self.assertEqual(c._schedule_connection.mock_calls,
-                         [mock.call(0.0, DirectTCPV1Hint("foo", 55, 0.0),
-                                    is_relay=False)])
+def test_initial_relay():
+    c, h = make_connector(listen=False, relay="tcp:foo:55", role=roles.LEADER)
+    c._schedule_connection = mock.Mock()
+    c.start()
+    assert h.manager.mock_calls == \
+                     [mock.call.send_hints([{"type": "relay-v1",
+                                             "hints": [
+                                                 {"type": "direct-tcp-v1",
+                                                  "hostname": "foo",
+                                                  "port": 55,
+                                                  "priority": 0.0
+                                                  },
+                                                 ],
+                                             }])]
+    assert c._schedule_connection.mock_calls == \
+                     [mock.call(0.0, DirectTCPV1Hint("foo", 55, 0.0),
+                                is_relay=True)]
 
-    def test_listen_addresses(self):
-        c, h = make_connector(listen=True, role=roles.LEADER)
-        with mock.patch("wormhole.ipaddrs.find_addresses",
-                        return_value=["127.0.0.1", "1.2.3.4", "5.6.7.8"]):
-            self.assertEqual(c._get_listener_addresses(),
-                             ["1.2.3.4", "5.6.7.8"])
-        with mock.patch("wormhole.ipaddrs.find_addresses",
-                        return_value=["127.0.0.1"]):
-            # some test hosts, including the appveyor VMs, *only* have
-            # 127.0.0.1, and the tests will hang badly if we remove it.
-            self.assertEqual(c._get_listener_addresses(), ["127.0.0.1"])
+def test_tor_no_manager():
+    # tor hints should be ignored if we don't have a Tor manager to use them
+    c, h = make_connector(listen=False, role=roles.LEADER)
+    c._schedule_connection = mock.Mock()
+    c.start()
+    hint = TorTCPV1Hint("foo", 55, 0.0)
+    c.got_hints([hint])
+    assert h.manager.mock_calls == []
+    assert c._schedule_connection.mock_calls == []
 
-    def test_listen(self):
-        c, h = make_connector(listen=True, role=roles.LEADER)
-        c._start_listener = mock.Mock()
-        with mock.patch("wormhole.ipaddrs.find_addresses",
-                        return_value=["127.0.0.1", "1.2.3.4", "5.6.7.8"]):
-            c.start()
-        self.assertEqual(c._start_listener.mock_calls,
-                         [mock.call(["1.2.3.4", "5.6.7.8"])])
+def test_tor_with_manager():
+    # tor hints should be processed if we do have a Tor manager
+    c, h = make_connector(listen=False, tor=True, role=roles.LEADER)
+    c._schedule_connection = mock.Mock()
+    c.start()
+    hint = TorTCPV1Hint("foo", 55, 0.0)
+    c.got_hints([hint])
+    assert c._schedule_connection.mock_calls == \
+                     [mock.call(0.0, hint, is_relay=False)]
 
-    def test_start_listen(self):
-        c, h = make_connector(listen=True, role=roles.LEADER)
-        ep = mock.Mock()
-        d = Deferred()
-        ep.listen = mock.Mock(return_value=d)
-        with mock.patch("wormhole._dilation.connector.serverFromString",
-                        return_value=ep) as sfs:
-            c._start_listener(["1.2.3.4", "5.6.7.8"])
-        self.assertEqual(sfs.mock_calls, [mock.call(h.reactor, "tcp:0")])
-        lp = mock.Mock()
-        host = mock.Mock()
-        host.port = 66
-        lp.getHost = mock.Mock(return_value=host)
-        d.callback(lp)
-        self.assertEqual(h.manager.mock_calls,
-                         [mock.call.send_hints([{"type": "direct-tcp-v1",
-                                                 "hostname": "1.2.3.4",
-                                                 "port": 66,
-                                                 "priority": 0.0
-                                                 },
-                                                {"type": "direct-tcp-v1",
-                                                 "hostname": "5.6.7.8",
-                                                 "port": 66,
-                                                 "priority": 0.0
-                                                 },
-                                                ])])
-
-    def test_schedule_connection_no_relay(self):
-        c, h = make_connector(listen=True, role=roles.LEADER)
-        hint = DirectTCPV1Hint("foo", 55, 0.0)
-        ep = mock.Mock()
-        with mock.patch("wormhole._dilation.connector.endpoint_from_hint_obj",
-                        side_effect=[ep]) as efho:
-            c._schedule_connection(0.0, hint, False)
-        self.assertEqual(efho.mock_calls, [mock.call(hint, h.tor, h.reactor)])
-        self.assertEqual(ep.mock_calls, [])
-        d = Deferred()
-        ep.connect = mock.Mock(side_effect=[d])
-        # direct hints are scheduled for T+0.0
-        f = mock.Mock()
-        with mock.patch("wormhole._dilation.connector.OutboundConnectionFactory",
-                        return_value=f) as ocf:
-            h.clock.advance(1.0)
-        self.assertEqual(ocf.mock_calls, [mock.call(c, None, "->tcp:foo:55")])
-        self.assertEqual(ep.connect.mock_calls, [mock.call(f)])
-        p = mock.Mock()
-        d.callback(p)
-        self.assertEqual(p.mock_calls,
-                         [mock.call.when_disconnected(),
-                          mock.call.when_disconnected().addCallback(c._pending_connections.discard)])
-
-    def test_schedule_connection_relay(self):
-        c, h = make_connector(listen=True, role=roles.LEADER)
-        hint = DirectTCPV1Hint("foo", 55, 0.0)
-        ep = mock.Mock()
-        with mock.patch("wormhole._dilation.connector.endpoint_from_hint_obj",
-                        side_effect=[ep]) as efho:
-            c._schedule_connection(0.0, hint, True)
-        self.assertEqual(efho.mock_calls, [mock.call(hint, h.tor, h.reactor)])
-        self.assertEqual(ep.mock_calls, [])
-        d = Deferred()
-        ep.connect = mock.Mock(side_effect=[d])
-        # direct hints are scheduled for T+0.0
-        f = mock.Mock()
-        with mock.patch("wormhole._dilation.connector.OutboundConnectionFactory",
-                        return_value=f) as ocf:
-            h.clock.advance(1.0)
-        handshake = build_sided_relay_handshake(h.dilation_key, h.side)
-        self.assertEqual(ocf.mock_calls, [mock.call(c, handshake, "->relay:tcp:foo:55")])
-
-    def test_listen_but_tor(self):
-        c, h = make_connector(listen=True, tor=True, role=roles.LEADER)
-        with mock.patch("wormhole.ipaddrs.find_addresses",
-                        return_value=["127.0.0.1", "1.2.3.4", "5.6.7.8"]) as fa:
-            c.start()
-        # don't even look up addresses
-        self.assertEqual(fa.mock_calls, [])
-        # no relays and the listener isn't ready yet, so no hints yet
-        self.assertEqual(h.manager.mock_calls, [])
-
-    def test_no_listen(self):
-        c, h = make_connector(listen=False, tor=False, role=roles.LEADER)
-        with mock.patch("wormhole.ipaddrs.find_addresses",
-                        return_value=["127.0.0.1", "1.2.3.4", "5.6.7.8"]) as fa:
-            c.start()
-        # don't even look up addresses
-        self.assertEqual(fa.mock_calls, [])
-        self.assertEqual(h.manager.mock_calls, [])
-
-    def test_relay_delay(self):
-        # given a direct connection and a relay, we should see the direct
-        # connection initiated at T+0 seconds, and the relay at T+RELAY_DELAY
-        c, h = make_connector(listen=True, relay=None, role=roles.LEADER)
-        c._schedule_connection = mock.Mock()
-        c._start_listener = mock.Mock()
-        c.start()
-        hint1 = DirectTCPV1Hint("foo", 55, 0.0)
-        hint2 = DirectTCPV1Hint("bar", 55, 0.0)
-        hint3 = RelayV1Hint([DirectTCPV1Hint("relay", 55, 0.0)])
-        c.got_hints([hint1, hint2, hint3])
-        self.assertEqual(c._schedule_connection.mock_calls,
-                         [mock.call(0.0, hint1, is_relay=False),
-                          mock.call(0.0, hint2, is_relay=False),
-                          mock.call(c.RELAY_DELAY, hint3.hints[0], is_relay=True),
-                          ])
-
-    def test_initial_relay(self):
-        c, h = make_connector(listen=False, relay="tcp:foo:55", role=roles.LEADER)
-        c._schedule_connection = mock.Mock()
-        c.start()
-        self.assertEqual(h.manager.mock_calls,
-                         [mock.call.send_hints([{"type": "relay-v1",
-                                                 "hints": [
-                                                     {"type": "direct-tcp-v1",
-                                                      "hostname": "foo",
-                                                      "port": 55,
-                                                      "priority": 0.0
-                                                      },
-                                                     ],
-                                                 }])])
-        self.assertEqual(c._schedule_connection.mock_calls,
-                         [mock.call(0.0, DirectTCPV1Hint("foo", 55, 0.0),
-                                    is_relay=True)])
-
-    def test_tor_no_manager(self):
-        # tor hints should be ignored if we don't have a Tor manager to use them
-        c, h = make_connector(listen=False, role=roles.LEADER)
-        c._schedule_connection = mock.Mock()
-        c.start()
-        hint = TorTCPV1Hint("foo", 55, 0.0)
-        c.got_hints([hint])
-        self.assertEqual(h.manager.mock_calls, [])
-        self.assertEqual(c._schedule_connection.mock_calls, [])
-
-    def test_tor_with_manager(self):
-        # tor hints should be processed if we do have a Tor manager
-        c, h = make_connector(listen=False, tor=True, role=roles.LEADER)
-        c._schedule_connection = mock.Mock()
-        c.start()
-        hint = TorTCPV1Hint("foo", 55, 0.0)
-        c.got_hints([hint])
-        self.assertEqual(c._schedule_connection.mock_calls,
-                         [mock.call(0.0, hint, is_relay=False)])
-
-    def test_priorities(self):
-        # given two hints with different priorities, we should somehow prefer
-        # one. This is a placeholder to fill in once we implement priorities.
-        pass
+def test_priorities():
+    # given two hints with different priorities, we should somehow prefer
+    # one. This is a placeholder to fill in once we implement priorities.
+    pass
 
 
-class Race(unittest.TestCase):
-    def test_one_leader(self):
-        c, h = make_connector(listen=True, role=roles.LEADER)
-        lp = mock.Mock()
+def test_one_leader():
+    c, h = make_connector(listen=True, role=roles.LEADER)
+    lp = mock.Mock()
 
-        def start_listener(addresses):
-            c._listeners.add(lp)
-        c._start_listener = start_listener
-        c._schedule_connection = mock.Mock()
-        c.start()
-        self.assertEqual(c._listeners, set([lp]))
+    def start_listener(addresses):
+        c._listeners.add(lp)
+    c._start_listener = start_listener
+    c._schedule_connection = mock.Mock()
+    c.start()
+    assert c._listeners == set([lp])
 
-        p1 = mock.Mock()  # DilatedConnectionProtocol instance
-        c.add_candidate(p1)
-        self.assertEqual(h.manager.mock_calls, [])
-        h.eq.flush_sync()
-        self.assertEqual(h.manager.mock_calls, [mock.call.connector_connection_made(p1)])
-        self.assertEqual(p1.mock_calls,
-                         [mock.call.select(h.manager),
-                          mock.call.send_record(KCM())])
-        self.assertEqual(lp.mock_calls[0], mock.call.stopListening())
-        # stop_listeners() uses a DeferredList, so we ignore the second call
+    p1 = mock.Mock()  # DilatedConnectionProtocol instance
+    c.add_candidate(p1)
+    assert h.manager.mock_calls == []
+    h.eq.flush_sync()
+    assert h.manager.mock_calls == [mock.call.connector_connection_made(p1)]
+    assert p1.mock_calls == \
+                     [mock.call.select(h.manager),
+                      mock.call.send_record(KCM())]
+    assert lp.mock_calls[0] == mock.call.stopListening()
+    # stop_listeners() uses a DeferredList, so we ignore the second call
 
-    def test_one_follower(self):
-        c, h = make_connector(listen=True, role=roles.FOLLOWER)
-        lp = mock.Mock()
+def test_one_follower():
+    c, h = make_connector(listen=True, role=roles.FOLLOWER)
+    lp = mock.Mock()
 
-        def start_listener(addresses):
-            c._listeners.add(lp)
-        c._start_listener = start_listener
-        c._schedule_connection = mock.Mock()
-        c.start()
-        self.assertEqual(c._listeners, set([lp]))
+    def start_listener(addresses):
+        c._listeners.add(lp)
+    c._start_listener = start_listener
+    c._schedule_connection = mock.Mock()
+    c.start()
+    assert c._listeners == set([lp])
 
-        p1 = mock.Mock()  # DilatedConnectionProtocol instance
-        c.add_candidate(p1)
-        self.assertEqual(h.manager.mock_calls, [])
-        h.eq.flush_sync()
-        self.assertEqual(h.manager.mock_calls, [mock.call.connector_connection_made(p1)])
-        # just like LEADER, but follower doesn't send KCM now (it sent one
-        # earlier, to tell the leader that this connection looks viable)
-        self.assertEqual(p1.mock_calls,
-                         [mock.call.select(h.manager)])
-        self.assertEqual(lp.mock_calls[0], mock.call.stopListening())
-        # stop_listeners() uses a DeferredList, so we ignore the second call
+    p1 = mock.Mock()  # DilatedConnectionProtocol instance
+    c.add_candidate(p1)
+    assert h.manager.mock_calls == []
+    h.eq.flush_sync()
+    assert h.manager.mock_calls == [mock.call.connector_connection_made(p1)]
+    # just like LEADER, but follower doesn't send KCM now (it sent one
+    # earlier, to tell the leader that this connection looks viable)
+    assert p1.mock_calls == \
+                     [mock.call.select(h.manager)]
+    assert lp.mock_calls[0] == mock.call.stopListening()
+    # stop_listeners() uses a DeferredList, so we ignore the second call
 
-    # TODO: make sure a pending connection is abandoned when the listener
-    # answers successfully
+# TODO: make sure a pending connection is abandoned when the listener
+# answers successfully
 
-    # TODO: make sure a second pending connection is abandoned when the first
-    # connection succeeds
+# TODO: make sure a second pending connection is abandoned when the first
+# connection succeeds
 
-    def test_late(self):
-        c, h = make_connector(listen=False, role=roles.LEADER)
-        c._schedule_connection = mock.Mock()
-        c.start()
+def test_late():
+    c, h = make_connector(listen=False, role=roles.LEADER)
+    c._schedule_connection = mock.Mock()
+    c.start()
 
-        p1 = mock.Mock()  # DilatedConnectionProtocol instance
-        c.add_candidate(p1)
-        self.assertEqual(h.manager.mock_calls, [])
-        h.eq.flush_sync()
-        self.assertEqual(h.manager.mock_calls, [mock.call.connector_connection_made(p1)])
-        clear_mock_calls(h.manager)
-        self.assertEqual(p1.mock_calls,
-                         [mock.call.select(h.manager),
-                          mock.call.send_record(KCM())])
+    p1 = mock.Mock()  # DilatedConnectionProtocol instance
+    c.add_candidate(p1)
+    assert h.manager.mock_calls == []
+    h.eq.flush_sync()
+    assert h.manager.mock_calls == [mock.call.connector_connection_made(p1)]
+    clear_mock_calls(h.manager)
+    assert p1.mock_calls == \
+                     [mock.call.select(h.manager),
+                      mock.call.send_record(KCM())]
 
-        # late connection is ignored
-        p2 = mock.Mock()
-        c.add_candidate(p2)
-        self.assertEqual(h.manager.mock_calls, [])
+    # late connection is ignored
+    p2 = mock.Mock()
+    c.add_candidate(p2)
+    assert h.manager.mock_calls == []
 
-    # make sure an established connection is dropped when stop() is called
-    def test_stop(self):
-        c, h = make_connector(listen=False, role=roles.LEADER)
-        c._schedule_connection = mock.Mock()
-        c.start()
+# make sure an established connection is dropped when stop() is called
+def test_stop():
+    c, h = make_connector(listen=False, role=roles.LEADER)
+    c._schedule_connection = mock.Mock()
+    c.start()
 
-        p1 = mock.Mock()  # DilatedConnectionProtocol instance
-        c.add_candidate(p1)
-        self.assertEqual(h.manager.mock_calls, [])
-        h.eq.flush_sync()
-        self.assertEqual(p1.mock_calls,
-                         [mock.call.select(h.manager),
-                          mock.call.send_record(KCM())])
-        self.assertEqual(h.manager.mock_calls, [mock.call.connector_connection_made(p1)])
+    p1 = mock.Mock()  # DilatedConnectionProtocol instance
+    c.add_candidate(p1)
+    assert h.manager.mock_calls == []
+    h.eq.flush_sync()
+    assert p1.mock_calls == \
+                     [mock.call.select(h.manager),
+                      mock.call.send_record(KCM())]
+    assert h.manager.mock_calls == [mock.call.connector_connection_made(p1)]
 
-        c.stop()
+    c.stop()
 
 
-class Describe(unittest.TestCase):
-    def test_describe_inbound(self):
-        self.assertEqual(describe_inbound(HostnameAddress("example.com", 1234)),
-                         "<-tcp:example.com:1234")
-        self.assertEqual(describe_inbound(IPv4Address("TCP", "1.2.3.4", 1234)),
-                         "<-tcp:1.2.3.4:1234")
-        self.assertEqual(describe_inbound(IPv6Address("TCP", "::1", 1234)),
-                         "<-tcp:[::1]:1234")
-        other = "none-of-the-above"
-        self.assertEqual(describe_inbound(other), "<-%r" % other)
+def test_describe_inbound():
+    assert describe_inbound(HostnameAddress("example.com", 1234)) == \
+                     "<-tcp:example.com:1234"
+    assert describe_inbound(IPv4Address("TCP", "1.2.3.4", 1234)) == \
+                     "<-tcp:1.2.3.4:1234"
+    assert describe_inbound(IPv6Address("TCP", "::1", 1234)) == \
+                     "<-tcp:[::1]:1234"
+    other = "none-of-the-above"
+    assert describe_inbound(other) == "<-%r" % other

--- a/src/wormhole/test/dilate/test_encoding.py
+++ b/src/wormhole/test/dilate/test_encoding.py
@@ -1,25 +1,23 @@
-from twisted.trial import unittest
 from ..._dilation.encode import to_be4, from_be4
+import pytest
 
 
-class Encoding(unittest.TestCase):
+def test_be4():
+    assert to_be4(0) == b"\x00\x00\x00\x00"
+    assert to_be4(1) == b"\x00\x00\x00\x01"
+    assert to_be4(256) == b"\x00\x00\x01\x00"
+    assert to_be4(257) == b"\x00\x00\x01\x01"
+    with pytest.raises(ValueError):
+        to_be4(-1)
+    with pytest.raises(ValueError):
+        to_be4(2**32)
 
-    def test_be4(self):
-        self.assertEqual(to_be4(0), b"\x00\x00\x00\x00")
-        self.assertEqual(to_be4(1), b"\x00\x00\x00\x01")
-        self.assertEqual(to_be4(256), b"\x00\x00\x01\x00")
-        self.assertEqual(to_be4(257), b"\x00\x00\x01\x01")
-        with self.assertRaises(ValueError):
-            to_be4(-1)
-        with self.assertRaises(ValueError):
-            to_be4(2**32)
+    assert from_be4(b"\x00\x00\x00\x00") == 0
+    assert from_be4(b"\x00\x00\x00\x01") == 1
+    assert from_be4(b"\x00\x00\x01\x00") == 256
+    assert from_be4(b"\x00\x00\x01\x01") == 257
 
-        self.assertEqual(from_be4(b"\x00\x00\x00\x00"), 0)
-        self.assertEqual(from_be4(b"\x00\x00\x00\x01"), 1)
-        self.assertEqual(from_be4(b"\x00\x00\x01\x00"), 256)
-        self.assertEqual(from_be4(b"\x00\x00\x01\x01"), 257)
-
-        with self.assertRaises(TypeError):
-            from_be4(0)
-        with self.assertRaises(ValueError):
-            from_be4(b"\x01\x00\x00\x00\x00")
+    with pytest.raises(TypeError):
+        from_be4(0)
+    with pytest.raises(ValueError):
+        from_be4(b"\x01\x00\x00\x00\x00")

--- a/src/wormhole/test/dilate/test_endpoints.py
+++ b/src/wormhole/test/dilate/test_endpoints.py
@@ -1,8 +1,10 @@
 from unittest import mock
 from zope.interface import alsoProvides
-from twisted.trial import unittest
 from twisted.internet.task import Clock
 from twisted.python.failure import Failure
+import pytest
+import pytest_twisted
+
 from ..._interfaces import ISubChannel
 from ...eventual import EventualQueue
 from ..._dilation.subchannel import (ControlEndpoint,
@@ -18,349 +20,379 @@ class CannotDilateError(Exception):
     pass
 
 
-class Control(unittest.TestCase):
-    def test_early_succeed(self):
-        # ep.connect() is called before dilation can proceed
-        scid0 = 0
-        peeraddr = _SubchannelAddress(scid0)
-        sc0 = mock.Mock()
-        alsoProvides(sc0, ISubChannel)
-        eq = EventualQueue(Clock())
-        ep = ControlEndpoint(peeraddr, sc0, eq)
+@pytest_twisted.ensureDeferred
+async def test_early_succeed():
+    # ep.connect() is called before dilation can proceed
+    scid0 = 0
+    peeraddr = _SubchannelAddress(scid0)
+    sc0 = mock.Mock()
+    alsoProvides(sc0, ISubChannel)
+    eq = EventualQueue(Clock())
+    ep = ControlEndpoint(peeraddr, sc0, eq)
 
-        f = mock.Mock()
-        p = mock.Mock()
-        f.buildProtocol = mock.Mock(return_value=p)
+    f = mock.Mock()
+    p = mock.Mock()
+    f.buildProtocol = mock.Mock(return_value=p)
+    d = ep.connect(f)
+    assert not d.called
+
+    ep._main_channel_ready()
+    eq.flush_sync()
+
+    proto = await d
+    assert proto is p
+    assert f.buildProtocol.mock_calls == [mock.call(peeraddr)]
+    assert sc0.mock_calls == [mock.call._set_protocol(p),
+                                      mock.call._deliver_queued_data()]
+    assert p.mock_calls == [mock.call.makeConnection(sc0)]
+
+    d = ep.connect(f)
+    with pytest.raises(SingleUseEndpointError):
+        await d
+
+
+@pytest_twisted.ensureDeferred
+async def test_early_fail():
+    # ep.connect() is called before dilation is abandoned
+    scid0 = 0
+    peeraddr = _SubchannelAddress(scid0)
+    sc0 = mock.Mock()
+    alsoProvides(sc0, ISubChannel)
+    eq = EventualQueue(Clock())
+    ep = ControlEndpoint(peeraddr, sc0, eq)
+
+    f = mock.Mock()
+    p = mock.Mock()
+    f.buildProtocol = mock.Mock(return_value=p)
+    d = ep.connect(f)
+    assert not d.called
+
+    ep._main_channel_failed(Failure(CannotDilateError()))
+    eq.flush_sync()
+
+    with pytest.raises(CannotDilateError):
+        await d
+    assert f.buildProtocol.mock_calls == []
+    assert sc0.mock_calls == []
+
+    d = ep.connect(f)
+    with pytest.raises(SingleUseEndpointError):
+        await d
+
+
+@pytest_twisted.ensureDeferred
+async def test_late_succeed():
+    # dilation can proceed, then ep.connect() is called
+    scid0 = 0
+    peeraddr = _SubchannelAddress(scid0)
+    sc0 = mock.Mock()
+    alsoProvides(sc0, ISubChannel)
+    eq = EventualQueue(Clock())
+    ep = ControlEndpoint(peeraddr, sc0, eq)
+
+    ep._main_channel_ready()
+
+    f = mock.Mock()
+    p = mock.Mock()
+    f.buildProtocol = mock.Mock(return_value=p)
+    d = ep.connect(f)
+    eq.flush_sync()
+    proto = await d
+    assert proto is p
+    assert f.buildProtocol.mock_calls == [mock.call(peeraddr)]
+    assert sc0.mock_calls == [mock.call._set_protocol(p),
+                                      mock.call._deliver_queued_data()]
+    assert p.mock_calls == [mock.call.makeConnection(sc0)]
+
+    d = ep.connect(f)
+    with pytest.raises(SingleUseEndpointError):
+        await d
+
+
+@pytest_twisted.ensureDeferred
+async def test_late_fail():
+    # dilation is abandoned, then ep.connect() is called
+    scid0 = 0
+    peeraddr = _SubchannelAddress(scid0)
+    sc0 = mock.Mock()
+    alsoProvides(sc0, ISubChannel)
+    eq = EventualQueue(Clock())
+    ep = ControlEndpoint(peeraddr, sc0, eq)
+
+    ep._main_channel_failed(Failure(CannotDilateError()))
+
+    f = mock.Mock()
+    p = mock.Mock()
+    f.buildProtocol = mock.Mock(return_value=p)
+    d = ep.connect(f)
+    eq.flush_sync()
+
+    with pytest.raises(CannotDilateError):
+        await d
+    assert f.buildProtocol.mock_calls == []
+    assert sc0.mock_calls == []
+
+    with pytest.raises(SingleUseEndpointError):
+        await ep.connect(f)
+
+
+def OFFassert_makeConnection(mock_calls):
+    assert len(mock_calls) == 1
+    assert mock_calls[0][0] == "makeConnection"
+    assert len(mock_calls[0][1]) == 1
+    return mock_calls[0][1][0]
+
+
+@pytest_twisted.ensureDeferred
+async def test_early_succeed():
+    m = mock_manager()
+    m.allocate_subchannel_id = mock.Mock(return_value=0)
+    hostaddr = _WormholeAddress()
+    peeraddr = _SubchannelAddress(0)
+    eq = EventualQueue(Clock())
+    ep = SubchannelConnectorEndpoint(m, hostaddr, eq)
+
+    f = mock.Mock()
+    p = mock.Mock()
+    t = mock.Mock()
+    f.buildProtocol = mock.Mock(return_value=p)
+    with mock.patch("wormhole._dilation.subchannel.SubChannel",
+                    return_value=t) as sc:
         d = ep.connect(f)
-        self.assertNoResult(d)
-
+        eq.flush_sync()
+        assert not d.called
         ep._main_channel_ready()
         eq.flush_sync()
 
-        self.assertIdentical(self.successResultOf(d), p)
-        self.assertEqual(f.buildProtocol.mock_calls, [mock.call(peeraddr)])
-        self.assertEqual(sc0.mock_calls, [mock.call._set_protocol(p),
-                                          mock.call._deliver_queued_data()])
-        self.assertEqual(p.mock_calls, [mock.call.makeConnection(sc0)])
+    proto = await d
+    assert proto is p
+    assert f.buildProtocol.mock_calls == [mock.call(peeraddr)]
+    assert sc.mock_calls == [mock.call(0, m, hostaddr, peeraddr)]
+    assert t.mock_calls == [mock.call._set_protocol(p)]
+    assert p.mock_calls == [mock.call.makeConnection(t)]
 
+
+@pytest_twisted.ensureDeferred
+async def test_early_fail():
+    m = mock_manager()
+    m.allocate_subchannel_id = mock.Mock(return_value=0)
+    hostaddr = _WormholeAddress()
+    eq = EventualQueue(Clock())
+    ep = SubchannelConnectorEndpoint(m, hostaddr, eq)
+
+    f = mock.Mock()
+    p = mock.Mock()
+    t = mock.Mock()
+    f.buildProtocol = mock.Mock(return_value=p)
+    with mock.patch("wormhole._dilation.subchannel.SubChannel",
+                    return_value=t) as sc:
         d = ep.connect(f)
-        self.failureResultOf(d, SingleUseEndpointError)
-
-    def test_early_fail(self):
-        # ep.connect() is called before dilation is abandoned
-        scid0 = 0
-        peeraddr = _SubchannelAddress(scid0)
-        sc0 = mock.Mock()
-        alsoProvides(sc0, ISubChannel)
-        eq = EventualQueue(Clock())
-        ep = ControlEndpoint(peeraddr, sc0, eq)
-
-        f = mock.Mock()
-        p = mock.Mock()
-        f.buildProtocol = mock.Mock(return_value=p)
-        d = ep.connect(f)
-        self.assertNoResult(d)
-
+        eq.flush_sync()
+        assert not d.called
         ep._main_channel_failed(Failure(CannotDilateError()))
         eq.flush_sync()
 
-        self.failureResultOf(d).check(CannotDilateError)
-        self.assertEqual(f.buildProtocol.mock_calls, [])
-        self.assertEqual(sc0.mock_calls, [])
+    with pytest.raises(CannotDilateError):
+        await d
+    assert f.buildProtocol.mock_calls == []
+    assert sc.mock_calls == []
+    assert t.mock_calls == []
 
-        d = ep.connect(f)
-        self.failureResultOf(d, SingleUseEndpointError)
 
-    def test_late_succeed(self):
-        # dilation can proceed, then ep.connect() is called
-        scid0 = 0
-        peeraddr = _SubchannelAddress(scid0)
-        sc0 = mock.Mock()
-        alsoProvides(sc0, ISubChannel)
-        eq = EventualQueue(Clock())
-        ep = ControlEndpoint(peeraddr, sc0, eq)
+@pytest_twisted.ensureDeferred
+async def test_late_succeed():
+    m = mock_manager()
+    m.allocate_subchannel_id = mock.Mock(return_value=0)
+    hostaddr = _WormholeAddress()
+    peeraddr = _SubchannelAddress(0)
+    eq = EventualQueue(Clock())
+    ep = SubchannelConnectorEndpoint(m, hostaddr, eq)
+    ep._main_channel_ready()
 
-        ep._main_channel_ready()
-
-        f = mock.Mock()
-        p = mock.Mock()
-        f.buildProtocol = mock.Mock(return_value=p)
-        d = ep.connect(f)
-        eq.flush_sync()
-        self.assertIdentical(self.successResultOf(d), p)
-        self.assertEqual(f.buildProtocol.mock_calls, [mock.call(peeraddr)])
-        self.assertEqual(sc0.mock_calls, [mock.call._set_protocol(p),
-                                          mock.call._deliver_queued_data()])
-        self.assertEqual(p.mock_calls, [mock.call.makeConnection(sc0)])
-
-        d = ep.connect(f)
-        self.failureResultOf(d, SingleUseEndpointError)
-
-    def test_late_fail(self):
-        # dilation is abandoned, then ep.connect() is called
-        scid0 = 0
-        peeraddr = _SubchannelAddress(scid0)
-        sc0 = mock.Mock()
-        alsoProvides(sc0, ISubChannel)
-        eq = EventualQueue(Clock())
-        ep = ControlEndpoint(peeraddr, sc0, eq)
-
-        ep._main_channel_failed(Failure(CannotDilateError()))
-
-        f = mock.Mock()
-        p = mock.Mock()
-        f.buildProtocol = mock.Mock(return_value=p)
+    f = mock.Mock()
+    p = mock.Mock()
+    t = mock.Mock()
+    f.buildProtocol = mock.Mock(return_value=p)
+    with mock.patch("wormhole._dilation.subchannel.SubChannel",
+                    return_value=t) as sc:
         d = ep.connect(f)
         eq.flush_sync()
 
-        self.failureResultOf(d).check(CannotDilateError)
-        self.assertEqual(f.buildProtocol.mock_calls, [])
-        self.assertEqual(sc0.mock_calls, [])
+    proto = await d
+    assert proto is p
+    assert f.buildProtocol.mock_calls == [mock.call(peeraddr)]
+    assert sc.mock_calls == [mock.call(0, m, hostaddr, peeraddr)]
+    assert t.mock_calls == [mock.call._set_protocol(p)]
+    assert p.mock_calls == [mock.call.makeConnection(t)]
 
+
+@pytest_twisted.ensureDeferred
+async def test_late_fail():
+    m = mock_manager()
+    m.allocate_subchannel_id = mock.Mock(return_value=0)
+    hostaddr = _WormholeAddress()
+    eq = EventualQueue(Clock())
+    ep = SubchannelConnectorEndpoint(m, hostaddr, eq)
+    ep._main_channel_failed(Failure(CannotDilateError()))
+
+    f = mock.Mock()
+    p = mock.Mock()
+    t = mock.Mock()
+    f.buildProtocol = mock.Mock(return_value=p)
+    with mock.patch("wormhole._dilation.subchannel.SubChannel",
+                    return_value=t) as sc:
         d = ep.connect(f)
-        self.failureResultOf(d, SingleUseEndpointError)
-
-
-class Endpoints(unittest.TestCase):
-    def OFFassert_makeConnection(self, mock_calls):
-        self.assertEqual(len(mock_calls), 1)
-        self.assertEqual(mock_calls[0][0], "makeConnection")
-        self.assertEqual(len(mock_calls[0][1]), 1)
-        return mock_calls[0][1][0]
-
-
-class Connector(unittest.TestCase):
-    def test_early_succeed(self):
-        m = mock_manager()
-        m.allocate_subchannel_id = mock.Mock(return_value=0)
-        hostaddr = _WormholeAddress()
-        peeraddr = _SubchannelAddress(0)
-        eq = EventualQueue(Clock())
-        ep = SubchannelConnectorEndpoint(m, hostaddr, eq)
-
-        f = mock.Mock()
-        p = mock.Mock()
-        t = mock.Mock()
-        f.buildProtocol = mock.Mock(return_value=p)
-        with mock.patch("wormhole._dilation.subchannel.SubChannel",
-                        return_value=t) as sc:
-            d = ep.connect(f)
-            eq.flush_sync()
-            self.assertNoResult(d)
-            ep._main_channel_ready()
-            eq.flush_sync()
-
-        self.assertIdentical(self.successResultOf(d), p)
-        self.assertEqual(f.buildProtocol.mock_calls, [mock.call(peeraddr)])
-        self.assertEqual(sc.mock_calls, [mock.call(0, m, hostaddr, peeraddr)])
-        self.assertEqual(t.mock_calls, [mock.call._set_protocol(p)])
-        self.assertEqual(p.mock_calls, [mock.call.makeConnection(t)])
-
-    def test_early_fail(self):
-        m = mock_manager()
-        m.allocate_subchannel_id = mock.Mock(return_value=0)
-        hostaddr = _WormholeAddress()
-        eq = EventualQueue(Clock())
-        ep = SubchannelConnectorEndpoint(m, hostaddr, eq)
-
-        f = mock.Mock()
-        p = mock.Mock()
-        t = mock.Mock()
-        f.buildProtocol = mock.Mock(return_value=p)
-        with mock.patch("wormhole._dilation.subchannel.SubChannel",
-                        return_value=t) as sc:
-            d = ep.connect(f)
-            eq.flush_sync()
-            self.assertNoResult(d)
-            ep._main_channel_failed(Failure(CannotDilateError()))
-            eq.flush_sync()
-
-        self.failureResultOf(d).check(CannotDilateError)
-        self.assertEqual(f.buildProtocol.mock_calls, [])
-        self.assertEqual(sc.mock_calls, [])
-        self.assertEqual(t.mock_calls, [])
-
-    def test_late_succeed(self):
-        m = mock_manager()
-        m.allocate_subchannel_id = mock.Mock(return_value=0)
-        hostaddr = _WormholeAddress()
-        peeraddr = _SubchannelAddress(0)
-        eq = EventualQueue(Clock())
-        ep = SubchannelConnectorEndpoint(m, hostaddr, eq)
-        ep._main_channel_ready()
-
-        f = mock.Mock()
-        p = mock.Mock()
-        t = mock.Mock()
-        f.buildProtocol = mock.Mock(return_value=p)
-        with mock.patch("wormhole._dilation.subchannel.SubChannel",
-                        return_value=t) as sc:
-            d = ep.connect(f)
-            eq.flush_sync()
-
-        self.assertIdentical(self.successResultOf(d), p)
-        self.assertEqual(f.buildProtocol.mock_calls, [mock.call(peeraddr)])
-        self.assertEqual(sc.mock_calls, [mock.call(0, m, hostaddr, peeraddr)])
-        self.assertEqual(t.mock_calls, [mock.call._set_protocol(p)])
-        self.assertEqual(p.mock_calls, [mock.call.makeConnection(t)])
-
-    def test_late_fail(self):
-        m = mock_manager()
-        m.allocate_subchannel_id = mock.Mock(return_value=0)
-        hostaddr = _WormholeAddress()
-        eq = EventualQueue(Clock())
-        ep = SubchannelConnectorEndpoint(m, hostaddr, eq)
-        ep._main_channel_failed(Failure(CannotDilateError()))
-
-        f = mock.Mock()
-        p = mock.Mock()
-        t = mock.Mock()
-        f.buildProtocol = mock.Mock(return_value=p)
-        with mock.patch("wormhole._dilation.subchannel.SubChannel",
-                        return_value=t) as sc:
-            d = ep.connect(f)
-            eq.flush_sync()
-
-        self.failureResultOf(d).check(CannotDilateError)
-        self.assertEqual(f.buildProtocol.mock_calls, [])
-        self.assertEqual(sc.mock_calls, [])
-        self.assertEqual(t.mock_calls, [])
-
-
-class Listener(unittest.TestCase):
-    def test_early_succeed(self):
-        # listen, main_channel_ready, got_open, got_open
-        m = mock_manager()
-        m.allocate_subchannel_id = mock.Mock(return_value=0)
-        hostaddr = _WormholeAddress()
-        eq = EventualQueue(Clock())
-        ep = SubchannelListenerEndpoint(m, hostaddr, eq)
-
-        f = mock.Mock()
-        p1 = mock.Mock()
-        p2 = mock.Mock()
-        f.buildProtocol = mock.Mock(side_effect=[p1, p2])
-
-        d = ep.listen(f)
-        eq.flush_sync()
-        self.assertNoResult(d)
-        self.assertEqual(f.buildProtocol.mock_calls, [])
-
-        ep._main_channel_ready()
-        eq.flush_sync()
-        lp = self.successResultOf(d)
-        self.assertIsInstance(lp, SubchannelListeningPort)
-
-        self.assertEqual(lp.getHost(), hostaddr)
-        # TODO: IListeningPort says we must provide this, but I don't know
-        # that anyone would ever call it.
-        lp.startListening()
-
-        t1 = mock.Mock()
-        peeraddr1 = _SubchannelAddress(1)
-        ep._got_open(t1, peeraddr1)
-
-        self.assertEqual(t1.mock_calls, [mock.call._set_protocol(p1),
-                                         mock.call._deliver_queued_data()])
-        self.assertEqual(p1.mock_calls, [mock.call.makeConnection(t1)])
-        self.assertEqual(f.buildProtocol.mock_calls, [mock.call(peeraddr1)])
-
-        t2 = mock.Mock()
-        peeraddr2 = _SubchannelAddress(2)
-        ep._got_open(t2, peeraddr2)
-
-        self.assertEqual(t2.mock_calls, [mock.call._set_protocol(p2),
-                                         mock.call._deliver_queued_data()])
-        self.assertEqual(p2.mock_calls, [mock.call.makeConnection(t2)])
-        self.assertEqual(f.buildProtocol.mock_calls, [mock.call(peeraddr1),
-                                                      mock.call(peeraddr2)])
-
-        lp.stopListening()  # TODO: should this do more?
-
-    def test_early_fail(self):
-        # listen, main_channel_fail
-        m = mock_manager()
-        m.allocate_subchannel_id = mock.Mock(return_value=0)
-        hostaddr = _WormholeAddress()
-        eq = EventualQueue(Clock())
-        ep = SubchannelListenerEndpoint(m, hostaddr, eq)
-
-        f = mock.Mock()
-        p1 = mock.Mock()
-        p2 = mock.Mock()
-        f.buildProtocol = mock.Mock(side_effect=[p1, p2])
-
-        d = ep.listen(f)
-        eq.flush_sync()
-        self.assertNoResult(d)
-
-        ep._main_channel_failed(Failure(CannotDilateError()))
-        eq.flush_sync()
-        self.failureResultOf(d).check(CannotDilateError)
-        self.assertEqual(f.buildProtocol.mock_calls, [])
-
-    def test_late_succeed(self):
-        # main_channel_ready, got_open, listen, got_open
-        m = mock_manager()
-        m.allocate_subchannel_id = mock.Mock(return_value=0)
-        hostaddr = _WormholeAddress()
-        eq = EventualQueue(Clock())
-        ep = SubchannelListenerEndpoint(m, hostaddr, eq)
-        ep._main_channel_ready()
-
-        f = mock.Mock()
-        p1 = mock.Mock()
-        p2 = mock.Mock()
-        f.buildProtocol = mock.Mock(side_effect=[p1, p2])
-
-        t1 = mock.Mock()
-        peeraddr1 = _SubchannelAddress(1)
-        ep._got_open(t1, peeraddr1)
         eq.flush_sync()
 
-        self.assertEqual(t1.mock_calls, [])
-        self.assertEqual(p1.mock_calls, [])
+    with pytest.raises(CannotDilateError):
+        await d
+    assert f.buildProtocol.mock_calls == []
+    assert sc.mock_calls == []
+    assert t.mock_calls == []
 
-        d = ep.listen(f)
-        eq.flush_sync()
-        lp = self.successResultOf(d)
-        self.assertIsInstance(lp, SubchannelListeningPort)
-        self.assertEqual(lp.getHost(), hostaddr)
-        lp.startListening()
 
-        # TODO: assert makeConnection is called *before* _deliver_queued_data
-        self.assertEqual(t1.mock_calls, [mock.call._set_protocol(p1),
-                                         mock.call._deliver_queued_data()])
-        self.assertEqual(p1.mock_calls, [mock.call.makeConnection(t1)])
-        self.assertEqual(f.buildProtocol.mock_calls, [mock.call(peeraddr1)])
+@pytest_twisted.ensureDeferred
+async def test_early_succeed():
+    # listen, main_channel_ready, got_open, got_open
+    m = mock_manager()
+    m.allocate_subchannel_id = mock.Mock(return_value=0)
+    hostaddr = _WormholeAddress()
+    eq = EventualQueue(Clock())
+    ep = SubchannelListenerEndpoint(m, hostaddr, eq)
 
-        t2 = mock.Mock()
-        peeraddr2 = _SubchannelAddress(2)
-        ep._got_open(t2, peeraddr2)
+    f = mock.Mock()
+    p1 = mock.Mock()
+    p2 = mock.Mock()
+    f.buildProtocol = mock.Mock(side_effect=[p1, p2])
 
-        self.assertEqual(t2.mock_calls, [mock.call._set_protocol(p2),
-                                         mock.call._deliver_queued_data()])
-        self.assertEqual(p2.mock_calls, [mock.call.makeConnection(t2)])
-        self.assertEqual(f.buildProtocol.mock_calls, [mock.call(peeraddr1),
-                                                      mock.call(peeraddr2)])
+    d = ep.listen(f)
+    eq.flush_sync()
+    assert not d.called
+    assert f.buildProtocol.mock_calls == []
 
-        lp.stopListening()  # TODO: should this do more?
+    ep._main_channel_ready()
+    eq.flush_sync()
+    lp = await d
+    assert isinstance(lp, SubchannelListeningPort)
 
-    def test_late_fail(self):
-        # main_channel_fail, listen
-        m = mock_manager()
-        m.allocate_subchannel_id = mock.Mock(return_value=0)
-        hostaddr = _WormholeAddress()
-        eq = EventualQueue(Clock())
-        ep = SubchannelListenerEndpoint(m, hostaddr, eq)
-        ep._main_channel_failed(Failure(CannotDilateError()))
+    assert lp.getHost() == hostaddr
+    # TODO: IListeningPort says we must provide this, but I don't know
+    # that anyone would ever call it.
+    lp.startListening()
 
-        f = mock.Mock()
-        p1 = mock.Mock()
-        p2 = mock.Mock()
-        f.buildProtocol = mock.Mock(side_effect=[p1, p2])
+    t1 = mock.Mock()
+    peeraddr1 = _SubchannelAddress(1)
+    ep._got_open(t1, peeraddr1)
 
-        d = ep.listen(f)
-        eq.flush_sync()
-        self.failureResultOf(d).check(CannotDilateError)
-        self.assertEqual(f.buildProtocol.mock_calls, [])
+    assert t1.mock_calls == [mock.call._set_protocol(p1),
+                                     mock.call._deliver_queued_data()]
+    assert p1.mock_calls == [mock.call.makeConnection(t1)]
+    assert f.buildProtocol.mock_calls == [mock.call(peeraddr1)]
+
+    t2 = mock.Mock()
+    peeraddr2 = _SubchannelAddress(2)
+    ep._got_open(t2, peeraddr2)
+
+    assert t2.mock_calls == [mock.call._set_protocol(p2),
+                                     mock.call._deliver_queued_data()]
+    assert p2.mock_calls == [mock.call.makeConnection(t2)]
+    assert f.buildProtocol.mock_calls == [mock.call(peeraddr1),
+                                                  mock.call(peeraddr2)]
+
+    lp.stopListening()  # TODO: should this do more?
+
+
+@pytest_twisted.ensureDeferred
+async def test_early_fail():
+    # listen, main_channel_fail
+    m = mock_manager()
+    m.allocate_subchannel_id = mock.Mock(return_value=0)
+    hostaddr = _WormholeAddress()
+    eq = EventualQueue(Clock())
+    ep = SubchannelListenerEndpoint(m, hostaddr, eq)
+
+    f = mock.Mock()
+    p1 = mock.Mock()
+    p2 = mock.Mock()
+    f.buildProtocol = mock.Mock(side_effect=[p1, p2])
+
+    d = ep.listen(f)
+    eq.flush_sync()
+    assert not d.called
+
+    ep._main_channel_failed(Failure(CannotDilateError()))
+    eq.flush_sync()
+    with pytest.raises(CannotDilateError):
+        await d
+    assert f.buildProtocol.mock_calls == []
+
+
+@pytest_twisted.ensureDeferred
+async def test_late_succeed():
+    # main_channel_ready, got_open, listen, got_open
+    m = mock_manager()
+    m.allocate_subchannel_id = mock.Mock(return_value=0)
+    hostaddr = _WormholeAddress()
+    eq = EventualQueue(Clock())
+    ep = SubchannelListenerEndpoint(m, hostaddr, eq)
+    ep._main_channel_ready()
+
+    f = mock.Mock()
+    p1 = mock.Mock()
+    p2 = mock.Mock()
+    f.buildProtocol = mock.Mock(side_effect=[p1, p2])
+
+    t1 = mock.Mock()
+    peeraddr1 = _SubchannelAddress(1)
+    ep._got_open(t1, peeraddr1)
+    eq.flush_sync()
+
+    assert t1.mock_calls == []
+    assert p1.mock_calls == []
+
+    d = ep.listen(f)
+    eq.flush_sync()
+    lp = await d
+    assert isinstance(lp, SubchannelListeningPort)
+    assert lp.getHost() == hostaddr
+    lp.startListening()
+
+    # TODO: assert makeConnection is called *before* _deliver_queued_data
+    assert t1.mock_calls == [mock.call._set_protocol(p1),
+                                     mock.call._deliver_queued_data()]
+    assert p1.mock_calls == [mock.call.makeConnection(t1)]
+    assert f.buildProtocol.mock_calls == [mock.call(peeraddr1)]
+
+    t2 = mock.Mock()
+    peeraddr2 = _SubchannelAddress(2)
+    ep._got_open(t2, peeraddr2)
+
+    assert t2.mock_calls == [mock.call._set_protocol(p2),
+                                     mock.call._deliver_queued_data()]
+    assert p2.mock_calls == [mock.call.makeConnection(t2)]
+    assert f.buildProtocol.mock_calls == [mock.call(peeraddr1),
+                                                  mock.call(peeraddr2)]
+
+    lp.stopListening()  # TODO: should this do more?
+
+
+@pytest_twisted.ensureDeferred
+async def test_late_fail():
+    # main_channel_fail, listen
+    m = mock_manager()
+    m.allocate_subchannel_id = mock.Mock(return_value=0)
+    hostaddr = _WormholeAddress()
+    eq = EventualQueue(Clock())
+    ep = SubchannelListenerEndpoint(m, hostaddr, eq)
+    ep._main_channel_failed(Failure(CannotDilateError()))
+
+    f = mock.Mock()
+    p1 = mock.Mock()
+    p2 = mock.Mock()
+    f.buildProtocol = mock.Mock(side_effect=[p1, p2])
+
+    d = ep.listen(f)
+    eq.flush_sync()
+    with pytest.raises(CannotDilateError):
+        await d
+    assert f.buildProtocol.mock_calls == []

--- a/src/wormhole/test/dilate/test_endpoints.py
+++ b/src/wormhole/test/dilate/test_endpoints.py
@@ -21,7 +21,7 @@ class CannotDilateError(Exception):
 
 
 @pytest_twisted.ensureDeferred
-async def test_early_succeed():
+async def test_control_early_succeed():
     # ep.connect() is called before dilation can proceed
     scid0 = 0
     peeraddr = _SubchannelAddress(scid0)
@@ -52,7 +52,7 @@ async def test_early_succeed():
 
 
 @pytest_twisted.ensureDeferred
-async def test_early_fail():
+async def test_control_early_fail():
     # ep.connect() is called before dilation is abandoned
     scid0 = 0
     peeraddr = _SubchannelAddress(scid0)
@@ -81,7 +81,7 @@ async def test_early_fail():
 
 
 @pytest_twisted.ensureDeferred
-async def test_late_succeed():
+async def test_control_late_succeed():
     # dilation can proceed, then ep.connect() is called
     scid0 = 0
     peeraddr = _SubchannelAddress(scid0)
@@ -110,7 +110,7 @@ async def test_late_succeed():
 
 
 @pytest_twisted.ensureDeferred
-async def test_late_fail():
+async def test_control_late_fail():
     # dilation is abandoned, then ep.connect() is called
     scid0 = 0
     peeraddr = _SubchannelAddress(scid0)
@@ -144,7 +144,7 @@ def OFFassert_makeConnection(mock_calls):
 
 
 @pytest_twisted.ensureDeferred
-async def test_early_succeed():
+async def test_connector_early_succeed():
     m = mock_manager()
     m.allocate_subchannel_id = mock.Mock(return_value=0)
     hostaddr = _WormholeAddress()
@@ -173,7 +173,7 @@ async def test_early_succeed():
 
 
 @pytest_twisted.ensureDeferred
-async def test_early_fail():
+async def test_connector_early_fail():
     m = mock_manager()
     m.allocate_subchannel_id = mock.Mock(return_value=0)
     hostaddr = _WormholeAddress()
@@ -200,7 +200,7 @@ async def test_early_fail():
 
 
 @pytest_twisted.ensureDeferred
-async def test_late_succeed():
+async def test_connector_late_succeed():
     m = mock_manager()
     m.allocate_subchannel_id = mock.Mock(return_value=0)
     hostaddr = _WormholeAddress()
@@ -227,7 +227,7 @@ async def test_late_succeed():
 
 
 @pytest_twisted.ensureDeferred
-async def test_late_fail():
+async def test_connector_late_fail():
     m = mock_manager()
     m.allocate_subchannel_id = mock.Mock(return_value=0)
     hostaddr = _WormholeAddress()
@@ -252,7 +252,7 @@ async def test_late_fail():
 
 
 @pytest_twisted.ensureDeferred
-async def test_early_succeed():
+async def test_listener_early_succeed():
     # listen, main_channel_ready, got_open, got_open
     m = mock_manager()
     m.allocate_subchannel_id = mock.Mock(return_value=0)
@@ -303,7 +303,7 @@ async def test_early_succeed():
 
 
 @pytest_twisted.ensureDeferred
-async def test_early_fail():
+async def test_listener_early_fail():
     # listen, main_channel_fail
     m = mock_manager()
     m.allocate_subchannel_id = mock.Mock(return_value=0)
@@ -328,7 +328,7 @@ async def test_early_fail():
 
 
 @pytest_twisted.ensureDeferred
-async def test_late_succeed():
+async def test_listener_late_succeed():
     # main_channel_ready, got_open, listen, got_open
     m = mock_manager()
     m.allocate_subchannel_id = mock.Mock(return_value=0)
@@ -377,7 +377,7 @@ async def test_late_succeed():
 
 
 @pytest_twisted.ensureDeferred
-async def test_late_fail():
+async def test_listener_late_fail():
     # main_channel_fail, listen
     m = mock_manager()
     m.allocate_subchannel_id = mock.Mock(return_value=0)

--- a/src/wormhole/test/dilate/test_framer.py
+++ b/src/wormhole/test/dilate/test_framer.py
@@ -1,8 +1,8 @@
 from unittest import mock
 from zope.interface import alsoProvides
-from twisted.trial import unittest
 from twisted.internet.interfaces import ITransport
 from ..._dilation.connection import _Framer, Frame, Prologue, Disconnect
+import pytest
 
 
 def make_framer():
@@ -12,100 +12,104 @@ def make_framer():
     return f, t
 
 
-class Framer(unittest.TestCase):
-    def test_bad_prologue_length(self):
-        f, t = make_framer()
-        self.assertEqual(t.mock_calls, [])
+def test_bad_prologue_length():
+    f, t = make_framer()
+    assert t.mock_calls == []
 
-        f.connectionMade()
-        self.assertEqual(t.mock_calls, [mock.call.write(b"outbound_prologue\n")])
-        t.mock_calls[:] = []
-        self.assertEqual([], list(f.add_and_parse(b"inbound_")))  # wait for it
-        self.assertEqual(t.mock_calls, [])
+    f.connectionMade()
+    assert t.mock_calls == [mock.call.write(b"outbound_prologue\n")]
+    t.mock_calls[:] = []
+    assert [] == list(f.add_and_parse(b"inbound_"))  # wait for it
+    assert t.mock_calls == []
 
-        with mock.patch("wormhole._dilation.connection.log.msg") as m:
-            with self.assertRaises(Disconnect):
-                list(f.add_and_parse(b"not the prologue after all"))
-        self.assertEqual(m.mock_calls,
-                         [mock.call("bad prologue: {}".format(
-                             b"inbound_not the p"))])
-        self.assertEqual(t.mock_calls, [])
+    with mock.patch("wormhole._dilation.connection.log.msg") as m:
+        with pytest.raises(Disconnect):
+            list(f.add_and_parse(b"not the prologue after all"))
+    assert m.mock_calls == \
+                     [mock.call("bad prologue: {}".format(
+                         b"inbound_not the p"))]
+    assert t.mock_calls == []
 
-    def test_bad_prologue_newline(self):
-        f, t = make_framer()
-        self.assertEqual(t.mock_calls, [])
 
-        f.connectionMade()
-        self.assertEqual(t.mock_calls, [mock.call.write(b"outbound_prologue\n")])
-        t.mock_calls[:] = []
-        self.assertEqual([], list(f.add_and_parse(b"inbound_")))  # wait for it
+def test_bad_prologue_newline():
+    f, t = make_framer()
+    assert t.mock_calls == []
 
-        self.assertEqual([], list(f.add_and_parse(b"not")))
-        with mock.patch("wormhole._dilation.connection.log.msg") as m:
-            with self.assertRaises(Disconnect):
-                list(f.add_and_parse(b"\n"))
-        self.assertEqual(m.mock_calls,
-                         [mock.call("bad prologue: {}".format(
-                             b"inbound_not\n"))])
-        self.assertEqual(t.mock_calls, [])
+    f.connectionMade()
+    assert t.mock_calls == [mock.call.write(b"outbound_prologue\n")]
+    t.mock_calls[:] = []
+    assert [] == list(f.add_and_parse(b"inbound_"))  # wait for it
 
-    def test_good_prologue(self):
-        f, t = make_framer()
-        self.assertEqual(t.mock_calls, [])
+    assert [] == list(f.add_and_parse(b"not"))
+    with mock.patch("wormhole._dilation.connection.log.msg") as m:
+        with pytest.raises(Disconnect):
+            list(f.add_and_parse(b"\n"))
+    assert m.mock_calls == \
+                     [mock.call("bad prologue: {}".format(
+                         b"inbound_not\n"))]
+    assert t.mock_calls == []
 
-        f.connectionMade()
-        self.assertEqual(t.mock_calls, [mock.call.write(b"outbound_prologue\n")])
-        t.mock_calls[:] = []
-        self.assertEqual([Prologue()],
-                         list(f.add_and_parse(b"inbound_prologue\n")))
-        self.assertEqual(t.mock_calls, [])
 
-        # now send_frame should work
-        f.send_frame(b"frame")
-        self.assertEqual(t.mock_calls,
-                         [mock.call.write(b"\x00\x00\x00\x05frame")])
+def test_good_prologue():
+    f, t = make_framer()
+    assert t.mock_calls == []
 
-    def test_bad_relay(self):
-        f, t = make_framer()
-        self.assertEqual(t.mock_calls, [])
-        f.use_relay(b"relay handshake\n")
+    f.connectionMade()
+    assert t.mock_calls == [mock.call.write(b"outbound_prologue\n")]
+    t.mock_calls[:] = []
+    assert [Prologue()] == \
+                     list(f.add_and_parse(b"inbound_prologue\n"))
+    assert t.mock_calls == []
 
-        f.connectionMade()
-        self.assertEqual(t.mock_calls, [mock.call.write(b"relay handshake\n")])
-        t.mock_calls[:] = []
-        with mock.patch("wormhole._dilation.connection.log.msg") as m:
-            with self.assertRaises(Disconnect):
-                list(f.add_and_parse(b"goodbye\n"))
-        self.assertEqual(m.mock_calls,
-                         [mock.call("bad relay_ok: {}".format(b"goo"))])
-        self.assertEqual(t.mock_calls, [])
+    # now send_frame should work
+    f.send_frame(b"frame")
+    assert t.mock_calls == \
+                     [mock.call.write(b"\x00\x00\x00\x05frame")]
 
-    def test_good_relay(self):
-        f, t = make_framer()
-        self.assertEqual(t.mock_calls, [])
-        f.use_relay(b"relay handshake\n")
-        self.assertEqual(t.mock_calls, [])
 
-        f.connectionMade()
-        self.assertEqual(t.mock_calls, [mock.call.write(b"relay handshake\n")])
-        t.mock_calls[:] = []
+def test_bad_relay():
+    f, t = make_framer()
+    assert t.mock_calls == []
+    f.use_relay(b"relay handshake\n")
 
-        self.assertEqual([], list(f.add_and_parse(b"ok\n")))
-        self.assertEqual(t.mock_calls, [mock.call.write(b"outbound_prologue\n")])
+    f.connectionMade()
+    assert t.mock_calls == [mock.call.write(b"relay handshake\n")]
+    t.mock_calls[:] = []
+    with mock.patch("wormhole._dilation.connection.log.msg") as m:
+        with pytest.raises(Disconnect):
+            list(f.add_and_parse(b"goodbye\n"))
+    assert m.mock_calls == \
+                     [mock.call("bad relay_ok: {}".format(b"goo"))]
+    assert t.mock_calls == []
 
-    def test_frame(self):
-        f, t = make_framer()
-        self.assertEqual(t.mock_calls, [])
 
-        f.connectionMade()
-        self.assertEqual(t.mock_calls, [mock.call.write(b"outbound_prologue\n")])
-        t.mock_calls[:] = []
-        self.assertEqual([Prologue()],
-                         list(f.add_and_parse(b"inbound_prologue\n")))
-        self.assertEqual(t.mock_calls, [])
+def test_good_relay():
+    f, t = make_framer()
+    assert t.mock_calls == []
+    f.use_relay(b"relay handshake\n")
+    assert t.mock_calls == []
 
-        encoded_frame = b"\x00\x00\x00\x05frame"
-        self.assertEqual([], list(f.add_and_parse(encoded_frame[:2])))
-        self.assertEqual([], list(f.add_and_parse(encoded_frame[2:6])))
-        self.assertEqual([Frame(frame=b"frame")],
-                         list(f.add_and_parse(encoded_frame[6:])))
+    f.connectionMade()
+    assert t.mock_calls == [mock.call.write(b"relay handshake\n")]
+    t.mock_calls[:] = []
+
+    assert [] == list(f.add_and_parse(b"ok\n"))
+    assert t.mock_calls == [mock.call.write(b"outbound_prologue\n")]
+
+
+def test_frame():
+    f, t = make_framer()
+    assert t.mock_calls == []
+
+    f.connectionMade()
+    assert t.mock_calls == [mock.call.write(b"outbound_prologue\n")]
+    t.mock_calls[:] = []
+    assert [Prologue()] == \
+                     list(f.add_and_parse(b"inbound_prologue\n"))
+    assert t.mock_calls == []
+
+    encoded_frame = b"\x00\x00\x00\x05frame"
+    assert [] == list(f.add_and_parse(encoded_frame[:2]))
+    assert [] == list(f.add_and_parse(encoded_frame[2:6]))
+    assert [Frame(frame=b"frame")] == \
+                     list(f.add_and_parse(encoded_frame[6:]))

--- a/src/wormhole/test/dilate/test_full.py
+++ b/src/wormhole/test/dilate/test_full.py
@@ -4,7 +4,8 @@ from twisted.internet.defer import Deferred, gatherResults
 from twisted.internet.protocol import Protocol, Factory
 from twisted.trial import unittest
 
-from pytest_twisted import ensureDeferred
+import pytest
+import pytest_twisted
 
 from ..common import ServerBase, poll_until
 from ..._interfaces import IDilationConnector
@@ -31,57 +32,50 @@ class L(Protocol):
         print("connectionLost")
 
 
-class Full(ServerBase, unittest.TestCase):
-    @ensureDeferred()
-    async def setUp(self):
-        if not NoiseConnection:
-            raise unittest.SkipTest("noiseprotocol unavailable")
-        # test_welcome wants to see [current_cli_version]
-        await self._setup_relay(None)
+@pytest_twisted.ensureDeferred()
+@pytest.mark.skipIf(not NoiseConnection)
+async def test_control(reactor, mailbox):
+    eq = EventualQueue(reactor)
+    w1 = wormhole.create(APPID, mailbox.url, reactor, _enable_dilate=True)
+    w2 = wormhole.create(APPID, mailbox.url, reactor, _enable_dilate=True)
+    w1.allocate_code()
+    code = await w1.get_code()
+    print("code is: {}".format(code))
+    w2.set_code(code)
+    await doBoth(w1.get_verifier(), w2.get_verifier())
+    print("connected")
 
-    @ensureDeferred()
-    async def test_control(self):
-        eq = EventualQueue(reactor)
-        w1 = wormhole.create(APPID, self.relayurl, reactor, _enable_dilate=True)
-        w2 = wormhole.create(APPID, self.relayurl, reactor, _enable_dilate=True)
-        w1.allocate_code()
-        code = await w1.get_code()
-        print("code is: {}".format(code))
-        w2.set_code(code)
-        await doBoth(w1.get_verifier(), w2.get_verifier())
-        print("connected")
+    eps1 = w1.dilate()
+    eps2 = w2.dilate()
+    print("w.dilate ready")
 
-        eps1 = w1.dilate()
-        eps2 = w2.dilate()
-        print("w.dilate ready")
+    f1 = Factory()
+    f1.protocol = L
+    f1.d = Deferred()
+    f1.d.addCallback(lambda data: eq.fire_eventually(data))
+    d1 = eps1.control.connect(f1)
 
-        f1 = Factory()
-        f1.protocol = L
-        f1.d = Deferred()
-        f1.d.addCallback(lambda data: eq.fire_eventually(data))
-        d1 = eps1.control.connect(f1)
+    f2 = Factory()
+    f2.protocol = L
+    f2.d = Deferred()
+    f2.d.addCallback(lambda data: eq.fire_eventually(data))
+    d2 = eps2.control.connect(f2)
+    await d1
+    await d2
+    print("control endpoints connected")
+    # note: I'm making some horrible assumptions about one-to-one writes
+    # and reads across a TCP stack that isn't obligated to maintain such
+    # a relationship, but it's much easier than doing this properly. If
+    # the tests ever start failing, do the extra work, probably by
+    # using a twisted.protocols.basic.LineOnlyReceiver
+    data1 = await f1.d
+    data2 = await f2.d
+    assert data1 == b"hello\n"
+    assert data2 == b"hello\n"
 
-        f2 = Factory()
-        f2.protocol = L
-        f2.d = Deferred()
-        f2.d.addCallback(lambda data: eq.fire_eventually(data))
-        d2 = eps2.control.connect(f2)
-        await d1
-        await d2
-        print("control endpoints connected")
-        # note: I'm making some horrible assumptions about one-to-one writes
-        # and reads across a TCP stack that isn't obligated to maintain such
-        # a relationship, but it's much easier than doing this properly. If
-        # the tests ever start failing, do the extra work, probably by
-        # using a twisted.protocols.basic.LineOnlyReceiver
-        data1 = await f1.d
-        data2 = await f2.d
-        self.assertEqual(data1, b"hello\n")
-        self.assertEqual(data2, b"hello\n")
-
-        await w1.close()
-        await w2.close()
-    test_control.timeout = 30
+    await w1.close()
+    await w2.close()
+test_control.timeout = 30
 
 
 class ReconP(Protocol):
@@ -116,231 +110,218 @@ class ReconF(Factory):
         return d
 
 
-class Reconnect(ServerBase, unittest.TestCase):
-    @ensureDeferred()
-    async def setUp(self):
-        if not NoiseConnection:
-            raise unittest.SkipTest("noiseprotocol unavailable")
-        # test_welcome wants to see [current_cli_version]
-        await self._setup_relay(None)
+@pytest_twisted.ensureDeferred()
+@pytest.mark.skipIf(not NoiseConnection)
+async def test_reconnect(reactor, mailbox):
+    eq = EventualQueue(reactor)
+    w1 = wormhole.create(APPID, mailbox.url, reactor, _enable_dilate=True)
+    w2 = wormhole.create(APPID, mailbox.url, reactor, _enable_dilate=True)
+    w1.allocate_code()
+    code = await w1.get_code()
+    w2.set_code(code)
+    await doBoth(w1.get_verifier(), w2.get_verifier())
 
-    @ensureDeferred()
-    async def test_reconnect(self):
-        eq = EventualQueue(reactor)
-        w1 = wormhole.create(APPID, self.relayurl, reactor, _enable_dilate=True)
-        w2 = wormhole.create(APPID, self.relayurl, reactor, _enable_dilate=True)
-        w1.allocate_code()
-        code = await w1.get_code()
-        w2.set_code(code)
-        await doBoth(w1.get_verifier(), w2.get_verifier())
+    eps1 = w1.dilate()
+    eps2 = w2.dilate()
+    print("w.dilate ready")
 
-        eps1 = w1.dilate()
-        eps2 = w2.dilate()
-        print("w.dilate ready")
+    f1, f2 = ReconF(eq), ReconF(eq)
+    d1, d2 = eps1.control.connect(f1), eps2.control.connect(f2)
+    await d1
+    await d2
 
-        f1, f2 = ReconF(eq), ReconF(eq)
-        d1, d2 = eps1.control.connect(f1), eps2.control.connect(f2)
-        await d1
-        await d2
+    protocols = {}
 
-        protocols = {}
+    def p_connected(p, index):
+        protocols[index] = p
+        msg = "hello from %s\n" % index
+        p.transport.write(msg.encode("ascii"))
+    f1.deferreds["connectionMade"].addCallback(p_connected, 1)
+    f2.deferreds["connectionMade"].addCallback(p_connected, 2)
 
-        def p_connected(p, index):
-            protocols[index] = p
-            msg = "hello from %s\n" % index
-            p.transport.write(msg.encode("ascii"))
-        f1.deferreds["connectionMade"].addCallback(p_connected, 1)
-        f2.deferreds["connectionMade"].addCallback(p_connected, 2)
+    data1 = await f1.deferreds["dataReceived"]
+    data2 = await f2.deferreds["dataReceived"]
+    assert data1 == b"hello from 2\n"
+    assert data2 == b"hello from 1\n"
+    # the ACKs are now in flight and may not arrive before we kill the
+    # connection
 
-        data1 = await f1.deferreds["dataReceived"]
-        data2 = await f2.deferreds["dataReceived"]
-        self.assertEqual(data1, b"hello from 2\n")
-        self.assertEqual(data2, b"hello from 1\n")
-        # the ACKs are now in flight and may not arrive before we kill the
-        # connection
+    f1.resetDeferred("connectionMade")
+    f2.resetDeferred("connectionMade")
+    d1 = f1.resetDeferred("dataReceived")
+    d2 = f2.resetDeferred("dataReceived")
 
-        f1.resetDeferred("connectionMade")
-        f2.resetDeferred("connectionMade")
-        d1 = f1.resetDeferred("dataReceived")
-        d2 = f2.resetDeferred("dataReceived")
+    # now we reach inside and drop the connection
+    sc = protocols[1].transport
+    orig_connection = sc._manager._connection
+    orig_connection.disconnect()
 
-        # now we reach inside and drop the connection
-        sc = protocols[1].transport
-        orig_connection = sc._manager._connection
-        orig_connection.disconnect()
+    # stall until the connection has been replaced
+    await poll_until(lambda: sc._manager._connection
+                     and (orig_connection != sc._manager._connection))
 
-        # stall until the connection has been replaced
-        await poll_until(lambda: sc._manager._connection
-                         and (orig_connection != sc._manager._connection))
+    # now write some more data, which should travel over the new
+    # connection
+    protocols[1].transport.write(b"more\n")
+    data2 = await d2
+    assert data2 == b"more\n"
 
-        # now write some more data, which should travel over the new
-        # connection
-        protocols[1].transport.write(b"more\n")
-        data2 = await d2
-        self.assertEqual(data2, b"more\n")
+    replacement_connection = sc._manager._connection
+    assert orig_connection != replacement_connection
 
-        replacement_connection = sc._manager._connection
-        self.assertNotEqual(orig_connection, replacement_connection)
+    # the application-visible Protocol should not observe the
+    # interruption
+    assert not f1.deferreds["connectionMade"].called
+    assert not f2.deferreds["connectionMade"].called
+    assert not f1.deferreds["connectionLost"].called
+    assert not f2.deferreds["connectionLost"].called
 
-        # the application-visible Protocol should not observe the
-        # interruption
-        self.assertNoResult(f1.deferreds["connectionMade"])
-        self.assertNoResult(f2.deferreds["connectionMade"])
-        self.assertNoResult(f1.deferreds["connectionLost"])
-        self.assertNoResult(f2.deferreds["connectionLost"])
+    await w1.close()
+    await w2.close()
 
-        await w1.close()
-        await w2.close()
+@pytest_twisted.ensureDeferred()
+@pytest.mark.skipIf(not NoiseConnection)
+async def test_data_while_offline(reactor, mailbox):
+    eq = EventualQueue(reactor)
+    w1 = wormhole.create(APPID, mailbox.url, reactor, _enable_dilate=True)
+    w2 = wormhole.create(APPID, mailbox.url, reactor, _enable_dilate=True)
+    w1.allocate_code()
+    code = await w1.get_code()
+    w2.set_code(code)
+    await doBoth(w1.get_verifier(), w2.get_verifier())
 
-    @ensureDeferred()
-    async def test_data_while_offline(self):
-        eq = EventualQueue(reactor)
-        w1 = wormhole.create(APPID, self.relayurl, reactor, _enable_dilate=True)
-        w2 = wormhole.create(APPID, self.relayurl, reactor, _enable_dilate=True)
-        w1.allocate_code()
-        code = await w1.get_code()
-        w2.set_code(code)
-        await doBoth(w1.get_verifier(), w2.get_verifier())
+    eps1 = w1.dilate()
+    eps2 = w2.dilate()
+    print("w.dilate ready")
 
-        eps1 = w1.dilate()
-        eps2 = w2.dilate()
-        print("w.dilate ready")
+    f1, f2 = ReconF(eq), ReconF(eq)
+    d1, d2 = eps1.control.connect(f1), eps2.control.connect(f2)
+    await d1
+    await d2
 
-        f1, f2 = ReconF(eq), ReconF(eq)
-        d1, d2 = eps1.control.connect(f1), eps2.control.connect(f2)
-        await d1
-        await d2
+    protocols = {}
 
-        protocols = {}
+    def p_connected(p, index):
+        protocols[index] = p
+        msg = "hello from %s\n" % index
+        p.transport.write(msg.encode("ascii"))
+    f1.deferreds["connectionMade"].addCallback(p_connected, 1)
+    f2.deferreds["connectionMade"].addCallback(p_connected, 2)
 
-        def p_connected(p, index):
-            protocols[index] = p
-            msg = "hello from %s\n" % index
-            p.transport.write(msg.encode("ascii"))
-        f1.deferreds["connectionMade"].addCallback(p_connected, 1)
-        f2.deferreds["connectionMade"].addCallback(p_connected, 2)
+    data1 = await f1.deferreds["dataReceived"]
+    data2 = await f2.deferreds["dataReceived"]
+    assert data1 == b"hello from 2\n"
+    assert data2 == b"hello from 1\n"
+    # the ACKs are now in flight and may not arrive before we kill the
+    # connection
 
-        data1 = await f1.deferreds["dataReceived"]
-        data2 = await f2.deferreds["dataReceived"]
-        self.assertEqual(data1, b"hello from 2\n")
-        self.assertEqual(data2, b"hello from 1\n")
-        # the ACKs are now in flight and may not arrive before we kill the
-        # connection
+    f1.resetDeferred("connectionMade")
+    f2.resetDeferred("connectionMade")
+    d1 = f1.resetDeferred("dataReceived")
+    d2 = f2.resetDeferred("dataReceived")
 
-        f1.resetDeferred("connectionMade")
-        f2.resetDeferred("connectionMade")
-        d1 = f1.resetDeferred("dataReceived")
-        d2 = f2.resetDeferred("dataReceived")
+    # switch off connections
+    assert not w1._boss._D._manager._debug_stall_connector
+    cd1, cd2 = Deferred(), Deferred()
+    w1._boss._D._manager._debug_stall_connector = cd1.callback
+    w2._boss._D._manager._debug_stall_connector = cd2.callback
 
-        # switch off connections
-        assert not w1._boss._D._manager._debug_stall_connector
-        cd1, cd2 = Deferred(), Deferred()
-        w1._boss._D._manager._debug_stall_connector = cd1.callback
-        w2._boss._D._manager._debug_stall_connector = cd2.callback
+    # now we reach inside and drop the connection
+    sc = protocols[1].transport
+    orig_connection = sc._manager._connection
+    orig_connection.disconnect()
 
-        # now we reach inside and drop the connection
-        sc = protocols[1].transport
-        orig_connection = sc._manager._connection
-        orig_connection.disconnect()
+    c1 = await cd1
+    c2 = await cd2
+    assert IDilationConnector.providedBy(c1)
+    assert IDilationConnector.providedBy(c2)
+    assert c1 is not orig_connection
+    w1._boss._D._manager._debug_stall_connector = False
+    w2._boss._D._manager._debug_stall_connector = False
 
-        c1 = await cd1
-        c2 = await cd2
-        assert IDilationConnector.providedBy(c1)
-        assert IDilationConnector.providedBy(c2)
-        assert c1 is not orig_connection
-        w1._boss._D._manager._debug_stall_connector = False
-        w2._boss._D._manager._debug_stall_connector = False
+    # now write some data while the connection is definitely offline
+    protocols[1].transport.write(b"more 1->2\n")
+    protocols[2].transport.write(b"more 2->1\n")
 
-        # now write some data while the connection is definitely offline
-        protocols[1].transport.write(b"more 1->2\n")
-        protocols[2].transport.write(b"more 2->1\n")
+    # allow the connections to proceed
+    c1.start()
+    c2.start()
 
-        # allow the connections to proceed
-        c1.start()
-        c2.start()
+    # and wait for the data to arrive
+    data2 = await d2
+    assert data2 == b"more 1->2\n"
+    data1 = await d1
+    assert data1 == b"more 2->1\n"
 
-        # and wait for the data to arrive
-        data2 = await d2
-        self.assertEqual(data2, b"more 1->2\n")
-        data1 = await d1
-        self.assertEqual(data1, b"more 2->1\n")
+    # the application-visible Protocol should not observe the
+    # interruption
+    assert not f1.deferreds["connectionMade"].called
+    assert not f2.deferreds["connectionMade"].called
+    assert not f1.deferreds["connectionLost"].called
+    assert not f2.deferreds["connectionLost"].called
 
-        # the application-visible Protocol should not observe the
-        # interruption
-        self.assertNoResult(f1.deferreds["connectionMade"])
-        self.assertNoResult(f2.deferreds["connectionMade"])
-        self.assertNoResult(f1.deferreds["connectionLost"])
-        self.assertNoResult(f2.deferreds["connectionLost"])
-
-        await w1.close()
-        await w2.close()
+    await w1.close()
+    await w2.close()
 
 
-class Endpoints(ServerBase, unittest.TestCase):
-    @ensureDeferred()
-    async def setUp(self):
-        if not NoiseConnection:
-            raise unittest.SkipTest("noiseprotocol unavailable")
-        # test_welcome wants to see [current_cli_version]
-        await self._setup_relay(None)
+@pytest_twisted.ensureDeferred()
+@pytest.mark.skipIf(not NoiseConnection)
+async def test_endpoints(reactor, mailbox):
+    eq = EventualQueue(reactor)
+    w1 = wormhole.create(APPID, mailbox.url, reactor, _enable_dilate=True)
+    w2 = wormhole.create(APPID, mailbox.url, reactor, _enable_dilate=True)
+    w1.allocate_code()
+    code = await w1.get_code()
+    w2.set_code(code)
+    await doBoth(w1.get_verifier(), w2.get_verifier())
 
-    @ensureDeferred()
-    async def test_endpoints(self):
-        eq = EventualQueue(reactor)
-        w1 = wormhole.create(APPID, self.relayurl, reactor, _enable_dilate=True)
-        w2 = wormhole.create(APPID, self.relayurl, reactor, _enable_dilate=True)
-        w1.allocate_code()
-        code = await w1.get_code()
-        w2.set_code(code)
-        await doBoth(w1.get_verifier(), w2.get_verifier())
+    eps1 = w1.dilate()
+    eps2 = w2.dilate()
+    print("w.dilate ready")
 
-        eps1 = w1.dilate()
-        eps2 = w2.dilate()
-        print("w.dilate ready")
+    f0 = ReconF(eq)
+    await eps2.listen.listen(f0)
 
-        f0 = ReconF(eq)
-        await eps2.listen.listen(f0)
+    from twisted.python import log
+    f1 = ReconF(eq)
+    log.msg("connecting")
+    p1_client = await eps1.connect.connect(f1)
+    log.msg("sending c->s")
+    p1_client.transport.write(b"hello from p1\n")
+    data = await f0.deferreds["dataReceived"]
+    assert data == b"hello from p1\n"
+    p1_server = await f0.deferreds["connectionMade"]
+    log.msg("sending s->c")
+    p1_server.transport.write(b"hello p1\n")
+    log.msg("waiting for client to receive")
+    data = await f1.deferreds["dataReceived"]
+    assert data == b"hello p1\n"
 
-        from twisted.python import log
-        f1 = ReconF(eq)
-        log.msg("connecting")
-        p1_client = await eps1.connect.connect(f1)
-        log.msg("sending c->s")
-        p1_client.transport.write(b"hello from p1\n")
-        data = await f0.deferreds["dataReceived"]
-        self.assertEqual(data, b"hello from p1\n")
-        p1_server = self.successResultOf(f0.deferreds["connectionMade"])
-        log.msg("sending s->c")
-        p1_server.transport.write(b"hello p1\n")
-        log.msg("waiting for client to receive")
-        data = await f1.deferreds["dataReceived"]
-        self.assertEqual(data, b"hello p1\n")
+    # open a second channel
+    f0.resetDeferred("connectionMade")
+    f0.resetDeferred("dataReceived")
+    f1.resetDeferred("dataReceived")
+    f2 = ReconF(eq)
+    p2_client = await eps1.connect.connect(f2)
+    p2_server = await f0.deferreds["connectionMade"]
+    p2_server.transport.write(b"hello p2\n")
+    data = await f2.deferreds["dataReceived"]
+    assert data == b"hello p2\n"
+    p2_client.transport.write(b"hello from p2\n")
+    data = await f0.deferreds["dataReceived"]
+    assert data == b"hello from p2\n"
+    assert not f1.deferreds["dataReceived"].called
 
-        # open a second channel
-        f0.resetDeferred("connectionMade")
-        f0.resetDeferred("dataReceived")
-        f1.resetDeferred("dataReceived")
-        f2 = ReconF(eq)
-        p2_client = await eps1.connect.connect(f2)
-        p2_server = await f0.deferreds["connectionMade"]
-        p2_server.transport.write(b"hello p2\n")
-        data = await f2.deferreds["dataReceived"]
-        self.assertEqual(data, b"hello p2\n")
-        p2_client.transport.write(b"hello from p2\n")
-        data = await f0.deferreds["dataReceived"]
-        self.assertEqual(data, b"hello from p2\n")
-        self.assertNoResult(f1.deferreds["dataReceived"])
+    # now close the first subchannel (p1) from the listener side
+    p1_server.transport.loseConnection()
+    await f0.deferreds["connectionLost"]
+    await f1.deferreds["connectionLost"]
 
-        # now close the first subchannel (p1) from the listener side
-        p1_server.transport.loseConnection()
-        await f0.deferreds["connectionLost"]
-        await f1.deferreds["connectionLost"]
+    f0.resetDeferred("connectionLost")
+    # and close the second from the connector side
+    p2_client.transport.loseConnection()
+    await f0.deferreds["connectionLost"]
+    await f2.deferreds["connectionLost"]
 
-        f0.resetDeferred("connectionLost")
-        # and close the second from the connector side
-        p2_client.transport.loseConnection()
-        await f0.deferreds["connectionLost"]
-        await f2.deferreds["connectionLost"]
-
-        await w1.close()
-        await w2.close()
+    await w1.close()
+    await w2.close()

--- a/src/wormhole/test/dilate/test_full.py
+++ b/src/wormhole/test/dilate/test_full.py
@@ -1,5 +1,4 @@
 import wormhole
-from twisted.internet import reactor
 from twisted.internet.defer import Deferred, gatherResults
 from twisted.internet.protocol import Protocol, Factory
 

--- a/src/wormhole/test/dilate/test_full.py
+++ b/src/wormhole/test/dilate/test_full.py
@@ -2,7 +2,6 @@ import wormhole
 from twisted.internet import reactor
 from twisted.internet.defer import Deferred, gatherResults
 from twisted.internet.protocol import Protocol, Factory
-from twisted.trial import unittest
 
 import pytest
 import pytest_twisted

--- a/src/wormhole/test/dilate/test_full.py
+++ b/src/wormhole/test/dilate/test_full.py
@@ -7,7 +7,7 @@ from twisted.trial import unittest
 import pytest
 import pytest_twisted
 
-from ..common import ServerBase, poll_until
+from ..common import poll_until
 from ..._interfaces import IDilationConnector
 from ...eventual import EventualQueue
 from ..._dilation._noise import NoiseConnection
@@ -33,7 +33,7 @@ class L(Protocol):
 
 
 @pytest_twisted.ensureDeferred()
-@pytest.mark.skipIf(not NoiseConnection)
+@pytest.mark.skipif(not NoiseConnection, reason="noiseprotocol required")
 async def test_control(reactor, mailbox):
     eq = EventualQueue(reactor)
     w1 = wormhole.create(APPID, mailbox.url, reactor, _enable_dilate=True)
@@ -111,7 +111,7 @@ class ReconF(Factory):
 
 
 @pytest_twisted.ensureDeferred()
-@pytest.mark.skipIf(not NoiseConnection)
+@pytest.mark.skipif(not NoiseConnection, reason="noiseprotocol required")
 async def test_reconnect(reactor, mailbox):
     eq = EventualQueue(reactor)
     w1 = wormhole.create(APPID, mailbox.url, reactor, _enable_dilate=True)
@@ -180,7 +180,7 @@ async def test_reconnect(reactor, mailbox):
     await w2.close()
 
 @pytest_twisted.ensureDeferred()
-@pytest.mark.skipIf(not NoiseConnection)
+@pytest.mark.skipif(not NoiseConnection, reason="noiseprotocol required")
 async def test_data_while_offline(reactor, mailbox):
     eq = EventualQueue(reactor)
     w1 = wormhole.create(APPID, mailbox.url, reactor, _enable_dilate=True)
@@ -265,7 +265,7 @@ async def test_data_while_offline(reactor, mailbox):
 
 
 @pytest_twisted.ensureDeferred()
-@pytest.mark.skipIf(not NoiseConnection)
+@pytest.mark.skipif(not NoiseConnection, reason="noiseprotocol required")
 async def test_endpoints(reactor, mailbox):
     eq = EventualQueue(reactor)
     w1 = wormhole.create(APPID, mailbox.url, reactor, _enable_dilate=True)

--- a/src/wormhole/test/dilate/test_inbound.py
+++ b/src/wormhole/test/dilate/test_inbound.py
@@ -1,6 +1,5 @@
 from unittest import mock
 from zope.interface import alsoProvides
-from twisted.trial import unittest
 from ..._interfaces import IDilationManager
 from ..._dilation.connection import Open, Data, Close
 from ..._dilation.inbound import (Inbound, DuplicateOpenError,
@@ -16,158 +15,160 @@ def make_inbound():
     return i, m, host_addr
 
 
-class InboundTest(unittest.TestCase):
-    def test_seqnum(self):
-        i, m, host_addr = make_inbound()
-        r1 = Open(scid=513, seqnum=1)
-        r2 = Data(scid=513, seqnum=2, data=b"")
-        r3 = Close(scid=513, seqnum=3)
-        self.assertFalse(i.is_record_old(r1))
-        self.assertFalse(i.is_record_old(r2))
-        self.assertFalse(i.is_record_old(r3))
+def test_seqnum():
+    i, m, host_addr = make_inbound()
+    r1 = Open(scid=513, seqnum=1)
+    r2 = Data(scid=513, seqnum=2, data=b"")
+    r3 = Close(scid=513, seqnum=3)
+    assert not i.is_record_old(r1)
+    assert not i.is_record_old(r2)
+    assert not i.is_record_old(r3)
 
-        i.update_ack_watermark(r1.seqnum)
-        self.assertTrue(i.is_record_old(r1))
-        self.assertFalse(i.is_record_old(r2))
-        self.assertFalse(i.is_record_old(r3))
+    i.update_ack_watermark(r1.seqnum)
+    assert i.is_record_old(r1)
+    assert not i.is_record_old(r2)
+    assert not i.is_record_old(r3)
 
-        i.update_ack_watermark(r2.seqnum)
-        self.assertTrue(i.is_record_old(r1))
-        self.assertTrue(i.is_record_old(r2))
-        self.assertFalse(i.is_record_old(r3))
+    i.update_ack_watermark(r2.seqnum)
+    assert i.is_record_old(r1)
+    assert i.is_record_old(r2)
+    assert not i.is_record_old(r3)
 
-    def test_open_data_close(self):
-        i, m, host_addr = make_inbound()
-        scid1 = b"scid"
-        scid2 = b"scXX"
-        c = mock.Mock()
-        lep = mock.Mock()
-        i.set_listener_endpoint(lep)
-        i.use_connection(c)
-        sc1 = mock.Mock()
-        peer_addr = object()
-        with mock.patch("wormhole._dilation.inbound.SubChannel",
-                        side_effect=[sc1]) as sc:
-            with mock.patch("wormhole._dilation.inbound._SubchannelAddress",
-                            side_effect=[peer_addr]) as sca:
-                i.handle_open(scid1)
-        self.assertEqual(lep.mock_calls, [mock.call._got_open(sc1, peer_addr)])
-        self.assertEqual(sc.mock_calls, [mock.call(scid1, m, host_addr, peer_addr)])
-        self.assertEqual(sca.mock_calls, [mock.call(scid1)])
-        lep.mock_calls[:] = []
 
-        # a subsequent duplicate OPEN should be ignored
-        with mock.patch("wormhole._dilation.inbound.SubChannel",
-                        side_effect=[sc1]) as sc:
-            with mock.patch("wormhole._dilation.inbound._SubchannelAddress",
-                            side_effect=[peer_addr]) as sca:
-                i.handle_open(scid1)
-        self.assertEqual(lep.mock_calls, [])
-        self.assertEqual(sc.mock_calls, [])
-        self.assertEqual(sca.mock_calls, [])
-        self.flushLoggedErrors(DuplicateOpenError)
+def test_open_data_close(observe_errors):
+    i, m, host_addr = make_inbound()
+    scid1 = b"scid"
+    scid2 = b"scXX"
+    c = mock.Mock()
+    lep = mock.Mock()
+    i.set_listener_endpoint(lep)
+    i.use_connection(c)
+    sc1 = mock.Mock()
+    peer_addr = object()
+    with mock.patch("wormhole._dilation.inbound.SubChannel",
+                    side_effect=[sc1]) as sc:
+        with mock.patch("wormhole._dilation.inbound._SubchannelAddress",
+                        side_effect=[peer_addr]) as sca:
+            i.handle_open(scid1)
+    assert lep.mock_calls == [mock.call._got_open(sc1, peer_addr)]
+    assert sc.mock_calls == [mock.call(scid1, m, host_addr, peer_addr)]
+    assert sca.mock_calls == [mock.call(scid1)]
+    lep.mock_calls[:] = []
 
-        i.handle_data(scid1, b"data")
-        self.assertEqual(sc1.mock_calls, [mock.call.remote_data(b"data")])
-        sc1.mock_calls[:] = []
+    # a subsequent duplicate OPEN should be ignored
+    with mock.patch("wormhole._dilation.inbound.SubChannel",
+                    side_effect=[sc1]) as sc:
+        with mock.patch("wormhole._dilation.inbound._SubchannelAddress",
+                        side_effect=[peer_addr]) as sca:
+            i.handle_open(scid1)
+    assert lep.mock_calls == []
+    assert sc.mock_calls == []
+    assert sca.mock_calls == []
+    observe_errors.flush(DuplicateOpenError)
 
-        i.handle_data(scid2, b"for non-existent subchannel")
-        self.assertEqual(sc1.mock_calls, [])
-        self.flushLoggedErrors(DataForMissingSubchannelError)
+    i.handle_data(scid1, b"data")
+    assert sc1.mock_calls == [mock.call.remote_data(b"data")]
+    sc1.mock_calls[:] = []
 
-        i.handle_close(scid1)
-        self.assertEqual(sc1.mock_calls, [mock.call.remote_close()])
-        sc1.mock_calls[:] = []
+    i.handle_data(scid2, b"for non-existent subchannel")
+    assert sc1.mock_calls == []
+    observe_errors.flush(DataForMissingSubchannelError)
 
-        i.handle_close(scid2)
-        self.assertEqual(sc1.mock_calls, [])
-        self.flushLoggedErrors(CloseForMissingSubchannelError)
+    i.handle_close(scid1)
+    assert sc1.mock_calls == [mock.call.remote_close()]
+    sc1.mock_calls[:] = []
 
-        # after the subchannel is closed, the Manager will notify Inbound
-        i.subchannel_closed(scid1, sc1)
+    i.handle_close(scid2)
+    assert sc1.mock_calls == []
+    observe_errors.flush(CloseForMissingSubchannelError)
 
-        i.stop_using_connection()
+    # after the subchannel is closed, the Manager will notify Inbound
+    i.subchannel_closed(scid1, sc1)
 
-    def test_control_channel(self):
-        i, m, host_addr = make_inbound()
-        lep = mock.Mock()
-        i.set_listener_endpoint(lep)
+    i.stop_using_connection()
 
-        scid0 = b"scid"
-        sc0 = mock.Mock()
-        i.set_subchannel_zero(scid0, sc0)
 
-        # OPEN on the control channel identifier should be ignored as a
-        # duplicate, since the control channel is already registered
-        sc1 = mock.Mock()
-        peer_addr = object()
-        with mock.patch("wormhole._dilation.inbound.SubChannel",
-                        side_effect=[sc1]) as sc:
-            with mock.patch("wormhole._dilation.inbound._SubchannelAddress",
-                            side_effect=[peer_addr]) as sca:
-                i.handle_open(scid0)
-        self.assertEqual(lep.mock_calls, [])
-        self.assertEqual(sc.mock_calls, [])
-        self.assertEqual(sca.mock_calls, [])
-        self.flushLoggedErrors(DuplicateOpenError)
+def test_control_channel(observe_errors):
+    i, m, host_addr = make_inbound()
+    lep = mock.Mock()
+    i.set_listener_endpoint(lep)
 
-        # and DATA to it should be delivered correctly
-        i.handle_data(scid0, b"data")
-        self.assertEqual(sc0.mock_calls, [mock.call.remote_data(b"data")])
-        sc0.mock_calls[:] = []
+    scid0 = b"scid"
+    sc0 = mock.Mock()
+    i.set_subchannel_zero(scid0, sc0)
 
-    def test_pause(self):
-        i, m, host_addr = make_inbound()
-        c = mock.Mock()
-        lep = mock.Mock()
-        i.set_listener_endpoint(lep)
+    # OPEN on the control channel identifier should be ignored as a
+    # duplicate, since the control channel is already registered
+    sc1 = mock.Mock()
+    peer_addr = object()
+    with mock.patch("wormhole._dilation.inbound.SubChannel",
+                    side_effect=[sc1]) as sc:
+        with mock.patch("wormhole._dilation.inbound._SubchannelAddress",
+                        side_effect=[peer_addr]) as sca:
+            i.handle_open(scid0)
+    assert lep.mock_calls == []
+    assert sc.mock_calls == []
+    assert sca.mock_calls == []
+    observe_errors.flush(DuplicateOpenError)
 
-        # add two subchannels, pause one, then add a connection
-        scid1 = b"sci1"
-        scid2 = b"sci2"
-        sc1 = mock.Mock()
-        sc2 = mock.Mock()
-        peer_addr = object()
-        with mock.patch("wormhole._dilation.inbound.SubChannel",
-                        side_effect=[sc1, sc2]):
-            with mock.patch("wormhole._dilation.inbound._SubchannelAddress",
-                            return_value=peer_addr):
-                i.handle_open(scid1)
-                i.handle_open(scid2)
-        self.assertEqual(c.mock_calls, [])
+    # and DATA to it should be delivered correctly
+    i.handle_data(scid0, b"data")
+    assert sc0.mock_calls == [mock.call.remote_data(b"data")]
+    sc0.mock_calls[:] = []
 
-        i.subchannel_pauseProducing(sc1)
-        self.assertEqual(c.mock_calls, [])
-        i.subchannel_resumeProducing(sc1)
-        self.assertEqual(c.mock_calls, [])
-        i.subchannel_pauseProducing(sc1)
-        self.assertEqual(c.mock_calls, [])
 
-        i.use_connection(c)
-        self.assertEqual(c.mock_calls, [mock.call.pauseProducing()])
-        c.mock_calls[:] = []
+def test_pause():
+    i, m, host_addr = make_inbound()
+    c = mock.Mock()
+    lep = mock.Mock()
+    i.set_listener_endpoint(lep)
 
-        i.subchannel_resumeProducing(sc1)
-        self.assertEqual(c.mock_calls, [mock.call.resumeProducing()])
-        c.mock_calls[:] = []
+    # add two subchannels, pause one, then add a connection
+    scid1 = b"sci1"
+    scid2 = b"sci2"
+    sc1 = mock.Mock()
+    sc2 = mock.Mock()
+    peer_addr = object()
+    with mock.patch("wormhole._dilation.inbound.SubChannel",
+                    side_effect=[sc1, sc2]):
+        with mock.patch("wormhole._dilation.inbound._SubchannelAddress",
+                        return_value=peer_addr):
+            i.handle_open(scid1)
+            i.handle_open(scid2)
+    assert c.mock_calls == []
 
-        # consumers aren't really supposed to do this, but tolerate it
-        i.subchannel_resumeProducing(sc1)
-        self.assertEqual(c.mock_calls, [])
+    i.subchannel_pauseProducing(sc1)
+    assert c.mock_calls == []
+    i.subchannel_resumeProducing(sc1)
+    assert c.mock_calls == []
+    i.subchannel_pauseProducing(sc1)
+    assert c.mock_calls == []
 
-        i.subchannel_pauseProducing(sc1)
-        self.assertEqual(c.mock_calls, [mock.call.pauseProducing()])
-        c.mock_calls[:] = []
-        i.subchannel_pauseProducing(sc2)
-        self.assertEqual(c.mock_calls, [])  # was already paused
+    i.use_connection(c)
+    assert c.mock_calls == [mock.call.pauseProducing()]
+    c.mock_calls[:] = []
 
-        # tolerate duplicate pauseProducing
-        i.subchannel_pauseProducing(sc2)
-        self.assertEqual(c.mock_calls, [])
+    i.subchannel_resumeProducing(sc1)
+    assert c.mock_calls == [mock.call.resumeProducing()]
+    c.mock_calls[:] = []
 
-        # stopProducing is treated like a terminal resumeProducing
-        i.subchannel_stopProducing(sc1)
-        self.assertEqual(c.mock_calls, [])
-        i.subchannel_stopProducing(sc2)
-        self.assertEqual(c.mock_calls, [mock.call.resumeProducing()])
-        c.mock_calls[:] = []
+    # consumers aren't really supposed to do this, but tolerate it
+    i.subchannel_resumeProducing(sc1)
+    assert c.mock_calls == []
+
+    i.subchannel_pauseProducing(sc1)
+    assert c.mock_calls == [mock.call.pauseProducing()]
+    c.mock_calls[:] = []
+    i.subchannel_pauseProducing(sc2)
+    assert c.mock_calls == []  # was already paused
+
+    # tolerate duplicate pauseProducing
+    i.subchannel_pauseProducing(sc2)
+    assert c.mock_calls == []
+
+    # stopProducing is treated like a terminal resumeProducing
+    i.subchannel_stopProducing(sc1)
+    assert c.mock_calls == []
+    i.subchannel_stopProducing(sc2)
+    assert c.mock_calls == [mock.call.resumeProducing()]
+    c.mock_calls[:] = []

--- a/src/wormhole/test/dilate/test_manager.py
+++ b/src/wormhole/test/dilate/test_manager.py
@@ -1,8 +1,10 @@
 from zope.interface import alsoProvides
-from twisted.trial import unittest
 from twisted.internet.task import Clock, Cooperator
 from twisted.internet.interfaces import IStreamServerEndpoint
 from unittest import mock
+import pytest
+import pytest_twisted
+
 from ...eventual import EventualQueue
 from ..._interfaces import ISend, ITerminator, ISubChannel
 from ...util import dict_to_bytes
@@ -42,134 +44,142 @@ def make_dilator():
     return dil, h
 
 
-class TestDilator(unittest.TestCase):
-    # we should test the interleavings between:
-    # * application calls w.dilate() and gets back endpoints
-    # * wormhole gets: dilation key, VERSION, 0-n dilation messages
+# we should test the interleavings between:
+# * application calls w.dilate() and gets back endpoints
+# * wormhole gets: dilation key, VERSION, 0-n dilation messages
 
-    def test_dilate_first(self):
-        (dil, h) = make_dilator()
-        side = object()
-        m = mock.Mock()
-        eps = object()
-        m.get_endpoints = mock.Mock(return_value=eps)
-        mm = mock.Mock(side_effect=[m])
-        with mock.patch("wormhole._dilation.manager.Manager", mm), \
-             mock.patch("wormhole._dilation.manager.make_side",
-                        return_value=side):
-            eps1 = dil.dilate()
-            eps2 = dil.dilate()
-        self.assertIdentical(eps1, eps)
-        self.assertIdentical(eps1, eps2)
-        self.assertEqual(mm.mock_calls, [mock.call(h.send, side, None,
-                                                   h.reactor, h.eq, h.coop, 30.0, False, None, initial_mailbox_status=None)])
 
-        self.assertEqual(m.mock_calls, [mock.call.get_endpoints(),
-                                        mock.call.get_endpoints()])
-        clear_mock_calls(m)
+def test_dilate_first():
+    (dil, h) = make_dilator()
+    side = object()
+    m = mock.Mock()
+    eps = object()
+    m.get_endpoints = mock.Mock(return_value=eps)
+    mm = mock.Mock(side_effect=[m])
+    with mock.patch("wormhole._dilation.manager.Manager", mm), \
+         mock.patch("wormhole._dilation.manager.make_side",
+                    return_value=side):
+        eps1 = dil.dilate()
+        eps2 = dil.dilate()
+    assert eps1 is eps
+    assert eps1 is eps2
+    assert mm.mock_calls == [mock.call(h.send, side, None,
+                                               h.reactor, h.eq, h.coop, 30.0, False, None, initial_mailbox_status=None)]
 
-        key = b"key"
-        transit_key = object()
-        with mock.patch("wormhole._dilation.manager.derive_key",
-                        return_value=transit_key) as dk:
-            dil.got_key(key)
-        self.assertEqual(dk.mock_calls, [mock.call(key, b"dilation-v1", 32)])
-        self.assertEqual(m.mock_calls, [mock.call.got_dilation_key(transit_key)])
-        clear_mock_calls(m)
+    assert m.mock_calls == [mock.call.get_endpoints(),
+                                    mock.call.get_endpoints()]
+    clear_mock_calls(m)
 
-        wv = object()
-        dil.got_wormhole_versions(wv)
-        self.assertEqual(m.mock_calls, [mock.call.got_wormhole_versions(wv)])
-        clear_mock_calls(m)
+    key = b"key"
+    transit_key = object()
+    with mock.patch("wormhole._dilation.manager.derive_key",
+                    return_value=transit_key) as dk:
+        dil.got_key(key)
+    assert dk.mock_calls == [mock.call(key, b"dilation-v1", 32)]
+    assert m.mock_calls == [mock.call.got_dilation_key(transit_key)]
+    clear_mock_calls(m)
 
-        dm1 = object()
-        dm2 = object()
-        dil.received_dilate(dm1)
-        dil.received_dilate(dm2)
-        self.assertEqual(m.mock_calls, [mock.call.received_dilation_message(dm1),
-                                        mock.call.received_dilation_message(dm2),
-                                        ])
-        clear_mock_calls(m)
+    wv = object()
+    dil.got_wormhole_versions(wv)
+    assert m.mock_calls == [mock.call.got_wormhole_versions(wv)]
+    clear_mock_calls(m)
 
-        stopped_d = mock.Mock()
-        m.when_stopped = mock.Mock(return_value=stopped_d)
-        dil.stop()
-        self.assertEqual(m.mock_calls, [mock.call.stop(),
-                                        mock.call.when_stopped(),
-                                        ])
+    dm1 = object()
+    dm2 = object()
+    dil.received_dilate(dm1)
+    dil.received_dilate(dm2)
+    assert m.mock_calls == [mock.call.received_dilation_message(dm1),
+                                    mock.call.received_dilation_message(dm2),
+                                    ]
+    clear_mock_calls(m)
 
-    def test_dilate_later(self):
-        (dil, h) = make_dilator()
-        m = mock.Mock()
-        mm = mock.Mock(side_effect=[m])
+    stopped_d = mock.Mock()
+    m.when_stopped = mock.Mock(return_value=stopped_d)
+    dil.stop()
+    assert m.mock_calls == [mock.call.stop(),
+                                    mock.call.when_stopped(),
+                                    ]
 
-        key = b"key"
-        transit_key = object()
-        with mock.patch("wormhole._dilation.manager.derive_key",
-                        return_value=transit_key) as dk:
-            dil.got_key(key)
-        self.assertEqual(dk.mock_calls, [mock.call(key, b"dilation-v1", 32)])
 
-        wv = object()
-        dil.got_wormhole_versions(wv)
+def test_dilate_later():
+    (dil, h) = make_dilator()
+    m = mock.Mock()
+    mm = mock.Mock(side_effect=[m])
 
-        dm1 = object()
-        dil.received_dilate(dm1)
+    key = b"key"
+    transit_key = object()
+    with mock.patch("wormhole._dilation.manager.derive_key",
+                    return_value=transit_key) as dk:
+        dil.got_key(key)
+    assert dk.mock_calls == [mock.call(key, b"dilation-v1", 32)]
 
-        self.assertEqual(mm.mock_calls, [])
+    wv = object()
+    dil.got_wormhole_versions(wv)
 
-        with mock.patch("wormhole._dilation.manager.Manager", mm):
-            dil.dilate()
-        self.assertEqual(m.mock_calls, [mock.call.got_dilation_key(transit_key),
-                                        mock.call.got_wormhole_versions(wv),
-                                        mock.call.received_dilation_message(dm1),
-                                        mock.call.get_endpoints(),
-                                        ])
-        clear_mock_calls(m)
+    dm1 = object()
+    dil.received_dilate(dm1)
 
-        dm2 = object()
-        dil.received_dilate(dm2)
-        self.assertEqual(m.mock_calls, [mock.call.received_dilation_message(dm2),
-                                        ])
+    assert mm.mock_calls == []
 
-    def test_stop_early(self):
-        (dil, h) = make_dilator()
-        # we stop before w.dilate(), so there is no Manager to stop
-        dil.stop()
-        self.assertEqual(h.terminator.mock_calls, [mock.call.stoppedD()])
+    with mock.patch("wormhole._dilation.manager.Manager", mm):
+        dil.dilate()
+    assert m.mock_calls == [mock.call.got_dilation_key(transit_key),
+                                    mock.call.got_wormhole_versions(wv),
+                                    mock.call.received_dilation_message(dm1),
+                                    mock.call.get_endpoints(),
+                                    ]
+    clear_mock_calls(m)
 
-    def test_peer_cannot_dilate(self):
-        (dil, h) = make_dilator()
-        eps = dil.dilate()
+    dm2 = object()
+    dil.received_dilate(dm2)
+    assert m.mock_calls == [mock.call.received_dilation_message(dm2),
+                                    ]
 
-        dil.got_key(b"\x01" * 32)
-        dil.got_wormhole_versions({})  # missing "can-dilate"
-        d = eps.connect.connect(None)
-        h.eq.flush_sync()
-        self.failureResultOf(d).check(OldPeerCannotDilateError)
+def test_stop_early():
+    (dil, h) = make_dilator()
+    # we stop before w.dilate(), so there is no Manager to stop
+    dil.stop()
+    assert h.terminator.mock_calls == [mock.call.stoppedD()]
 
-    def test_disjoint_versions(self):
-        (dil, h) = make_dilator()
-        eps = dil.dilate()
 
-        dil.got_key(b"\x01" * 32)
-        dil.got_wormhole_versions({"can-dilate": ["-1"]})
-        d = eps.connect.connect(None)
-        h.eq.flush_sync()
-        self.failureResultOf(d).check(OldPeerCannotDilateError)
+@pytest_twisted.ensureDeferred
+async def test_peer_cannot_dilate():
+    (dil, h) = make_dilator()
+    eps = dil.dilate()
 
-    def test_transit_relay(self):
-        (dil, h) = make_dilator()
-        transit_relay_location = object()
-        side = object()
-        m = mock.Mock()
-        mm = mock.Mock(side_effect=[m])
-        with mock.patch("wormhole._dilation.manager.Manager", mm), \
-             mock.patch("wormhole._dilation.manager.make_side",
-                        return_value=side):
-            dil.dilate(transit_relay_location)
-        self.assertEqual(mm.mock_calls, [mock.call(h.send, side, transit_relay_location,
-                                                   h.reactor, h.eq, h.coop, 30.0, False, None, initial_mailbox_status=None)])
+    dil.got_key(b"\x01" * 32)
+    dil.got_wormhole_versions({})  # missing "can-dilate"
+    d = eps.connect.connect(None)
+    h.eq.flush_sync()
+    with pytest.raises(OldPeerCannotDilateError):
+        await d
+
+
+@pytest_twisted.ensureDeferred
+async def test_disjoint_versions():
+    (dil, h) = make_dilator()
+    eps = dil.dilate()
+
+    dil.got_key(b"\x01" * 32)
+    dil.got_wormhole_versions({"can-dilate": ["-1"]})
+    d = eps.connect.connect(None)
+    h.eq.flush_sync()
+    with pytest.raises(OldPeerCannotDilateError):
+        await d
+
+
+def test_transit_relay():
+    (dil, h) = make_dilator()
+    transit_relay_location = object()
+    side = object()
+    m = mock.Mock()
+    mm = mock.Mock(side_effect=[m])
+    with mock.patch("wormhole._dilation.manager.Manager", mm), \
+         mock.patch("wormhole._dilation.manager.make_side",
+                    return_value=side):
+        dil.dilate(transit_relay_location)
+    assert mm.mock_calls == [mock.call(h.send, side, transit_relay_location,
+                                               h.reactor, h.eq, h.coop, 30.0, False, None, initial_mailbox_status=None)]
 
 
 LEADER = "ff3456abcdef"
@@ -230,430 +240,435 @@ def make_manager(leader=True):
     return m, h
 
 
-class TestManager(unittest.TestCase):
-    def test_make_side(self):
-        side = make_side()
-        self.assertEqual(type(side), type(u""))
-        self.assertEqual(len(side), 2 * 8)
+def test_make_side():
+    side = make_side()
+    assert type(side) == type(u"")
+    assert len(side) == 2 * 8
 
-    def test_create(self):
-        m, h = make_manager()
 
-    def test_leader(self):
-        m, h = make_manager(leader=True)
-        self.assertEqual(h.send.mock_calls, [])
-        self.assertEqual(h.Inbound.mock_calls, [mock.call(m, h.hostaddr)])
-        self.assertEqual(h.Outbound.mock_calls, [mock.call(m, h.coop)])
-        scid0 = 0
-        sc0_peer_addr = _SubchannelAddress(scid0)
-        self.assertEqual(h.SubChannel.mock_calls, [
-            mock.call(scid0, m, m._host_addr, sc0_peer_addr),
-            ])
-        self.assertEqual(h.inbound.mock_calls, [
-            mock.call.set_subchannel_zero(scid0, h.sc0),
-            mock.call.set_listener_endpoint(h.listen_ep)
-            ])
-        clear_mock_calls(h.inbound)
+def test_create():
+    m, h = make_manager()
 
-        eps = m.get_endpoints()
-        self.assertTrue(hasattr(eps, "control"))
-        self.assertTrue(hasattr(eps, "connect"))
-        self.assertEqual(eps.listen, h.listen_ep)
 
-        m.got_wormhole_versions({"can-dilate": ["1"]})
-        self.assertEqual(h.send.mock_calls, [
-            mock.call.send("dilate-0",
-                           dict_to_bytes({"type": "please", "side": LEADER, "use-version": "1"}))
-            ])
-        clear_mock_calls(h.send)
+def test_leader():
+    m, h = make_manager(leader=True)
+    assert h.send.mock_calls == []
+    assert h.Inbound.mock_calls == [mock.call(m, h.hostaddr)]
+    assert h.Outbound.mock_calls == [mock.call(m, h.coop)]
+    scid0 = 0
+    sc0_peer_addr = _SubchannelAddress(scid0)
+    assert h.SubChannel.mock_calls == [
+        mock.call(scid0, m, m._host_addr, sc0_peer_addr),
+        ]
+    assert h.inbound.mock_calls == [
+        mock.call.set_subchannel_zero(scid0, h.sc0),
+        mock.call.set_listener_endpoint(h.listen_ep)
+        ]
+    clear_mock_calls(h.inbound)
 
-        # ignore early hints
-        m.rx_HINTS({})
-        self.assertEqual(h.send.mock_calls, [])
+    eps = m.get_endpoints()
+    assert hasattr(eps, "control")
+    assert hasattr(eps, "connect")
+    assert eps.listen == h.listen_ep
 
-        c = mock.Mock()
-        connector = mock.Mock(return_value=c)
-        with mock.patch("wormhole._dilation.manager.Connector", connector):
-            # receiving this PLEASE triggers creation of the Connector
-            m.rx_PLEASE({"side": FOLLOWER})
-        self.assertEqual(h.send.mock_calls, [])
-        self.assertEqual(connector.mock_calls, [
-            mock.call(b"\x00" * 32, None, m, h.reactor, h.eq,
-                      False,  # no_listen
-                      None,  # tor
-                      None,  # timing
-                      LEADER, roles.LEADER),
-            ])
-        self.assertEqual(c.mock_calls, [mock.call.start()])
-        clear_mock_calls(connector, c)
+    m.got_wormhole_versions({"can-dilate": ["1"]})
+    assert h.send.mock_calls == [
+        mock.call.send("dilate-0",
+                       dict_to_bytes({"type": "please", "side": LEADER, "use-version": "1"}))
+        ]
+    clear_mock_calls(h.send)
 
-        # now any inbound hints should get passed to our Connector
-        with mock.patch("wormhole._dilation.manager.parse_hint",
-                        side_effect=["p1", None, "p3"]) as ph:
-            m.rx_HINTS({"hints": [1, 2, 3]})
-        self.assertEqual(ph.mock_calls, [mock.call(1), mock.call(2), mock.call(3)])
-        self.assertEqual(c.mock_calls, [mock.call.got_hints(["p1", "p3"])])
-        clear_mock_calls(ph, c)
+    # ignore early hints
+    m.rx_HINTS({})
+    assert h.send.mock_calls == []
 
-        # and we send out any (listening) hints from our Connector
-        m.send_hints([1, 2])
-        self.assertEqual(h.send.mock_calls, [
-            mock.call.send("dilate-1",
-                           dict_to_bytes({"type": "connection-hints",
-                                          "hints": [1, 2]}))
-            ])
-        clear_mock_calls(h.send)
+    c = mock.Mock()
+    connector = mock.Mock(return_value=c)
+    with mock.patch("wormhole._dilation.manager.Connector", connector):
+        # receiving this PLEASE triggers creation of the Connector
+        m.rx_PLEASE({"side": FOLLOWER})
+    assert h.send.mock_calls == []
+    assert connector.mock_calls == [
+        mock.call(b"\x00" * 32, None, m, h.reactor, h.eq,
+                  False,  # no_listen
+                  None,  # tor
+                  None,  # timing
+                  LEADER, roles.LEADER),
+        ]
+    assert c.mock_calls == [mock.call.start()]
+    clear_mock_calls(connector, c)
 
-        # the first successful connection fires when_first_connected(), so
-        # the endpoints can activate
-        c1 = mock.Mock()
-        m.connector_connection_made(c1)
+    # now any inbound hints should get passed to our Connector
+    with mock.patch("wormhole._dilation.manager.parse_hint",
+                    side_effect=["p1", None, "p3"]) as ph:
+        m.rx_HINTS({"hints": [1, 2, 3]})
+    assert ph.mock_calls == [mock.call(1), mock.call(2), mock.call(3)]
+    assert c.mock_calls == [mock.call.got_hints(["p1", "p3"])]
+    clear_mock_calls(ph, c)
 
-        self.assertEqual(h.inbound.mock_calls, [mock.call.use_connection(c1)])
-        self.assertEqual(h.outbound.mock_calls[1:], [mock.call.use_connection(c1)])
-        clear_mock_calls(h.inbound, h.outbound)
+    # and we send out any (listening) hints from our Connector
+    m.send_hints([1, 2])
+    assert h.send.mock_calls == [
+        mock.call.send("dilate-1",
+                       dict_to_bytes({"type": "connection-hints",
+                                      "hints": [1, 2]}))
+        ]
+    clear_mock_calls(h.send)
 
-        # the Leader making a new outbound channel should get scid=1
-        scid1 = 1
-        self.assertEqual(m.allocate_subchannel_id(), scid1)
-        r1 = Open(10, scid1)  # seqnum=10
-        h.outbound.build_record = mock.Mock(return_value=r1)
-        m.send_open(scid1)
-        self.assertEqual(h.outbound.mock_calls, [
-            mock.call.build_record(Open, scid1),
-            mock.call.queue_and_send_record(r1),
-            ])
-        clear_mock_calls(h.outbound)
+    # the first successful connection fires when_first_connected(), so
+    # the endpoints can activate
+    c1 = mock.Mock()
+    m.connector_connection_made(c1)
 
-        r2 = Data(11, scid1, b"data")
-        h.outbound.build_record = mock.Mock(return_value=r2)
-        m.send_data(scid1, b"data")
-        self.assertEqual(h.outbound.mock_calls, [
-            mock.call.build_record(Data, scid1, b"data"),
-            mock.call.queue_and_send_record(r2),
-            ])
-        clear_mock_calls(h.outbound)
+    assert h.inbound.mock_calls == [mock.call.use_connection(c1)]
+    assert h.outbound.mock_calls[1:] == [mock.call.use_connection(c1)]
+    clear_mock_calls(h.inbound, h.outbound)
 
-        r3 = Close(12, scid1)
-        h.outbound.build_record = mock.Mock(return_value=r3)
-        m.send_close(scid1)
-        self.assertEqual(h.outbound.mock_calls, [
-            mock.call.build_record(Close, scid1),
-            mock.call.queue_and_send_record(r3),
-            ])
-        clear_mock_calls(h.outbound)
+    # the Leader making a new outbound channel should get scid=1
+    scid1 = 1
+    assert m.allocate_subchannel_id() == scid1
+    r1 = Open(10, scid1)  # seqnum=10
+    h.outbound.build_record = mock.Mock(return_value=r1)
+    m.send_open(scid1)
+    assert h.outbound.mock_calls == [
+        mock.call.build_record(Open, scid1),
+        mock.call.queue_and_send_record(r1),
+        ]
+    clear_mock_calls(h.outbound)
 
-        # ack the OPEN
-        m.got_record(Ack(10))
-        self.assertEqual(h.outbound.mock_calls, [
-            mock.call.handle_ack(10)
-            ])
-        clear_mock_calls(h.outbound)
+    r2 = Data(11, scid1, b"data")
+    h.outbound.build_record = mock.Mock(return_value=r2)
+    m.send_data(scid1, b"data")
+    assert h.outbound.mock_calls == [
+        mock.call.build_record(Data, scid1, b"data"),
+        mock.call.queue_and_send_record(r2),
+        ]
+    clear_mock_calls(h.outbound)
 
-        # test that inbound records get acked and routed to Inbound
-        h.inbound.is_record_old = mock.Mock(return_value=False)
-        scid2 = 2
-        o200 = Open(200, scid2)
-        m.got_record(o200)
-        self.assertEqual(h.outbound.mock_calls, [
-            mock.call.send_if_connected(Ack(200))
-            ])
-        self.assertEqual(h.inbound.mock_calls, [
-            mock.call.is_record_old(o200),
-            mock.call.update_ack_watermark(200),
-            mock.call.handle_open(scid2),
-            ])
-        clear_mock_calls(h.outbound, h.inbound)
+    r3 = Close(12, scid1)
+    h.outbound.build_record = mock.Mock(return_value=r3)
+    m.send_close(scid1)
+    assert h.outbound.mock_calls == [
+        mock.call.build_record(Close, scid1),
+        mock.call.queue_and_send_record(r3),
+        ]
+    clear_mock_calls(h.outbound)
 
-        # old (duplicate) records should provoke new Acks, but not get
-        # forwarded
-        h.inbound.is_record_old = mock.Mock(return_value=True)
-        m.got_record(o200)
-        self.assertEqual(h.outbound.mock_calls, [
-            mock.call.send_if_connected(Ack(200))
-            ])
-        self.assertEqual(h.inbound.mock_calls, [
-            mock.call.is_record_old(o200),
-            ])
-        clear_mock_calls(h.outbound, h.inbound)
+    # ack the OPEN
+    m.got_record(Ack(10))
+    assert h.outbound.mock_calls == [
+        mock.call.handle_ack(10)
+        ]
+    clear_mock_calls(h.outbound)
 
-        # check Data and Close too
-        h.inbound.is_record_old = mock.Mock(return_value=False)
-        d201 = Data(201, scid2, b"data")
-        m.got_record(d201)
-        self.assertEqual(h.outbound.mock_calls, [
-            mock.call.send_if_connected(Ack(201))
-            ])
-        self.assertEqual(h.inbound.mock_calls, [
-            mock.call.is_record_old(d201),
-            mock.call.update_ack_watermark(201),
-            mock.call.handle_data(scid2, b"data"),
-            ])
-        clear_mock_calls(h.outbound, h.inbound)
+    # test that inbound records get acked and routed to Inbound
+    h.inbound.is_record_old = mock.Mock(return_value=False)
+    scid2 = 2
+    o200 = Open(200, scid2)
+    m.got_record(o200)
+    assert h.outbound.mock_calls == [
+        mock.call.send_if_connected(Ack(200))
+        ]
+    assert h.inbound.mock_calls == [
+        mock.call.is_record_old(o200),
+        mock.call.update_ack_watermark(200),
+        mock.call.handle_open(scid2),
+        ]
+    clear_mock_calls(h.outbound, h.inbound)
 
-        c202 = Close(202, scid2)
-        m.got_record(c202)
-        self.assertEqual(h.outbound.mock_calls, [
-            mock.call.send_if_connected(Ack(202))
-            ])
-        self.assertEqual(h.inbound.mock_calls, [
-            mock.call.is_record_old(c202),
-            mock.call.update_ack_watermark(202),
-            mock.call.handle_close(scid2),
-            ])
-        clear_mock_calls(h.outbound, h.inbound)
+    # old (duplicate) records should provoke new Acks, but not get
+    # forwarded
+    h.inbound.is_record_old = mock.Mock(return_value=True)
+    m.got_record(o200)
+    assert h.outbound.mock_calls == [
+        mock.call.send_if_connected(Ack(200))
+        ]
+    assert h.inbound.mock_calls == [
+        mock.call.is_record_old(o200),
+        ]
+    clear_mock_calls(h.outbound, h.inbound)
 
-        # Now we lose the connection. The Leader should tell the other side
-        # that we're reconnecting.
+    # check Data and Close too
+    h.inbound.is_record_old = mock.Mock(return_value=False)
+    d201 = Data(201, scid2, b"data")
+    m.got_record(d201)
+    assert h.outbound.mock_calls == [
+        mock.call.send_if_connected(Ack(201))
+        ]
+    assert h.inbound.mock_calls == [
+        mock.call.is_record_old(d201),
+        mock.call.update_ack_watermark(201),
+        mock.call.handle_data(scid2, b"data"),
+        ]
+    clear_mock_calls(h.outbound, h.inbound)
 
-        m.connector_connection_lost()
-        self.assertEqual(h.send.mock_calls, [
-            mock.call.send("dilate-2",
-                           dict_to_bytes({"type": "reconnect"}))
-            ])
-        self.assertEqual(h.inbound.mock_calls, [
-            mock.call.stop_using_connection()
-            ])
-        self.assertEqual(h.outbound.mock_calls, [
-            mock.call.stop_using_connection()
-            ])
-        clear_mock_calls(h.send, h.inbound, h.outbound)
+    c202 = Close(202, scid2)
+    m.got_record(c202)
+    assert h.outbound.mock_calls == [
+        mock.call.send_if_connected(Ack(202))
+        ]
+    assert h.inbound.mock_calls == [
+        mock.call.is_record_old(c202),
+        mock.call.update_ack_watermark(202),
+        mock.call.handle_close(scid2),
+        ]
+    clear_mock_calls(h.outbound, h.inbound)
 
-        # leader does nothing (stays in FLUSHING) until the follower acks by
-        # sending RECONNECTING
+    # Now we lose the connection. The Leader should tell the other side
+    # that we're reconnecting.
 
-        # inbound hints should be ignored during FLUSHING
-        with mock.patch("wormhole._dilation.manager.parse_hint",
-                        return_value=None) as ph:
-            m.rx_HINTS({"hints": [1, 2, 3]})
-        self.assertEqual(ph.mock_calls, [])  # ignored
+    m.connector_connection_lost()
+    assert h.send.mock_calls == [
+        mock.call.send("dilate-2",
+                       dict_to_bytes({"type": "reconnect"}))
+        ]
+    assert h.inbound.mock_calls == [
+        mock.call.stop_using_connection()
+        ]
+    assert h.outbound.mock_calls == [
+        mock.call.stop_using_connection()
+        ]
+    clear_mock_calls(h.send, h.inbound, h.outbound)
 
-        c2 = mock.Mock()
-        connector2 = mock.Mock(return_value=c2)
-        with mock.patch("wormhole._dilation.manager.Connector", connector2):
-            # this triggers creation of a new Connector
-            m.rx_RECONNECTING()
-        self.assertEqual(h.send.mock_calls, [])
-        self.assertEqual(connector2.mock_calls, [
-            mock.call(b"\x00" * 32, None, m, h.reactor, h.eq,
-                      False,  # no_listen
-                      None,  # tor
-                      None,  # timing
-                      LEADER, roles.LEADER),
-            ])
-        self.assertEqual(c2.mock_calls, [mock.call.start()])
-        clear_mock_calls(connector2, c2)
+    # leader does nothing (stays in FLUSHING) until the follower acks by
+    # sending RECONNECTING
 
-        self.assertEqual(h.inbound.mock_calls, [])
-        self.assertEqual(h.outbound.mock_calls, [])
+    # inbound hints should be ignored during FLUSHING
+    with mock.patch("wormhole._dilation.manager.parse_hint",
+                    return_value=None) as ph:
+        m.rx_HINTS({"hints": [1, 2, 3]})
+    assert ph.mock_calls == []  # ignored
 
-        # and a new connection should re-register with Inbound/Outbound,
-        # which are responsible for re-sending unacked queued messages
-        c3 = mock.Mock()
-        m.connector_connection_made(c3)
+    c2 = mock.Mock()
+    connector2 = mock.Mock(return_value=c2)
+    with mock.patch("wormhole._dilation.manager.Connector", connector2):
+        # this triggers creation of a new Connector
+        m.rx_RECONNECTING()
+    assert h.send.mock_calls == []
+    assert connector2.mock_calls == [
+        mock.call(b"\x00" * 32, None, m, h.reactor, h.eq,
+                  False,  # no_listen
+                  None,  # tor
+                  None,  # timing
+                  LEADER, roles.LEADER),
+        ]
+    assert c2.mock_calls == [mock.call.start()]
+    clear_mock_calls(connector2, c2)
 
-        self.assertEqual(h.inbound.mock_calls, [mock.call.use_connection(c3)])
-        self.assertEqual(h.outbound.mock_calls[1:], [mock.call.use_connection(c3)])
-        clear_mock_calls(h.inbound, h.outbound)
+    assert h.inbound.mock_calls == []
+    assert h.outbound.mock_calls == []
 
-    def test_follower(self):
-        m, h = make_manager(leader=False)
+    # and a new connection should re-register with Inbound/Outbound,
+    # which are responsible for re-sending unacked queued messages
+    c3 = mock.Mock()
+    m.connector_connection_made(c3)
 
-        m.got_wormhole_versions({"can-dilate": ["1"]})
-        self.assertEqual(h.send.mock_calls, [
-            mock.call.send("dilate-0",
-                           dict_to_bytes({"type": "please", "side": FOLLOWER, "use-version": "1"}))
-            ])
-        clear_mock_calls(h.send)
-        clear_mock_calls(h.inbound)
+    assert h.inbound.mock_calls == [mock.call.use_connection(c3)]
+    assert h.outbound.mock_calls[1:] == [mock.call.use_connection(c3)]
+    clear_mock_calls(h.inbound, h.outbound)
 
-        c = mock.Mock()
-        connector = mock.Mock(return_value=c)
-        with mock.patch("wormhole._dilation.manager.Connector", connector):
-            # receiving this PLEASE triggers creation of the Connector
-            m.rx_PLEASE({"side": LEADER})
-        self.assertEqual(h.send.mock_calls, [])
-        self.assertEqual(connector.mock_calls, [
-            mock.call(b"\x00" * 32, None, m, h.reactor, h.eq,
-                      False,  # no_listen
-                      None,  # tor
-                      None,  # timing
-                      FOLLOWER, roles.FOLLOWER),
-            ])
-        self.assertEqual(c.mock_calls, [mock.call.start()])
-        clear_mock_calls(connector, c)
 
-        # get connected, then lose the connection
-        c1 = mock.Mock()
-        m.connector_connection_made(c1)
-        self.assertEqual(h.inbound.mock_calls, [mock.call.use_connection(c1)])
-        self.assertEqual(h.outbound.mock_calls, [mock.call.use_connection(c1)])
-        clear_mock_calls(h.inbound, h.outbound)
+def test_follower():
+    m, h = make_manager(leader=False)
 
-        # now lose the connection. As the follower, we don't notify the
-        # leader, we just wait for them to notice
-        m.connector_connection_lost()
-        self.assertEqual(h.send.mock_calls, [])
-        self.assertEqual(h.inbound.mock_calls, [
-            mock.call.stop_using_connection()
-            ])
-        self.assertEqual(h.outbound.mock_calls, [
-            mock.call.stop_using_connection()
-            ])
-        clear_mock_calls(h.send, h.inbound, h.outbound)
+    m.got_wormhole_versions({"can-dilate": ["1"]})
+    assert h.send.mock_calls == [
+        mock.call.send("dilate-0",
+                       dict_to_bytes({"type": "please", "side": FOLLOWER, "use-version": "1"}))
+        ]
+    clear_mock_calls(h.send)
+    clear_mock_calls(h.inbound)
 
-        # now we get a RECONNECT: we should send RECONNECTING
-        c2 = mock.Mock()
-        connector2 = mock.Mock(return_value=c2)
-        with mock.patch("wormhole._dilation.manager.Connector", connector2):
-            m.rx_RECONNECT()
-        self.assertEqual(h.send.mock_calls, [
-            mock.call.send("dilate-1",
-                           dict_to_bytes({"type": "reconnecting"}))
-            ])
-        self.assertEqual(connector2.mock_calls, [
-            mock.call(b"\x00" * 32, None, m, h.reactor, h.eq,
-                      False,  # no_listen
-                      None,  # tor
-                      None,  # timing
-                      FOLLOWER, roles.FOLLOWER),
-            ])
-        self.assertEqual(c2.mock_calls, [mock.call.start()])
-        clear_mock_calls(connector2, c2)
+    c = mock.Mock()
+    connector = mock.Mock(return_value=c)
+    with mock.patch("wormhole._dilation.manager.Connector", connector):
+        # receiving this PLEASE triggers creation of the Connector
+        m.rx_PLEASE({"side": LEADER})
+    assert h.send.mock_calls == []
+    assert connector.mock_calls == [
+        mock.call(b"\x00" * 32, None, m, h.reactor, h.eq,
+                  False,  # no_listen
+                  None,  # tor
+                  None,  # timing
+                  FOLLOWER, roles.FOLLOWER),
+        ]
+    assert c.mock_calls == [mock.call.start()]
+    clear_mock_calls(connector, c)
 
-        # while we're trying to connect, we get told to stop again, so we
-        # should abandon the connection attempt and start another
-        c3 = mock.Mock()
-        connector3 = mock.Mock(return_value=c3)
-        with mock.patch("wormhole._dilation.manager.Connector", connector3):
-            m.rx_RECONNECT()
-        self.assertEqual(c2.mock_calls, [mock.call.stop()])
-        self.assertEqual(connector3.mock_calls, [
-            mock.call(b"\x00" * 32, None, m, h.reactor, h.eq,
-                      False,  # no_listen
-                      None,  # tor
-                      None,  # timing
-                      FOLLOWER, roles.FOLLOWER),
-            ])
-        self.assertEqual(c3.mock_calls, [mock.call.start()])
-        clear_mock_calls(c2, connector3, c3)
+    # get connected, then lose the connection
+    c1 = mock.Mock()
+    m.connector_connection_made(c1)
+    assert h.inbound.mock_calls == [mock.call.use_connection(c1)]
+    assert h.outbound.mock_calls == [mock.call.use_connection(c1)]
+    clear_mock_calls(h.inbound, h.outbound)
 
-        m.connector_connection_made(c3)
-        # finally if we're already connected, rx_RECONNECT means we should
-        # abandon this connection (even though it still looks ok to us), then
-        # when the attempt is finished stopping, we should start another
+    # now lose the connection. As the follower, we don't notify the
+    # leader, we just wait for them to notice
+    m.connector_connection_lost()
+    assert h.send.mock_calls == []
+    assert h.inbound.mock_calls == [
+        mock.call.stop_using_connection()
+        ]
+    assert h.outbound.mock_calls == [
+        mock.call.stop_using_connection()
+        ]
+    clear_mock_calls(h.send, h.inbound, h.outbound)
 
+    # now we get a RECONNECT: we should send RECONNECTING
+    c2 = mock.Mock()
+    connector2 = mock.Mock(return_value=c2)
+    with mock.patch("wormhole._dilation.manager.Connector", connector2):
         m.rx_RECONNECT()
+    assert h.send.mock_calls == [
+        mock.call.send("dilate-1",
+                       dict_to_bytes({"type": "reconnecting"}))
+        ]
+    assert connector2.mock_calls == [
+        mock.call(b"\x00" * 32, None, m, h.reactor, h.eq,
+                  False,  # no_listen
+                  None,  # tor
+                  None,  # timing
+                  FOLLOWER, roles.FOLLOWER),
+        ]
+    assert c2.mock_calls == [mock.call.start()]
+    clear_mock_calls(connector2, c2)
 
-        c4 = mock.Mock()
-        connector4 = mock.Mock(return_value=c4)
-        with mock.patch("wormhole._dilation.manager.Connector", connector4):
-            m.connector_connection_lost()
-        self.assertEqual(c3.mock_calls, [mock.call.disconnect()])
-        self.assertEqual(connector4.mock_calls, [
-            mock.call(b"\x00" * 32, None, m, h.reactor, h.eq,
-                      False,  # no_listen
-                      None,  # tor
-                      None,  # timing
-                      FOLLOWER, roles.FOLLOWER),
-            ])
-        self.assertEqual(c4.mock_calls, [mock.call.start()])
-        clear_mock_calls(c3, connector4, c4)
+    # while we're trying to connect, we get told to stop again, so we
+    # should abandon the connection attempt and start another
+    c3 = mock.Mock()
+    connector3 = mock.Mock(return_value=c3)
+    with mock.patch("wormhole._dilation.manager.Connector", connector3):
+        m.rx_RECONNECT()
+    assert c2.mock_calls == [mock.call.stop()]
+    assert connector3.mock_calls == [
+        mock.call(b"\x00" * 32, None, m, h.reactor, h.eq,
+                  False,  # no_listen
+                  None,  # tor
+                  None,  # timing
+                  FOLLOWER, roles.FOLLOWER),
+        ]
+    assert c3.mock_calls == [mock.call.start()]
+    clear_mock_calls(c2, connector3, c3)
 
-    def test_mirror(self):
-        # receive a PLEASE with the same side as us: shouldn't happen
-        m, h = make_manager(leader=True)
+    m.connector_connection_made(c3)
+    # finally if we're already connected, rx_RECONNECT means we should
+    # abandon this connection (even though it still looks ok to us), then
+    # when the attempt is finished stopping, we should start another
 
-        m.start()
-        clear_mock_calls(h.send)
-        e = self.assertRaises(ValueError, m.rx_PLEASE, {"side": LEADER})
-        self.assertEqual(str(e), "their side shouldn't be equal: reflection?")
+    m.rx_RECONNECT()
 
-    def test_ping_pong(self):
-        m, h = make_manager(leader=False)
-
-        m.got_record(KCM())
-        self.flushLoggedErrors(UnexpectedKCM)
-
-        m.got_record(Ping(1))
-        self.assertEqual(h.outbound.mock_calls,
-                         [mock.call.send_if_connected(Pong(1))])
-        clear_mock_calls(h.outbound)
-
-        m.got_record(Pong(2))
-        # currently ignored, will eventually update a timer
-
-        m.got_record("not recognized")
-        e = self.flushLoggedErrors(UnknownMessageType)
-        self.assertEqual(len(e), 1)
-        self.assertEqual(str(e[0].value), "not recognized")
-
-        m.send_ping(3, lambda _: None)
-        self.assertEqual(h.outbound.mock_calls,
-                         [mock.call.send_if_connected(Pong(3))])
-        clear_mock_calls(h.outbound)
-
-        # sort of low-level; what does this look like to API user?
-        class FakeError(Exception):
-            pass
-
-        def cause_error(_):
-            raise FakeError()
-        m.send_ping(4, cause_error)
-        self.assertEqual(h.outbound.mock_calls,
-                         [mock.call.send_if_connected(Pong(4))])
-        clear_mock_calls(h.outbound)
-        with self.assertRaises(FakeError):
-            m.got_record(Pong(4))
+    c4 = mock.Mock()
+    connector4 = mock.Mock(return_value=c4)
+    with mock.patch("wormhole._dilation.manager.Connector", connector4):
+        m.connector_connection_lost()
+    assert c3.mock_calls == [mock.call.disconnect()]
+    assert connector4.mock_calls == [
+        mock.call(b"\x00" * 32, None, m, h.reactor, h.eq,
+                  False,  # no_listen
+                  None,  # tor
+                  None,  # timing
+                  FOLLOWER, roles.FOLLOWER),
+        ]
+    assert c4.mock_calls == [mock.call.start()]
+    clear_mock_calls(c3, connector4, c4)
 
 
+def test_mirror():
+    # receive a PLEASE with the same side as us: shouldn't happen
+    m, h = make_manager(leader=True)
 
-    def test_subchannel(self):
-        m, h = make_manager(leader=True)
-        clear_mock_calls(h.inbound)
-        sc = object()
+    m.start()
+    clear_mock_calls(h.send)
+    with pytest.raises(ValueError) as f:
+        m.rx_PLEASE({"side": LEADER})
+    assert str(f.value) == "their side shouldn't be equal: reflection?"
 
-        m.subchannel_pauseProducing(sc)
-        self.assertEqual(h.inbound.mock_calls, [
-            mock.call.subchannel_pauseProducing(sc)])
-        clear_mock_calls(h.inbound)
 
-        m.subchannel_resumeProducing(sc)
-        self.assertEqual(h.inbound.mock_calls, [
-            mock.call.subchannel_resumeProducing(sc)])
-        clear_mock_calls(h.inbound)
+def test_ping_pong(observe_errors):
+    m, h = make_manager(leader=False)
 
-        m.subchannel_stopProducing(sc)
-        self.assertEqual(h.inbound.mock_calls, [
-            mock.call.subchannel_stopProducing(sc)])
-        clear_mock_calls(h.inbound)
+    m.got_record(KCM())
+    observe_errors.flush(UnexpectedKCM)
 
-        p = object()
-        streaming = object()
+    m.got_record(Ping(1))
+    assert h.outbound.mock_calls == \
+                     [mock.call.send_if_connected(Pong(1))]
+    clear_mock_calls(h.outbound)
 
-        m.subchannel_registerProducer(sc, p, streaming)
-        self.assertEqual(h.outbound.mock_calls, [
-            mock.call.subchannel_registerProducer(sc, p, streaming)])
-        clear_mock_calls(h.outbound)
+    m.got_record(Pong(2))
+    # currently ignored, will eventually update a timer
 
-        m.subchannel_unregisterProducer(sc)
-        self.assertEqual(h.outbound.mock_calls, [
-            mock.call.subchannel_unregisterProducer(sc)])
-        clear_mock_calls(h.outbound)
+    m.got_record("not recognized")
+    e = observe_errors.flush(UnknownMessageType)
+    assert len(e) == 1
+    assert str(e[0].value) == "not recognized"
 
-        m.subchannel_closed(4, sc)
-        self.assertEqual(h.inbound.mock_calls, [
-            mock.call.subchannel_closed(4, sc)])
-        self.assertEqual(h.outbound.mock_calls, [
-            mock.call.subchannel_closed(4, sc)])
-        clear_mock_calls(h.inbound, h.outbound)
+    m.send_ping(3, lambda _: None)
+    assert h.outbound.mock_calls == \
+                     [mock.call.send_if_connected(Pong(3))]
+    clear_mock_calls(h.outbound)
 
-    def test_unknown_message(self):
-        # receive a PLEASE with the same side as us: shouldn't happen
-        m, h = make_manager(leader=True)
-        m.start()
+    # sort of low-level; what does this look like to API user?
+    class FakeError(Exception):
+        pass
 
-        m.received_dilation_message(dict_to_bytes(dict(type="unknown")))
-        self.flushLoggedErrors(UnknownDilationMessageType)
+    def cause_error(_):
+        raise FakeError()
+    m.send_ping(4, cause_error)
+    assert h.outbound.mock_calls == \
+                     [mock.call.send_if_connected(Pong(4))]
+    clear_mock_calls(h.outbound)
+    with pytest.raises(FakeError):
+        m.got_record(Pong(4))
 
-    # TODO: test transit relay is used
+
+def test_subchannel():
+    m, h = make_manager(leader=True)
+    clear_mock_calls(h.inbound)
+    sc = object()
+
+    m.subchannel_pauseProducing(sc)
+    assert h.inbound.mock_calls == [
+        mock.call.subchannel_pauseProducing(sc)]
+    clear_mock_calls(h.inbound)
+
+    m.subchannel_resumeProducing(sc)
+    assert h.inbound.mock_calls == [
+        mock.call.subchannel_resumeProducing(sc)]
+    clear_mock_calls(h.inbound)
+
+    m.subchannel_stopProducing(sc)
+    assert h.inbound.mock_calls == [
+        mock.call.subchannel_stopProducing(sc)]
+    clear_mock_calls(h.inbound)
+
+    p = object()
+    streaming = object()
+
+    m.subchannel_registerProducer(sc, p, streaming)
+    assert h.outbound.mock_calls == [
+        mock.call.subchannel_registerProducer(sc, p, streaming)]
+    clear_mock_calls(h.outbound)
+
+    m.subchannel_unregisterProducer(sc)
+    assert h.outbound.mock_calls == [
+        mock.call.subchannel_unregisterProducer(sc)]
+    clear_mock_calls(h.outbound)
+
+    m.subchannel_closed(4, sc)
+    assert h.inbound.mock_calls == [
+        mock.call.subchannel_closed(4, sc)]
+    assert h.outbound.mock_calls == [
+        mock.call.subchannel_closed(4, sc)]
+    clear_mock_calls(h.inbound, h.outbound)
+
+
+def test_unknown_message(observe_errors):
+    # receive a PLEASE with the same side as us: shouldn't happen
+    m, h = make_manager(leader=True)
+    m.start()
+
+    m.received_dilation_message(dict_to_bytes(dict(type="unknown")))
+    observe_errors.flush(UnknownDilationMessageType)
+
+# TODO: test transit relay is used

--- a/src/wormhole/test/dilate/test_manager.py
+++ b/src/wormhole/test/dilate/test_manager.py
@@ -242,7 +242,7 @@ def make_manager(leader=True):
 
 def test_make_side():
     side = make_side()
-    assert type(side) == type(u"")
+    assert type(side) is type(u"")
     assert len(side) == 2 * 8
 
 

--- a/src/wormhole/test/dilate/test_outbound.py
+++ b/src/wormhole/test/dilate/test_outbound.py
@@ -2,7 +2,6 @@ from collections import namedtuple
 from itertools import cycle
 from unittest import mock
 from zope.interface import alsoProvides
-from twisted.trial import unittest
 from twisted.internet.task import Clock, Cooperator
 from twisted.internet.interfaces import IPullProducer
 from ...eventual import EventualQueue
@@ -10,6 +9,7 @@ from ..._interfaces import IDilationManager
 from ..._dilation.connection import KCM, Open, Data, Close, Ack
 from ..._dilation.outbound import Outbound, PullToPush
 from .common import clear_mock_calls
+import pytest
 
 Pauser = namedtuple("Pauser", ["seqnum"])
 NonPauser = namedtuple("NonPauser", ["seqnum"])
@@ -41,521 +41,520 @@ def make_outbound():
     return o, m, c
 
 
-class OutboundTest(unittest.TestCase):
-    def test_build_record(self):
-        o, m, c = make_outbound()
-        scid1 = b"scid"
-        self.assertEqual(o.build_record(Open, scid1),
-                         Open(seqnum=0, scid=b"scid"))
-        self.assertEqual(o.build_record(Data, scid1, b"dataaa"),
-                         Data(seqnum=1, scid=b"scid", data=b"dataaa"))
-        self.assertEqual(o.build_record(Close, scid1),
-                         Close(seqnum=2, scid=b"scid"))
-        self.assertEqual(o.build_record(Close, scid1),
-                         Close(seqnum=3, scid=b"scid"))
+def test_build_record():
+    o, m, c = make_outbound()
+    scid1 = b"scid"
+    assert o.build_record(Open, scid1) == \
+                     Open(seqnum=0, scid=b"scid")
+    assert o.build_record(Data, scid1, b"dataaa") == \
+                     Data(seqnum=1, scid=b"scid", data=b"dataaa")
+    assert o.build_record(Close, scid1) == \
+                     Close(seqnum=2, scid=b"scid")
+    assert o.build_record(Close, scid1) == \
+                     Close(seqnum=3, scid=b"scid")
 
-    def test_outbound_queue(self):
-        o, m, c = make_outbound()
-        scid1 = b"scid"
-        r1 = o.build_record(Open, scid1)
-        r2 = o.build_record(Data, scid1, b"data1")
-        r3 = o.build_record(Data, scid1, b"data2")
-        o.queue_and_send_record(r1)
-        o.queue_and_send_record(r2)
-        o.queue_and_send_record(r3)
-        self.assertEqual(list(o._outbound_queue), [r1, r2, r3])
+def test_outbound_queue():
+    o, m, c = make_outbound()
+    scid1 = b"scid"
+    r1 = o.build_record(Open, scid1)
+    r2 = o.build_record(Data, scid1, b"data1")
+    r3 = o.build_record(Data, scid1, b"data2")
+    o.queue_and_send_record(r1)
+    o.queue_and_send_record(r2)
+    o.queue_and_send_record(r3)
+    assert list(o._outbound_queue) == [r1, r2, r3]
 
-        # we would never normally receive an ACK without first getting a
-        # connection
-        o.handle_ack(r2.seqnum)
-        self.assertEqual(list(o._outbound_queue), [r3])
+    # we would never normally receive an ACK without first getting a
+    # connection
+    o.handle_ack(r2.seqnum)
+    assert list(o._outbound_queue) == [r3]
 
-        o.handle_ack(r3.seqnum)
-        self.assertEqual(list(o._outbound_queue), [])
+    o.handle_ack(r3.seqnum)
+    assert list(o._outbound_queue) == []
 
-        o.handle_ack(r3.seqnum)  # ignored
-        self.assertEqual(list(o._outbound_queue), [])
+    o.handle_ack(r3.seqnum)  # ignored
+    assert list(o._outbound_queue) == []
 
-        o.handle_ack(r1.seqnum)  # ignored
-        self.assertEqual(list(o._outbound_queue), [])
+    o.handle_ack(r1.seqnum)  # ignored
+    assert list(o._outbound_queue) == []
 
-    def test_duplicate_registerProducer(self):
-        o, m, c = make_outbound()
-        sc1 = object()
-        p1 = mock.Mock()
+def test_duplicate_registerProducer():
+    o, m, c = make_outbound()
+    sc1 = object()
+    p1 = mock.Mock()
+    o.subchannel_registerProducer(sc1, p1, True)
+    with pytest.raises(ValueError) as ar:
         o.subchannel_registerProducer(sc1, p1, True)
-        with self.assertRaises(ValueError) as ar:
-            o.subchannel_registerProducer(sc1, p1, True)
-        s = str(ar.exception)
-        self.assertIn("registering producer", s)
-        self.assertIn("before previous one", s)
-        self.assertIn("was unregistered", s)
+    s = str(ar.value)
+    assert "registering producer" in s
+    assert "before previous one" in s
+    assert "was unregistered" in s
 
-    def test_connection_send_queued_unpaused(self):
-        o, m, c = make_outbound()
-        scid1 = b"scid"
-        r1 = o.build_record(Open, scid1)
-        r2 = o.build_record(Data, scid1, b"data1")
-        r3 = o.build_record(Data, scid1, b"data2")
-        o.queue_and_send_record(r1)
-        o.queue_and_send_record(r2)
-        self.assertEqual(list(o._outbound_queue), [r1, r2])
-        self.assertEqual(list(o._queued_unsent), [])
+def test_connection_send_queued_unpaused():
+    o, m, c = make_outbound()
+    scid1 = b"scid"
+    r1 = o.build_record(Open, scid1)
+    r2 = o.build_record(Data, scid1, b"data1")
+    r3 = o.build_record(Data, scid1, b"data2")
+    o.queue_and_send_record(r1)
+    o.queue_and_send_record(r2)
+    assert list(o._outbound_queue) == [r1, r2]
+    assert list(o._queued_unsent) == []
 
-        # as soon as the connection is established, everything is sent
-        o.use_connection(c)
-        self.assertEqual(c.mock_calls, [mock.call.transport.registerProducer(o, True),
-                                        mock.call.send_record(r1),
-                                        mock.call.send_record(r2)])
-        self.assertEqual(list(o._outbound_queue), [r1, r2])
-        self.assertEqual(list(o._queued_unsent), [])
-        clear_mock_calls(c)
+    # as soon as the connection is established, everything is sent
+    o.use_connection(c)
+    assert c.mock_calls == [mock.call.transport.registerProducer(o, True),
+                                    mock.call.send_record(r1),
+                                    mock.call.send_record(r2)]
+    assert list(o._outbound_queue) == [r1, r2]
+    assert list(o._queued_unsent) == []
+    clear_mock_calls(c)
 
-        o.queue_and_send_record(r3)
-        self.assertEqual(list(o._outbound_queue), [r1, r2, r3])
-        self.assertEqual(list(o._queued_unsent), [])
-        self.assertEqual(c.mock_calls, [mock.call.send_record(r3)])
+    o.queue_and_send_record(r3)
+    assert list(o._outbound_queue) == [r1, r2, r3]
+    assert list(o._queued_unsent) == []
+    assert c.mock_calls == [mock.call.send_record(r3)]
 
-    def test_connection_send_queued_paused(self):
-        o, m, c = make_outbound()
-        r1 = Pauser(seqnum=1)
-        r2 = Pauser(seqnum=2)
-        r3 = Pauser(seqnum=3)
-        o.queue_and_send_record(r1)
-        o.queue_and_send_record(r2)
-        self.assertEqual(list(o._outbound_queue), [r1, r2])
-        self.assertEqual(list(o._queued_unsent), [])
+def test_connection_send_queued_paused():
+    o, m, c = make_outbound()
+    r1 = Pauser(seqnum=1)
+    r2 = Pauser(seqnum=2)
+    r3 = Pauser(seqnum=3)
+    o.queue_and_send_record(r1)
+    o.queue_and_send_record(r2)
+    assert list(o._outbound_queue) == [r1, r2]
+    assert list(o._queued_unsent) == []
 
-        # pausing=True, so our mock Manager will pause the Outbound producer
-        # after each write. So only r1 should have been sent before getting
-        # paused
-        o.use_connection(c)
-        self.assertEqual(c.mock_calls, [mock.call.transport.registerProducer(o, True),
-                                        mock.call.send_record(r1)])
-        self.assertEqual(list(o._outbound_queue), [r1, r2])
-        self.assertEqual(list(o._queued_unsent), [r2])
-        clear_mock_calls(c)
+    # pausing=True, so our mock Manager will pause the Outbound producer
+    # after each write. So only r1 should have been sent before getting
+    # paused
+    o.use_connection(c)
+    assert c.mock_calls == [mock.call.transport.registerProducer(o, True),
+                                    mock.call.send_record(r1)]
+    assert list(o._outbound_queue) == [r1, r2]
+    assert list(o._queued_unsent) == [r2]
+    clear_mock_calls(c)
 
-        # Outbound is responsible for sending all records, so when Manager
-        # wants to send a new one, and Outbound is still in the middle of
-        # draining the beginning-of-connection queue, the new message gets
-        # queued behind the rest (in addition to being queued in
-        # _outbound_queue until an ACK retires it).
-        o.queue_and_send_record(r3)
-        self.assertEqual(list(o._outbound_queue), [r1, r2, r3])
-        self.assertEqual(list(o._queued_unsent), [r2, r3])
-        self.assertEqual(c.mock_calls, [])
+    # Outbound is responsible for sending all records, so when Manager
+    # wants to send a new one, and Outbound is still in the middle of
+    # draining the beginning-of-connection queue, the new message gets
+    # queued behind the rest (in addition to being queued in
+    # _outbound_queue until an ACK retires it).
+    o.queue_and_send_record(r3)
+    assert list(o._outbound_queue) == [r1, r2, r3]
+    assert list(o._queued_unsent) == [r2, r3]
+    assert c.mock_calls == []
 
-        o.handle_ack(r1.seqnum)
-        self.assertEqual(list(o._outbound_queue), [r2, r3])
-        self.assertEqual(list(o._queued_unsent), [r2, r3])
-        self.assertEqual(c.mock_calls, [])
+    o.handle_ack(r1.seqnum)
+    assert list(o._outbound_queue) == [r2, r3]
+    assert list(o._queued_unsent) == [r2, r3]
+    assert c.mock_calls == []
 
-    def test_premptive_ack(self):
-        # one mode I have in mind is for each side to send an immediate ACK,
-        # with everything they've ever seen, as the very first message on each
-        # new connection. The idea is that you might preempt sending stuff from
-        # the _queued_unsent list if it arrives fast enough (in practice this
-        # is more likely to be delivered via the DILATE mailbox message, but
-        # the effects might be vaguely similar, so it seems worth testing
-        # here). A similar situation would be if each side sends ACKs with the
-        # highest seqnum they've ever seen, instead of merely ACKing the
-        # message which was just received.
-        o, m, c = make_outbound()
-        r1 = Pauser(seqnum=1)
-        r2 = Pauser(seqnum=2)
-        r3 = Pauser(seqnum=3)
-        o.queue_and_send_record(r1)
-        o.queue_and_send_record(r2)
-        self.assertEqual(list(o._outbound_queue), [r1, r2])
-        self.assertEqual(list(o._queued_unsent), [])
+def test_premptive_ack():
+    # one mode I have in mind is for each side to send an immediate ACK,
+    # with everything they've ever seen, as the very first message on each
+    # new connection. The idea is that you might preempt sending stuff from
+    # the _queued_unsent list if it arrives fast enough (in practice this
+    # is more likely to be delivered via the DILATE mailbox message, but
+    # the effects might be vaguely similar, so it seems worth testing
+    # here). A similar situation would be if each side sends ACKs with the
+    # highest seqnum they've ever seen, instead of merely ACKing the
+    # message which was just received.
+    o, m, c = make_outbound()
+    r1 = Pauser(seqnum=1)
+    r2 = Pauser(seqnum=2)
+    r3 = Pauser(seqnum=3)
+    o.queue_and_send_record(r1)
+    o.queue_and_send_record(r2)
+    assert list(o._outbound_queue) == [r1, r2]
+    assert list(o._queued_unsent) == []
 
-        o.use_connection(c)
-        self.assertEqual(c.mock_calls, [mock.call.transport.registerProducer(o, True),
-                                        mock.call.send_record(r1)])
-        self.assertEqual(list(o._outbound_queue), [r1, r2])
-        self.assertEqual(list(o._queued_unsent), [r2])
-        clear_mock_calls(c)
+    o.use_connection(c)
+    assert c.mock_calls == [mock.call.transport.registerProducer(o, True),
+                                    mock.call.send_record(r1)]
+    assert list(o._outbound_queue) == [r1, r2]
+    assert list(o._queued_unsent) == [r2]
+    clear_mock_calls(c)
 
-        o.queue_and_send_record(r3)
-        self.assertEqual(list(o._outbound_queue), [r1, r2, r3])
-        self.assertEqual(list(o._queued_unsent), [r2, r3])
-        self.assertEqual(c.mock_calls, [])
+    o.queue_and_send_record(r3)
+    assert list(o._outbound_queue) == [r1, r2, r3]
+    assert list(o._queued_unsent) == [r2, r3]
+    assert c.mock_calls == []
 
-        o.handle_ack(r2.seqnum)
-        self.assertEqual(list(o._outbound_queue), [r3])
-        self.assertEqual(list(o._queued_unsent), [r3])
-        self.assertEqual(c.mock_calls, [])
+    o.handle_ack(r2.seqnum)
+    assert list(o._outbound_queue) == [r3]
+    assert list(o._queued_unsent) == [r3]
+    assert c.mock_calls == []
 
-    def test_pause(self):
-        o, m, c = make_outbound()
-        o.use_connection(c)
-        self.assertEqual(c.mock_calls, [mock.call.transport.registerProducer(o, True)])
-        self.assertEqual(list(o._outbound_queue), [])
-        self.assertEqual(list(o._queued_unsent), [])
-        clear_mock_calls(c)
+def test_pause():
+    o, m, c = make_outbound()
+    o.use_connection(c)
+    assert c.mock_calls == [mock.call.transport.registerProducer(o, True)]
+    assert list(o._outbound_queue) == []
+    assert list(o._queued_unsent) == []
+    clear_mock_calls(c)
 
-        sc1, sc2, sc3 = object(), object(), object()
-        p1, p2, p3 = mock.Mock(name="p1"), mock.Mock(
-            name="p2"), mock.Mock(name="p3")
+    sc1, sc2, sc3 = object(), object(), object()
+    p1, p2, p3 = mock.Mock(name="p1"), mock.Mock(
+        name="p2"), mock.Mock(name="p3")
 
-        # we aren't paused yet, since we haven't sent any data
-        o.subchannel_registerProducer(sc1, p1, True)
-        self.assertEqual(p1.mock_calls, [])
+    # we aren't paused yet, since we haven't sent any data
+    o.subchannel_registerProducer(sc1, p1, True)
+    assert p1.mock_calls == []
 
-        r1 = Pauser(seqnum=1)
-        o.queue_and_send_record(r1)
-        # now we should be paused
-        self.assertTrue(o._paused)
-        self.assertEqual(c.mock_calls, [mock.call.send_record(r1)])
-        self.assertEqual(p1.mock_calls, [mock.call.pauseProducing()])
-        clear_mock_calls(p1, c)
+    r1 = Pauser(seqnum=1)
+    o.queue_and_send_record(r1)
+    # now we should be paused
+    assert o._paused
+    assert c.mock_calls == [mock.call.send_record(r1)]
+    assert p1.mock_calls == [mock.call.pauseProducing()]
+    clear_mock_calls(p1, c)
 
-        # so an IPushProducer will be paused right away
-        o.subchannel_registerProducer(sc2, p2, True)
-        self.assertEqual(p2.mock_calls, [mock.call.pauseProducing()])
-        clear_mock_calls(p2)
+    # so an IPushProducer will be paused right away
+    o.subchannel_registerProducer(sc2, p2, True)
+    assert p2.mock_calls == [mock.call.pauseProducing()]
+    clear_mock_calls(p2)
 
-        o.subchannel_registerProducer(sc3, p3, True)
-        self.assertEqual(p3.mock_calls, [mock.call.pauseProducing()])
-        self.assertEqual(o._paused_producers, set([p1, p2, p3]))
-        self.assertEqual(list(o._all_producers), [p1, p2, p3])
-        clear_mock_calls(p3)
+    o.subchannel_registerProducer(sc3, p3, True)
+    assert p3.mock_calls == [mock.call.pauseProducing()]
+    assert o._paused_producers == set([p1, p2, p3])
+    assert list(o._all_producers) == [p1, p2, p3]
+    clear_mock_calls(p3)
 
-        # one resumeProducing should cause p1 to get a turn, since p2 was added
-        # after we were paused and p1 was at the "end" of a one-element list.
-        # If it writes anything, it will get paused again immediately.
-        r2 = Pauser(seqnum=2)
-        p1.resumeProducing.side_effect = lambda: c.send_record(r2)
-        o.resumeProducing()
-        self.assertEqual(p1.mock_calls, [mock.call.resumeProducing(),
-                                         mock.call.pauseProducing(),
-                                         ])
-        self.assertEqual(p2.mock_calls, [])
-        self.assertEqual(p3.mock_calls, [])
-        self.assertEqual(c.mock_calls, [mock.call.send_record(r2)])
-        clear_mock_calls(p1, p2, p3, c)
-        # p2 should now be at the head of the queue
-        self.assertEqual(list(o._all_producers), [p2, p3, p1])
+    # one resumeProducing should cause p1 to get a turn, since p2 was added
+    # after we were paused and p1 was at the "end" of a one-element list.
+    # If it writes anything, it will get paused again immediately.
+    r2 = Pauser(seqnum=2)
+    p1.resumeProducing.side_effect = lambda: c.send_record(r2)
+    o.resumeProducing()
+    assert p1.mock_calls == [mock.call.resumeProducing(),
+                                     mock.call.pauseProducing(),
+                                     ]
+    assert p2.mock_calls == []
+    assert p3.mock_calls == []
+    assert c.mock_calls == [mock.call.send_record(r2)]
+    clear_mock_calls(p1, p2, p3, c)
+    # p2 should now be at the head of the queue
+    assert list(o._all_producers) == [p2, p3, p1]
 
-        # next turn: p2 has nothing to send, but p3 does. we should see p3
-        # called but not p1. The actual sequence of expected calls is:
-        # p2.resume, p3.resume, pauseProducing, set(p2.pause, p3.pause)
-        r3 = Pauser(seqnum=3)
-        p2.resumeProducing.side_effect = lambda: None
-        p3.resumeProducing.side_effect = lambda: c.send_record(r3)
-        o.resumeProducing()
-        self.assertEqual(p1.mock_calls, [])
-        self.assertEqual(p2.mock_calls, [mock.call.resumeProducing(),
-                                         mock.call.pauseProducing(),
-                                         ])
-        self.assertEqual(p3.mock_calls, [mock.call.resumeProducing(),
-                                         mock.call.pauseProducing(),
-                                         ])
-        self.assertEqual(c.mock_calls, [mock.call.send_record(r3)])
-        clear_mock_calls(p1, p2, p3, c)
-        # p1 should now be at the head of the queue
-        self.assertEqual(list(o._all_producers), [p1, p2, p3])
+    # next turn: p2 has nothing to send, but p3 does. we should see p3
+    # called but not p1. The actual sequence of expected calls is:
+    # p2.resume, p3.resume, pauseProducing, set(p2.pause, p3.pause)
+    r3 = Pauser(seqnum=3)
+    p2.resumeProducing.side_effect = lambda: None
+    p3.resumeProducing.side_effect = lambda: c.send_record(r3)
+    o.resumeProducing()
+    assert p1.mock_calls == []
+    assert p2.mock_calls == [mock.call.resumeProducing(),
+                                     mock.call.pauseProducing(),
+                                     ]
+    assert p3.mock_calls == [mock.call.resumeProducing(),
+                                     mock.call.pauseProducing(),
+                                     ]
+    assert c.mock_calls == [mock.call.send_record(r3)]
+    clear_mock_calls(p1, p2, p3, c)
+    # p1 should now be at the head of the queue
+    assert list(o._all_producers) == [p1, p2, p3]
 
-        # next turn: p1 has data to send, but not enough to cause a pause. same
-        # for p2. p3 causes a pause
-        r4 = NonPauser(seqnum=4)
-        r5 = NonPauser(seqnum=5)
-        r6 = Pauser(seqnum=6)
-        p1.resumeProducing.side_effect = lambda: c.send_record(r4)
-        p2.resumeProducing.side_effect = lambda: c.send_record(r5)
-        p3.resumeProducing.side_effect = lambda: c.send_record(r6)
-        o.resumeProducing()
-        self.assertEqual(p1.mock_calls, [mock.call.resumeProducing(),
-                                         mock.call.pauseProducing(),
-                                         ])
-        self.assertEqual(p2.mock_calls, [mock.call.resumeProducing(),
-                                         mock.call.pauseProducing(),
-                                         ])
-        self.assertEqual(p3.mock_calls, [mock.call.resumeProducing(),
-                                         mock.call.pauseProducing(),
-                                         ])
-        self.assertEqual(c.mock_calls, [mock.call.send_record(r4),
-                                        mock.call.send_record(r5),
-                                        mock.call.send_record(r6),
-                                        ])
-        clear_mock_calls(p1, p2, p3, c)
-        # p1 should now be at the head of the queue again
-        self.assertEqual(list(o._all_producers), [p1, p2, p3])
+    # next turn: p1 has data to send, but not enough to cause a pause. same
+    # for p2. p3 causes a pause
+    r4 = NonPauser(seqnum=4)
+    r5 = NonPauser(seqnum=5)
+    r6 = Pauser(seqnum=6)
+    p1.resumeProducing.side_effect = lambda: c.send_record(r4)
+    p2.resumeProducing.side_effect = lambda: c.send_record(r5)
+    p3.resumeProducing.side_effect = lambda: c.send_record(r6)
+    o.resumeProducing()
+    assert p1.mock_calls == [mock.call.resumeProducing(),
+                                     mock.call.pauseProducing(),
+                                     ]
+    assert p2.mock_calls == [mock.call.resumeProducing(),
+                                     mock.call.pauseProducing(),
+                                     ]
+    assert p3.mock_calls == [mock.call.resumeProducing(),
+                                     mock.call.pauseProducing(),
+                                     ]
+    assert c.mock_calls == [mock.call.send_record(r4),
+                                    mock.call.send_record(r5),
+                                    mock.call.send_record(r6),
+                                    ]
+    clear_mock_calls(p1, p2, p3, c)
+    # p1 should now be at the head of the queue again
+    assert list(o._all_producers) == [p1, p2, p3]
 
-        # now we let it catch up. p1 and p2 send non-pausing data, p3 sends
-        # nothing.
-        r7 = NonPauser(seqnum=4)
-        r8 = NonPauser(seqnum=5)
-        p1.resumeProducing.side_effect = lambda: c.send_record(r7)
-        p2.resumeProducing.side_effect = lambda: c.send_record(r8)
-        p3.resumeProducing.side_effect = lambda: None
+    # now we let it catch up. p1 and p2 send non-pausing data, p3 sends
+    # nothing.
+    r7 = NonPauser(seqnum=4)
+    r8 = NonPauser(seqnum=5)
+    p1.resumeProducing.side_effect = lambda: c.send_record(r7)
+    p2.resumeProducing.side_effect = lambda: c.send_record(r8)
+    p3.resumeProducing.side_effect = lambda: None
 
-        o.resumeProducing()
-        self.assertEqual(p1.mock_calls, [mock.call.resumeProducing(),
-                                         ])
-        self.assertEqual(p2.mock_calls, [mock.call.resumeProducing(),
-                                         ])
-        self.assertEqual(p3.mock_calls, [mock.call.resumeProducing(),
-                                         ])
-        self.assertEqual(c.mock_calls, [mock.call.send_record(r7),
-                                        mock.call.send_record(r8),
-                                        ])
-        clear_mock_calls(p1, p2, p3, c)
-        # p1 should now be at the head of the queue again
-        self.assertEqual(list(o._all_producers), [p1, p2, p3])
-        self.assertFalse(o._paused)
+    o.resumeProducing()
+    assert p1.mock_calls == [mock.call.resumeProducing(),
+                                     ]
+    assert p2.mock_calls == [mock.call.resumeProducing(),
+                                     ]
+    assert p3.mock_calls == [mock.call.resumeProducing(),
+                                     ]
+    assert c.mock_calls == [mock.call.send_record(r7),
+                                    mock.call.send_record(r8),
+                                    ]
+    clear_mock_calls(p1, p2, p3, c)
+    # p1 should now be at the head of the queue again
+    assert list(o._all_producers) == [p1, p2, p3]
+    assert not o._paused
 
-        # now a producer disconnects itself (spontaneously, not from inside a
-        # resumeProducing)
-        o.subchannel_unregisterProducer(sc1)
-        self.assertEqual(list(o._all_producers), [p2, p3])
-        self.assertEqual(p1.mock_calls, [])
-        self.assertFalse(o._paused)
+    # now a producer disconnects itself (spontaneously, not from inside a
+    # resumeProducing)
+    o.subchannel_unregisterProducer(sc1)
+    assert list(o._all_producers) == [p2, p3]
+    assert p1.mock_calls == []
+    assert not o._paused
 
-        # and another disconnects itself when called
-        p2.resumeProducing.side_effect = lambda: None
-        p3.resumeProducing.side_effect = lambda: o.subchannel_unregisterProducer(
-            sc3)
-        o.pauseProducing()
-        o.resumeProducing()
-        self.assertEqual(p2.mock_calls, [mock.call.pauseProducing(),
-                                         mock.call.resumeProducing()])
-        self.assertEqual(p3.mock_calls, [mock.call.pauseProducing(),
-                                         mock.call.resumeProducing()])
-        clear_mock_calls(p2, p3)
-        self.assertEqual(list(o._all_producers), [p2])
-        self.assertFalse(o._paused)
+    # and another disconnects itself when called
+    p2.resumeProducing.side_effect = lambda: None
+    p3.resumeProducing.side_effect = lambda: o.subchannel_unregisterProducer(
+        sc3)
+    o.pauseProducing()
+    o.resumeProducing()
+    assert p2.mock_calls == [mock.call.pauseProducing(),
+                                     mock.call.resumeProducing()]
+    assert p3.mock_calls == [mock.call.pauseProducing(),
+                                     mock.call.resumeProducing()]
+    clear_mock_calls(p2, p3)
+    assert list(o._all_producers) == [p2]
+    assert not o._paused
 
-    def test_subchannel_closed(self):
-        o, m, c = make_outbound()
+def test_subchannel_closed():
+    o, m, c = make_outbound()
 
-        sc1 = mock.Mock()
-        p1 = mock.Mock(name="p1")
-        o.subchannel_registerProducer(sc1, p1, True)
-        self.assertEqual(p1.mock_calls, [mock.call.pauseProducing()])
-        clear_mock_calls(p1)
+    sc1 = mock.Mock()
+    p1 = mock.Mock(name="p1")
+    o.subchannel_registerProducer(sc1, p1, True)
+    assert p1.mock_calls == [mock.call.pauseProducing()]
+    clear_mock_calls(p1)
 
-        o.subchannel_closed(1, sc1)
-        self.assertEqual(p1.mock_calls, [])
-        self.assertEqual(list(o._all_producers), [])
+    o.subchannel_closed(1, sc1)
+    assert p1.mock_calls == []
+    assert list(o._all_producers) == []
 
-        sc2 = mock.Mock()
-        o.subchannel_closed(2, sc2)
+    sc2 = mock.Mock()
+    o.subchannel_closed(2, sc2)
 
-    def test_disconnect(self):
-        o, m, c = make_outbound()
-        o.use_connection(c)
+def test_disconnect():
+    o, m, c = make_outbound()
+    o.use_connection(c)
 
-        sc1 = mock.Mock()
-        p1 = mock.Mock(name="p1")
-        o.subchannel_registerProducer(sc1, p1, True)
-        self.assertEqual(p1.mock_calls, [])
-        o.stop_using_connection()
-        self.assertEqual(p1.mock_calls, [mock.call.pauseProducing()])
+    sc1 = mock.Mock()
+    p1 = mock.Mock(name="p1")
+    o.subchannel_registerProducer(sc1, p1, True)
+    assert p1.mock_calls == []
+    o.stop_using_connection()
+    assert p1.mock_calls == [mock.call.pauseProducing()]
 
-    def OFF_test_push_pull(self):
-        # use one IPushProducer and one IPullProducer. They should take turns
-        o, m, c = make_outbound()
-        o.use_connection(c)
-        clear_mock_calls(c)
+def OFF_test_push_pull(self):
+    # use one IPushProducer and one IPullProducer. They should take turns
+    o, m, c = make_outbound()
+    o.use_connection(c)
+    clear_mock_calls(c)
 
-        sc1, sc2 = object(), object()
-        p1, p2 = mock.Mock(name="p1"), mock.Mock(name="p2")
-        r1 = Pauser(seqnum=1)
-        r2 = NonPauser(seqnum=2)
+    sc1, sc2 = object(), object()
+    p1, p2 = mock.Mock(name="p1"), mock.Mock(name="p2")
+    r1 = Pauser(seqnum=1)
+    r2 = NonPauser(seqnum=2)
 
-        # we aren't paused yet, since we haven't sent any data
-        o.subchannel_registerProducer(sc1, p1, True)  # push
-        o.queue_and_send_record(r1)
-        # now we're paused
-        self.assertTrue(o._paused)
-        self.assertEqual(c.mock_calls, [mock.call.send_record(r1)])
-        self.assertEqual(p1.mock_calls, [mock.call.pauseProducing()])
-        self.assertEqual(p2.mock_calls, [])
-        clear_mock_calls(p1, p2, c)
+    # we aren't paused yet, since we haven't sent any data
+    o.subchannel_registerProducer(sc1, p1, True)  # push
+    o.queue_and_send_record(r1)
+    # now we're paused
+    assert o._paused
+    assert c.mock_calls == [mock.call.send_record(r1)]
+    assert p1.mock_calls == [mock.call.pauseProducing()]
+    assert p2.mock_calls == []
+    clear_mock_calls(p1, p2, c)
 
-        p1.resumeProducing.side_effect = lambda: c.send_record(r1)
-        p2.resumeProducing.side_effect = lambda: c.send_record(r2)
-        o.subchannel_registerProducer(sc2, p2, False)  # pull: always ready
+    p1.resumeProducing.side_effect = lambda: c.send_record(r1)
+    p2.resumeProducing.side_effect = lambda: c.send_record(r2)
+    o.subchannel_registerProducer(sc2, p2, False)  # pull: always ready
 
-        # p1 is still first, since p2 was just added (at the end)
-        self.assertTrue(o._paused)
-        self.assertEqual(c.mock_calls, [])
-        self.assertEqual(p1.mock_calls, [])
-        self.assertEqual(p2.mock_calls, [])
-        self.assertEqual(list(o._all_producers), [p1, p2])
-        clear_mock_calls(p1, p2, c)
+    # p1 is still first, since p2 was just added (at the end)
+    assert o._paused
+    assert c.mock_calls == []
+    assert p1.mock_calls == []
+    assert p2.mock_calls == []
+    assert list(o._all_producers) == [p1, p2]
+    clear_mock_calls(p1, p2, c)
 
-        # resume should send r1, which should pause everything
-        o.resumeProducing()
-        self.assertTrue(o._paused)
-        self.assertEqual(c.mock_calls, [mock.call.send_record(r1),
-                                        ])
-        self.assertEqual(p1.mock_calls, [mock.call.resumeProducing(),
-                                         mock.call.pauseProducing(),
-                                         ])
-        self.assertEqual(p2.mock_calls, [])
-        self.assertEqual(list(o._all_producers), [p2, p1])  # now p2 is next
-        clear_mock_calls(p1, p2, c)
+    # resume should send r1, which should pause everything
+    o.resumeProducing()
+    assert o._paused
+    assert c.mock_calls == [mock.call.send_record(r1),
+                                    ]
+    assert p1.mock_calls == [mock.call.resumeProducing(),
+                                     mock.call.pauseProducing(),
+                                     ]
+    assert p2.mock_calls == []
+    assert list(o._all_producers) == [p2, p1]  # now p2 is next
+    clear_mock_calls(p1, p2, c)
 
-        # next should fire p2, then p1
-        o.resumeProducing()
-        self.assertTrue(o._paused)
-        self.assertEqual(c.mock_calls, [mock.call.send_record(r2),
-                                        mock.call.send_record(r1),
-                                        ])
-        self.assertEqual(p1.mock_calls, [mock.call.resumeProducing(),
-                                         mock.call.pauseProducing(),
-                                         ])
-        self.assertEqual(p2.mock_calls, [mock.call.resumeProducing(),
-                                         ])
-        self.assertEqual(list(o._all_producers), [p2, p1])  # p2 still at bat
-        clear_mock_calls(p1, p2, c)
+    # next should fire p2, then p1
+    o.resumeProducing()
+    assert o._paused
+    assert c.mock_calls == [mock.call.send_record(r2),
+                                    mock.call.send_record(r1),
+                                    ]
+    assert p1.mock_calls == [mock.call.resumeProducing(),
+                                     mock.call.pauseProducing(),
+                                     ]
+    assert p2.mock_calls == [mock.call.resumeProducing(),
+                                     ]
+    assert list(o._all_producers) == [p2, p1]  # p2 still at bat
+    clear_mock_calls(p1, p2, c)
 
-    def test_pull_producer(self):
-        # a single pull producer should write until it is paused, rate-limited
-        # by the cooperator (so we'll see back-to-back resumeProducing calls
-        # until the Connection is paused, or 10ms have passed, whichever comes
-        # first, and if it's stopped by the timer, then the next EventualQueue
-        # turn will start it off again)
+def test_pull_producer():
+    # a single pull producer should write until it is paused, rate-limited
+    # by the cooperator (so we'll see back-to-back resumeProducing calls
+    # until the Connection is paused, or 10ms have passed, whichever comes
+    # first, and if it's stopped by the timer, then the next EventualQueue
+    # turn will start it off again)
 
-        o, m, c = make_outbound()
-        eq = o._test_eq
-        o.use_connection(c)
-        clear_mock_calls(c)
-        self.assertFalse(o._paused)
+    o, m, c = make_outbound()
+    eq = o._test_eq
+    o.use_connection(c)
+    clear_mock_calls(c)
+    assert not o._paused
 
-        sc1 = mock.Mock()
-        p1 = mock.Mock(name="p1")
-        alsoProvides(p1, IPullProducer)
+    sc1 = mock.Mock()
+    p1 = mock.Mock(name="p1")
+    alsoProvides(p1, IPullProducer)
 
-        records = [NonPauser(seqnum=1)] * 10
-        records.append(Pauser(seqnum=2))
-        records.append(Stopper(sc1))
-        it = iter(records)
-        p1.resumeProducing.side_effect = lambda: c.send_record(next(it))
-        o.subchannel_registerProducer(sc1, p1, False)
-        eq.flush_sync()  # fast forward into the glorious (paused) future
+    records = [NonPauser(seqnum=1)] * 10
+    records.append(Pauser(seqnum=2))
+    records.append(Stopper(sc1))
+    it = iter(records)
+    p1.resumeProducing.side_effect = lambda: c.send_record(next(it))
+    o.subchannel_registerProducer(sc1, p1, False)
+    eq.flush_sync()  # fast forward into the glorious (paused) future
 
-        self.assertTrue(o._paused)
-        self.assertEqual(c.mock_calls,
-                         [mock.call.send_record(r) for r in records[:-1]])
-        self.assertEqual(p1.mock_calls,
-                         [mock.call.resumeProducing()] * (len(records) - 1))
-        clear_mock_calls(c, p1)
+    assert o._paused
+    assert c.mock_calls == \
+                     [mock.call.send_record(r) for r in records[:-1]]
+    assert p1.mock_calls == \
+                     [mock.call.resumeProducing()] * (len(records) - 1)
+    clear_mock_calls(c, p1)
 
-        # next resumeProducing should cause it to disconnect
-        o.resumeProducing()
-        eq.flush_sync()
-        self.assertEqual(c.mock_calls, [mock.call.send_record(records[-1])])
-        self.assertEqual(p1.mock_calls, [mock.call.resumeProducing()])
-        self.assertEqual(len(o._all_producers), 0)
-        self.assertFalse(o._paused)
+    # next resumeProducing should cause it to disconnect
+    o.resumeProducing()
+    eq.flush_sync()
+    assert c.mock_calls == [mock.call.send_record(records[-1])]
+    assert p1.mock_calls == [mock.call.resumeProducing()]
+    assert len(o._all_producers) == 0
+    assert not o._paused
 
-    def test_two_pull_producers(self):
-        # we should alternate between them until paused
-        p1_records = ([NonPauser(seqnum=i) for i in range(5)] +
-                      [Pauser(seqnum=5)] +
-                      [NonPauser(seqnum=i) for i in range(6, 10)])
-        p2_records = ([NonPauser(seqnum=i) for i in range(10, 19)] +
-                      [Pauser(seqnum=19)])
-        expected1 = [NonPauser(0), NonPauser(10),
-                     NonPauser(1), NonPauser(11),
-                     NonPauser(2), NonPauser(12),
-                     NonPauser(3), NonPauser(13),
-                     NonPauser(4), NonPauser(14),
-                     Pauser(5)]
-        expected2 = [NonPauser(15),
-                     NonPauser(6), NonPauser(16),
-                     NonPauser(7), NonPauser(17),
-                     NonPauser(8), NonPauser(18),
-                     NonPauser(9), Pauser(19),
-                     ]
+def test_two_pull_producers():
+    # we should alternate between them until paused
+    p1_records = ([NonPauser(seqnum=i) for i in range(5)] +
+                  [Pauser(seqnum=5)] +
+                  [NonPauser(seqnum=i) for i in range(6, 10)])
+    p2_records = ([NonPauser(seqnum=i) for i in range(10, 19)] +
+                  [Pauser(seqnum=19)])
+    expected1 = [NonPauser(0), NonPauser(10),
+                 NonPauser(1), NonPauser(11),
+                 NonPauser(2), NonPauser(12),
+                 NonPauser(3), NonPauser(13),
+                 NonPauser(4), NonPauser(14),
+                 Pauser(5)]
+    expected2 = [NonPauser(15),
+                 NonPauser(6), NonPauser(16),
+                 NonPauser(7), NonPauser(17),
+                 NonPauser(8), NonPauser(18),
+                 NonPauser(9), Pauser(19),
+                 ]
 
-        o, m, c = make_outbound()
-        eq = o._test_eq
-        o.use_connection(c)
-        clear_mock_calls(c)
-        self.assertFalse(o._paused)
+    o, m, c = make_outbound()
+    eq = o._test_eq
+    o.use_connection(c)
+    clear_mock_calls(c)
+    assert not o._paused
 
-        sc1 = mock.Mock()
-        p1 = mock.Mock(name="p1")
-        alsoProvides(p1, IPullProducer)
-        it1 = iter(p1_records)
-        p1.resumeProducing.side_effect = lambda: c.send_record(next(it1))
-        o.subchannel_registerProducer(sc1, p1, False)
+    sc1 = mock.Mock()
+    p1 = mock.Mock(name="p1")
+    alsoProvides(p1, IPullProducer)
+    it1 = iter(p1_records)
+    p1.resumeProducing.side_effect = lambda: c.send_record(next(it1))
+    o.subchannel_registerProducer(sc1, p1, False)
 
-        sc2 = mock.Mock()
-        p2 = mock.Mock(name="p2")
-        alsoProvides(p2, IPullProducer)
-        it2 = iter(p2_records)
-        p2.resumeProducing.side_effect = lambda: c.send_record(next(it2))
-        o.subchannel_registerProducer(sc2, p2, False)
+    sc2 = mock.Mock()
+    p2 = mock.Mock(name="p2")
+    alsoProvides(p2, IPullProducer)
+    it2 = iter(p2_records)
+    p2.resumeProducing.side_effect = lambda: c.send_record(next(it2))
+    o.subchannel_registerProducer(sc2, p2, False)
 
-        eq.flush_sync()  # fast forward into the glorious (paused) future
+    eq.flush_sync()  # fast forward into the glorious (paused) future
 
-        sends = [mock.call.resumeProducing()]
-        self.assertTrue(o._paused)
-        self.assertEqual(c.mock_calls,
-                         [mock.call.send_record(r) for r in expected1])
-        self.assertEqual(p1.mock_calls, 6 * sends)
-        self.assertEqual(p2.mock_calls, 5 * sends)
-        clear_mock_calls(c, p1, p2)
+    sends = [mock.call.resumeProducing()]
+    assert o._paused
+    assert c.mock_calls == \
+                     [mock.call.send_record(r) for r in expected1]
+    assert p1.mock_calls == 6 * sends
+    assert p2.mock_calls == 5 * sends
+    clear_mock_calls(c, p1, p2)
 
-        o.resumeProducing()
-        eq.flush_sync()
-        self.assertTrue(o._paused)
-        self.assertEqual(c.mock_calls,
-                         [mock.call.send_record(r) for r in expected2])
-        self.assertEqual(p1.mock_calls, 4 * sends)
-        self.assertEqual(p2.mock_calls, 5 * sends)
-        clear_mock_calls(c, p1, p2)
+    o.resumeProducing()
+    eq.flush_sync()
+    assert o._paused
+    assert c.mock_calls == \
+                     [mock.call.send_record(r) for r in expected2]
+    assert p1.mock_calls == 4 * sends
+    assert p2.mock_calls == 5 * sends
+    clear_mock_calls(c, p1, p2)
 
-    def test_send_if_connected(self):
-        o, m, c = make_outbound()
-        o.send_if_connected(Ack(1))  # not connected yet
+def test_send_if_connected():
+    o, m, c = make_outbound()
+    o.send_if_connected(Ack(1))  # not connected yet
 
-        o.use_connection(c)
-        o.send_if_connected(KCM())
-        self.assertEqual(c.mock_calls, [mock.call.transport.registerProducer(o, True),
-                                        mock.call.send_record(KCM())])
+    o.use_connection(c)
+    o.send_if_connected(KCM())
+    assert c.mock_calls == [mock.call.transport.registerProducer(o, True),
+                                    mock.call.send_record(KCM())]
 
-    def test_tolerate_duplicate_pause_resume(self):
-        o, m, c = make_outbound()
-        self.assertTrue(o._paused)  # no connection
-        o.use_connection(c)
-        self.assertFalse(o._paused)
-        o.pauseProducing()
-        self.assertTrue(o._paused)
-        o.pauseProducing()
-        self.assertTrue(o._paused)
-        o.resumeProducing()
-        self.assertFalse(o._paused)
-        o.resumeProducing()
-        self.assertFalse(o._paused)
+def test_tolerate_duplicate_pause_resume():
+    o, m, c = make_outbound()
+    assert o._paused  # no connection
+    o.use_connection(c)
+    assert not o._paused
+    o.pauseProducing()
+    assert o._paused
+    o.pauseProducing()
+    assert o._paused
+    o.resumeProducing()
+    assert not o._paused
+    o.resumeProducing()
+    assert not o._paused
 
-    def test_stopProducing(self):
-        o, m, c = make_outbound()
-        o.use_connection(c)
-        self.assertFalse(o._paused)
-        o.stopProducing()  # connection does this before loss
-        self.assertTrue(o._paused)
-        o.stop_using_connection()
-        self.assertTrue(o._paused)
+def test_stopProducing():
+    o, m, c = make_outbound()
+    o.use_connection(c)
+    assert not o._paused
+    o.stopProducing()  # connection does this before loss
+    assert o._paused
+    o.stop_using_connection()
+    assert o._paused
 
-    def test_resume_error(self):
-        o, m, c = make_outbound()
-        o.use_connection(c)
-        sc1 = mock.Mock()
-        p1 = mock.Mock(name="p1")
-        alsoProvides(p1, IPullProducer)
-        p1.resumeProducing.side_effect = PretendResumptionError
-        o.subchannel_registerProducer(sc1, p1, False)
-        o._test_eq.flush_sync()
-        # the error is supposed to automatically unregister the producer
-        self.assertEqual(list(o._all_producers), [])
-        self.flushLoggedErrors(PretendResumptionError)
+def test_resume_error(observe_errors):
+    o, m, c = make_outbound()
+    o.use_connection(c)
+    sc1 = mock.Mock()
+    p1 = mock.Mock(name="p1")
+    alsoProvides(p1, IPullProducer)
+    p1.resumeProducing.side_effect = PretendResumptionError
+    o.subchannel_registerProducer(sc1, p1, False)
+    o._test_eq.flush_sync()
+    # the error is supposed to automatically unregister the producer
+    assert list(o._all_producers) == []
+    observe_errors.flush(PretendResumptionError)
 
 
 def make_pushpull(pauses):
@@ -592,63 +591,62 @@ class PretendUnregisterError(Exception):
     pass
 
 
-class PushPull(unittest.TestCase):
-    # test our wrapper utility, which I copied from
-    # twisted.internet._producer_helpers since it isn't publicly exposed
+def test_start_unpaused():
+    p, unr, pp, eq = make_pushpull([True])  # pause on each resumeProducing
+    # if it starts unpaused, it gets one write before being halted
+    pp.startStreaming(False)
+    eq.flush_sync()
+    assert p.mock_calls == [mock.call.resumeProducing()] * 1
+    clear_mock_calls(p)
 
-    def test_start_unpaused(self):
-        p, unr, pp, eq = make_pushpull([True])  # pause on each resumeProducing
-        # if it starts unpaused, it gets one write before being halted
-        pp.startStreaming(False)
-        eq.flush_sync()
-        self.assertEqual(p.mock_calls, [mock.call.resumeProducing()] * 1)
-        clear_mock_calls(p)
+    # now each time we call resumeProducing, we should see one delivered to
+    # the underlying IPullProducer
+    pp.resumeProducing()
+    eq.flush_sync()
+    assert p.mock_calls == [mock.call.resumeProducing()] * 1
 
-        # now each time we call resumeProducing, we should see one delivered to
-        # the underlying IPullProducer
-        pp.resumeProducing()
-        eq.flush_sync()
-        self.assertEqual(p.mock_calls, [mock.call.resumeProducing()] * 1)
+    pp.stopStreaming()
+    pp.stopStreaming()  # should tolerate this
 
-        pp.stopStreaming()
-        pp.stopStreaming()  # should tolerate this
+def test_start_unpaused_two_writes():
+    p, unr, pp, eq = make_pushpull([False, True])  # pause every other time
+    # it should get two writes, since the first didn't pause
+    pp.startStreaming(False)
+    eq.flush_sync()
+    assert p.mock_calls == [mock.call.resumeProducing()] * 2
 
-    def test_start_unpaused_two_writes(self):
-        p, unr, pp, eq = make_pushpull([False, True])  # pause every other time
-        # it should get two writes, since the first didn't pause
-        pp.startStreaming(False)
-        eq.flush_sync()
-        self.assertEqual(p.mock_calls, [mock.call.resumeProducing()] * 2)
+def test_start_paused():
+    p, unr, pp, eq = make_pushpull([True])  # pause on each resumeProducing
+    pp.startStreaming(True)
+    eq.flush_sync()
+    assert p.mock_calls == []
+    pp.stopStreaming()
 
-    def test_start_paused(self):
-        p, unr, pp, eq = make_pushpull([True])  # pause on each resumeProducing
-        pp.startStreaming(True)
-        eq.flush_sync()
-        self.assertEqual(p.mock_calls, [])
-        pp.stopStreaming()
+def test_stop():
+    p, unr, pp, eq = make_pushpull([True])
+    pp.startStreaming(True)
+    pp.stopProducing()
+    eq.flush_sync()
+    assert p.mock_calls == [mock.call.stopProducing()]
 
-    def test_stop(self):
-        p, unr, pp, eq = make_pushpull([True])
-        pp.startStreaming(True)
-        pp.stopProducing()
-        eq.flush_sync()
-        self.assertEqual(p.mock_calls, [mock.call.stopProducing()])
 
-    def test_error(self):
-        p, unr, pp, eq = make_pushpull([PretendResumptionError()])
-        unr.side_effect = lambda: pp.stopStreaming()
-        pp.startStreaming(False)
-        eq.flush_sync()
-        self.assertEqual(unr.mock_calls, [mock.call()])
-        self.flushLoggedErrors(PretendResumptionError)
+def test_error(observe_errors):
+    p, unr, pp, eq = make_pushpull([PretendResumptionError()])
+    unr.side_effect = lambda: pp.stopStreaming()
+    pp.startStreaming(False)
+    eq.flush_sync()
+    assert unr.mock_calls == [mock.call()]
+    observe_errors.flush(PretendResumptionError)
 
-    def test_error_during_unregister(self):
-        p, unr, pp, eq = make_pushpull([PretendResumptionError()])
-        unr.side_effect = PretendUnregisterError()
-        pp.startStreaming(False)
-        eq.flush_sync()
-        self.assertEqual(unr.mock_calls, [mock.call()])
-        self.flushLoggedErrors(PretendResumptionError, PretendUnregisterError)
 
-        # TODO: consider making p1/p2/p3 all elements of a shared Mock, maybe I
-        # could capture the inter-call ordering that way
+def test_error_during_unregister(observe_errors):
+    p, unr, pp, eq = make_pushpull([PretendResumptionError()])
+    unr.side_effect = PretendUnregisterError()
+    pp.startStreaming(False)
+    eq.flush_sync()
+    assert unr.mock_calls == [mock.call()]
+    observe_errors.flush(PretendResumptionError)
+    observe_errors.flush(PretendUnregisterError)
+
+    # TODO: consider making p1/p2/p3 all elements of a shared Mock, maybe I
+    # could capture the inter-call ordering that way

--- a/src/wormhole/test/dilate/test_parse.py
+++ b/src/wormhole/test/dilate/test_parse.py
@@ -1,43 +1,43 @@
 from unittest import mock
-from twisted.trial import unittest
 from ..._dilation.connection import (parse_record, encode_record,
                                      KCM, Ping, Pong, Open, Data, Close, Ack)
+import pytest
 
 
-class Parse(unittest.TestCase):
-    def test_parse(self):
-        self.assertEqual(parse_record(b"\x00"), KCM())
-        self.assertEqual(parse_record(b"\x01\x55\x44\x33\x22"),
-                         Ping(ping_id=b"\x55\x44\x33\x22"))
-        self.assertEqual(parse_record(b"\x02\x55\x44\x33\x22"),
-                         Pong(ping_id=b"\x55\x44\x33\x22"))
-        self.assertEqual(parse_record(b"\x03\x00\x00\x02\x01\x00\x00\x01\x00"),
-                         Open(scid=513, seqnum=256))
-        self.assertEqual(parse_record(b"\x04\x00\x00\x02\x02\x00\x00\x01\x01dataaa"),
-                         Data(scid=514, seqnum=257, data=b"dataaa"))
-        self.assertEqual(parse_record(b"\x05\x00\x00\x02\x03\x00\x00\x01\x02"),
-                         Close(scid=515, seqnum=258))
-        self.assertEqual(parse_record(b"\x06\x00\x00\x01\x03"),
-                         Ack(resp_seqnum=259))
-        with mock.patch("wormhole._dilation.connection.log.err") as le:
-            with self.assertRaises(ValueError):
-                parse_record(b"\x07unknown")
-        self.assertEqual(le.mock_calls,
-                         [mock.call("received unknown message type: {}".format(
-                             b"\x07unknown"))])
+def test_parse():
+    assert parse_record(b"\x00") == KCM()
+    assert parse_record(b"\x01\x55\x44\x33\x22") == \
+                     Ping(ping_id=b"\x55\x44\x33\x22")
+    assert parse_record(b"\x02\x55\x44\x33\x22") == \
+                     Pong(ping_id=b"\x55\x44\x33\x22")
+    assert parse_record(b"\x03\x00\x00\x02\x01\x00\x00\x01\x00") == \
+                     Open(scid=513, seqnum=256)
+    assert parse_record(b"\x04\x00\x00\x02\x02\x00\x00\x01\x01dataaa") == \
+                     Data(scid=514, seqnum=257, data=b"dataaa")
+    assert parse_record(b"\x05\x00\x00\x02\x03\x00\x00\x01\x02") == \
+                     Close(scid=515, seqnum=258)
+    assert parse_record(b"\x06\x00\x00\x01\x03") == \
+                     Ack(resp_seqnum=259)
+    with mock.patch("wormhole._dilation.connection.log.err") as le:
+        with pytest.raises(ValueError):
+            parse_record(b"\x07unknown")
+    assert le.mock_calls == \
+                     [mock.call("received unknown message type: {}".format(
+                         b"\x07unknown"))]
 
-    def test_encode(self):
-        self.assertEqual(encode_record(KCM()), b"\x00")
-        self.assertEqual(encode_record(Ping(ping_id=b"ping")), b"\x01ping")
-        self.assertEqual(encode_record(Pong(ping_id=b"pong")), b"\x02pong")
-        self.assertEqual(encode_record(Open(scid=65536, seqnum=16)),
-                         b"\x03\x00\x01\x00\x00\x00\x00\x00\x10")
-        self.assertEqual(encode_record(Data(scid=65537, seqnum=17, data=b"dataaa")),
-                         b"\x04\x00\x01\x00\x01\x00\x00\x00\x11dataaa")
-        self.assertEqual(encode_record(Close(scid=65538, seqnum=18)),
-                         b"\x05\x00\x01\x00\x02\x00\x00\x00\x12")
-        self.assertEqual(encode_record(Ack(resp_seqnum=19)),
-                         b"\x06\x00\x00\x00\x13")
-        with self.assertRaises(TypeError) as ar:
-            encode_record("not a record")
-        self.assertEqual(str(ar.exception), "not a record")
+
+def test_encode():
+    assert encode_record(KCM()) == b"\x00"
+    assert encode_record(Ping(ping_id=b"ping")) == b"\x01ping"
+    assert encode_record(Pong(ping_id=b"pong")) == b"\x02pong"
+    assert encode_record(Open(scid=65536, seqnum=16)) == \
+                     b"\x03\x00\x01\x00\x00\x00\x00\x00\x10"
+    assert encode_record(Data(scid=65537, seqnum=17, data=b"dataaa")) == \
+                     b"\x04\x00\x01\x00\x01\x00\x00\x00\x11dataaa"
+    assert encode_record(Close(scid=65538, seqnum=18)) == \
+                     b"\x05\x00\x01\x00\x02\x00\x00\x00\x12"
+    assert encode_record(Ack(resp_seqnum=19)) == \
+                     b"\x06\x00\x00\x00\x13"
+    with pytest.raises(TypeError) as ar:
+        encode_record("not a record")
+    assert str(ar.value) == "not a record"

--- a/src/wormhole/test/dilate/test_record.py
+++ b/src/wormhole/test/dilate/test_record.py
@@ -281,6 +281,7 @@ def test_large_frame():
     frames
     """
     if not NoiseConnection:
+        import unittest
         raise unittest.SkipTest("noiseprotocol unavailable")
     # XXX could really benefit from some Hypothesis style
     # exploration of more cases .. but we don't already depend on

--- a/src/wormhole/test/dilate/test_record.py
+++ b/src/wormhole/test/dilate/test_record.py
@@ -1,6 +1,5 @@
 from unittest import mock
 from zope.interface import alsoProvides
-from twisted.trial import unittest
 from twisted.internet.interfaces import ITransport
 from ..._dilation._noise import NoiseInvalidMessage, NoiseConnection
 from ..._dilation.connection import (IFramer, Frame, Prologue,
@@ -9,6 +8,7 @@ from ..._dilation.connection import (IFramer, Frame, Prologue,
 from ..._dilation.connector import build_noise
 from ..._dilation.roles import LEADER, FOLLOWER
 from zope.interface import implementer
+import pytest
 
 
 def make_record():
@@ -20,377 +20,360 @@ def make_record():
     return r, f, n
 
 
-class Record(unittest.TestCase):
-    def test_good2(self):
-        f = mock.Mock()
-        alsoProvides(f, IFramer)
-        f.add_and_parse = mock.Mock(side_effect=[
-            [],
-            [Prologue()],
-            [Frame(frame=b"rx-handshake")],
-            [Frame(frame=b"frame1"), Frame(frame=b"frame2")],
-        ])
-        n = mock.Mock()
-        n.write_message = mock.Mock(return_value=b"tx-handshake")
-        p1, p2 = object(), object()
-        n.decrypt = mock.Mock(side_effect=[p1, p2])
-        r = _Record(f, n, LEADER)
-        r.set_role_leader()
-        self.assertEqual(f.mock_calls, [])
-        r.connectionMade()
-        self.assertEqual(f.mock_calls, [mock.call.connectionMade()])
-        f.mock_calls[:] = []
-        self.assertEqual(n.mock_calls, [mock.call.start_handshake()])
-        n.mock_calls[:] = []
+def test_good2():
+    f = mock.Mock()
+    alsoProvides(f, IFramer)
+    f.add_and_parse = mock.Mock(side_effect=[
+        [],
+        [Prologue()],
+        [Frame(frame=b"rx-handshake")],
+        [Frame(frame=b"frame1"), Frame(frame=b"frame2")],
+    ])
+    n = mock.Mock()
+    n.write_message = mock.Mock(return_value=b"tx-handshake")
+    p1, p2 = object(), object()
+    n.decrypt = mock.Mock(side_effect=[p1, p2])
+    r = _Record(f, n, LEADER)
+    r.set_role_leader()
+    assert f.mock_calls == []
+    r.connectionMade()
+    assert f.mock_calls == [mock.call.connectionMade()]
+    f.mock_calls[:] = []
+    assert n.mock_calls == [mock.call.start_handshake()]
+    n.mock_calls[:] = []
 
-        # Pretend to deliver the prologue in two parts. The text we send in
-        # doesn't matter: the side_effect= is what causes the prologue to be
-        # recognized by the second call.
-        self.assertEqual(list(r.add_and_unframe(b"pro")), [])
-        self.assertEqual(f.mock_calls, [mock.call.add_and_parse(b"pro")])
-        f.mock_calls[:] = []
-        self.assertEqual(n.mock_calls, [])
+    # Pretend to deliver the prologue in two parts. The text we send in
+    # doesn't matter: the side_effect= is what causes the prologue to be
+    # recognized by the second call.
+    assert list(r.add_and_unframe(b"pro")) == []
+    assert f.mock_calls == [mock.call.add_and_parse(b"pro")]
+    f.mock_calls[:] = []
+    assert n.mock_calls == []
 
-        # recognizing the prologue causes a handshake frame to be sent
-        self.assertEqual(list(r.add_and_unframe(b"logue")), [])
-        self.assertEqual(f.mock_calls, [mock.call.add_and_parse(b"logue"),
-                                        mock.call.send_frame(b"tx-handshake")])
-        f.mock_calls[:] = []
-        self.assertEqual(n.mock_calls, [mock.call.write_message()])
-        n.mock_calls[:] = []
+    # recognizing the prologue causes a handshake frame to be sent
+    assert list(r.add_and_unframe(b"logue")) == []
+    assert f.mock_calls == [mock.call.add_and_parse(b"logue"),
+                                    mock.call.send_frame(b"tx-handshake")]
+    f.mock_calls[:] = []
+    assert n.mock_calls == [mock.call.write_message()]
+    n.mock_calls[:] = []
 
-        # next add_and_unframe is recognized as the Handshake
-        self.assertEqual(list(r.add_and_unframe(b"blah")), [Handshake()])
-        self.assertEqual(f.mock_calls, [mock.call.add_and_parse(b"blah")])
-        f.mock_calls[:] = []
-        self.assertEqual(n.mock_calls, [mock.call.read_message(b"rx-handshake")])
-        n.mock_calls[:] = []
+    # next add_and_unframe is recognized as the Handshake
+    assert list(r.add_and_unframe(b"blah")) == [Handshake()]
+    assert f.mock_calls == [mock.call.add_and_parse(b"blah")]
+    f.mock_calls[:] = []
+    assert n.mock_calls == [mock.call.read_message(b"rx-handshake")]
+    n.mock_calls[:] = []
 
-        # next is a pair of Records
-        r1, r2 = object(), object()
-        with mock.patch("wormhole._dilation.connection.parse_record",
-                        side_effect=[r1, r2]) as pr:
-            self.assertEqual(list(r.add_and_unframe(b"blah2")), [r1, r2])
-            self.assertEqual(n.mock_calls, [mock.call.decrypt(b"frame1"),
-                                            mock.call.decrypt(b"frame2")])
-            self.assertEqual(pr.mock_calls, [mock.call(p1), mock.call(p2)])
+    # next is a pair of Records
+    r1, r2 = object(), object()
+    with mock.patch("wormhole._dilation.connection.parse_record",
+                    side_effect=[r1, r2]) as pr:
+        assert list(r.add_and_unframe(b"blah2")) == [r1, r2]
+        assert n.mock_calls == [mock.call.decrypt(b"frame1"),
+                                        mock.call.decrypt(b"frame2")]
+        assert pr.mock_calls == [mock.call(p1), mock.call(p2)]
 
-    def test_bad_handshake(self):
-        f = mock.Mock()
-        alsoProvides(f, IFramer)
-        f.add_and_parse = mock.Mock(return_value=[Prologue(),
-                                                  Frame(frame=b"rx-handshake")])
-        n = mock.Mock()
-        n.write_message = mock.Mock(return_value=b"tx-handshake")
-        nvm = NoiseInvalidMessage()
-        n.read_message = mock.Mock(side_effect=nvm)
-        r = _Record(f, n, LEADER)
-        r.set_role_leader()
-        self.assertEqual(f.mock_calls, [])
-        r.connectionMade()
-        self.assertEqual(f.mock_calls, [mock.call.connectionMade()])
-        f.mock_calls[:] = []
-        self.assertEqual(n.mock_calls, [mock.call.start_handshake()])
-        n.mock_calls[:] = []
+def test_bad_handshake():
+    f = mock.Mock()
+    alsoProvides(f, IFramer)
+    f.add_and_parse = mock.Mock(return_value=[Prologue(),
+                                              Frame(frame=b"rx-handshake")])
+    n = mock.Mock()
+    n.write_message = mock.Mock(return_value=b"tx-handshake")
+    nvm = NoiseInvalidMessage()
+    n.read_message = mock.Mock(side_effect=nvm)
+    r = _Record(f, n, LEADER)
+    r.set_role_leader()
+    assert f.mock_calls == []
+    r.connectionMade()
+    assert f.mock_calls == [mock.call.connectionMade()]
+    f.mock_calls[:] = []
+    assert n.mock_calls == [mock.call.start_handshake()]
+    n.mock_calls[:] = []
 
-        with mock.patch("wormhole._dilation.connection.log.err") as le:
-            with self.assertRaises(Disconnect):
-                list(r.add_and_unframe(b"data"))
-        self.assertEqual(le.mock_calls,
-                         [mock.call(nvm, "bad inbound noise handshake")])
+    with mock.patch("wormhole._dilation.connection.log.err") as le:
+        with pytest.raises(Disconnect):
+            list(r.add_and_unframe(b"data"))
+    assert le.mock_calls == \
+                     [mock.call(nvm, "bad inbound noise handshake")]
 
-    def test_bad_message(self):
-        f = mock.Mock()
-        alsoProvides(f, IFramer)
-        f.add_and_parse = mock.Mock(return_value=[Prologue(),
-                                                  Frame(frame=b"rx-handshake"),
-                                                  Frame(frame=b"bad-message")])
-        n = mock.Mock()
-        n.write_message = mock.Mock(return_value=b"tx-handshake")
-        nvm = NoiseInvalidMessage()
-        n.decrypt = mock.Mock(side_effect=nvm)
-        r = _Record(f, n, LEADER)
-        r.set_role_leader()
-        self.assertEqual(f.mock_calls, [])
-        r.connectionMade()
-        self.assertEqual(f.mock_calls, [mock.call.connectionMade()])
-        f.mock_calls[:] = []
-        self.assertEqual(n.mock_calls, [mock.call.start_handshake()])
-        n.mock_calls[:] = []
+def test_bad_message():
+    f = mock.Mock()
+    alsoProvides(f, IFramer)
+    f.add_and_parse = mock.Mock(return_value=[Prologue(),
+                                              Frame(frame=b"rx-handshake"),
+                                              Frame(frame=b"bad-message")])
+    n = mock.Mock()
+    n.write_message = mock.Mock(return_value=b"tx-handshake")
+    nvm = NoiseInvalidMessage()
+    n.decrypt = mock.Mock(side_effect=nvm)
+    r = _Record(f, n, LEADER)
+    r.set_role_leader()
+    assert f.mock_calls == []
+    r.connectionMade()
+    assert f.mock_calls == [mock.call.connectionMade()]
+    f.mock_calls[:] = []
+    assert n.mock_calls == [mock.call.start_handshake()]
+    n.mock_calls[:] = []
 
-        with mock.patch("wormhole._dilation.connection.log.err") as le:
-            with self.assertRaises(Disconnect):
-                list(r.add_and_unframe(b"data"))
-        self.assertEqual(le.mock_calls,
-                         [mock.call(nvm, "bad inbound noise frame")])
+    with mock.patch("wormhole._dilation.connection.log.err") as le:
+        with pytest.raises(Disconnect):
+            list(r.add_and_unframe(b"data"))
+    assert le.mock_calls == \
+                     [mock.call(nvm, "bad inbound noise frame")]
 
-    def test_send_record(self):
-        f = mock.Mock()
-        alsoProvides(f, IFramer)
-        n = mock.Mock()
-        f1 = b"some bytes"
-        n.encrypt = mock.Mock(return_value=f1)
-        r1 = Ping(b"pingid")
-        r = _Record(f, n, LEADER)
-        r.set_role_leader()
-        self.assertEqual(f.mock_calls, [])
-        m1 = b"some other bytes"
-        with mock.patch("wormhole._dilation.connection.encode_record",
-                        return_value=m1) as er:
-            r.send_record(r1)
-        self.assertEqual(er.mock_calls, [mock.call(r1)])
-        self.assertEqual(n.mock_calls, [mock.call.start_handshake(),
-                                        mock.call.encrypt(m1)])
-        self.assertEqual(f.mock_calls, [mock.call.send_frame(f1)])
+def test_send_record():
+    f = mock.Mock()
+    alsoProvides(f, IFramer)
+    n = mock.Mock()
+    f1 = b"some bytes"
+    n.encrypt = mock.Mock(return_value=f1)
+    r1 = Ping(b"pingid")
+    r = _Record(f, n, LEADER)
+    r.set_role_leader()
+    assert f.mock_calls == []
+    m1 = b"some other bytes"
+    with mock.patch("wormhole._dilation.connection.encode_record",
+                    return_value=m1) as er:
+        r.send_record(r1)
+    assert er.mock_calls == [mock.call(r1)]
+    assert n.mock_calls == [mock.call.start_handshake(),
+                                    mock.call.encrypt(m1)]
+    assert f.mock_calls == [mock.call.send_frame(f1)]
 
-    def test_good(self):
-        # Exercise the success path. The Record instance is given each chunk
-        # of data as it arrives on Protocol.dataReceived, and is supposed to
-        # return a series of Tokens (maybe none, if the chunk was incomplete,
-        # or more than one, if the chunk was larger). Internally, it delivers
-        # the chunks to the Framer for unframing (which returns 0 or more
-        # frames), manages the Noise decryption object, and parses any
-        # decrypted messages into tokens (some of which are consumed
-        # internally, others for delivery upstairs).
-        #
-        # in the normal flow, we get:
-        #
-        # |   | Inbound   | NoiseAction   | Outbound  | ToUpstairs |
-        # |   | -         | -             | -         | -          |
-        # | 1 |           |               | prologue  |            |
-        # | 2 | prologue  |               |           |            |
-        # | 3 |           | write_message | handshake |            |
-        # | 4 | handshake | read_message  |           | Handshake  |
-        # | 5 |           | encrypt       | KCM       |            |
-        # | 6 | KCM       | decrypt       |           | KCM        |
-        # | 7 | msg1      | decrypt       |           | msg1       |
+def test_good():
+    # Exercise the success path. The Record instance is given each chunk
+    # of data as it arrives on Protocol.dataReceived, and is supposed to
+    # return a series of Tokens (maybe none, if the chunk was incomplete,
+    # or more than one, if the chunk was larger). Internally, it delivers
+    # the chunks to the Framer for unframing (which returns 0 or more
+    # frames), manages the Noise decryption object, and parses any
+    # decrypted messages into tokens (some of which are consumed
+    # internally, others for delivery upstairs).
+    #
+    # in the normal flow, we get:
+    #
+    # |   | Inbound   | NoiseAction   | Outbound  | ToUpstairs |
+    # |   | -         | -             | -         | -          |
+    # | 1 |           |               | prologue  |            |
+    # | 2 | prologue  |               |           |            |
+    # | 3 |           | write_message | handshake |            |
+    # | 4 | handshake | read_message  |           | Handshake  |
+    # | 5 |           | encrypt       | KCM       |            |
+    # | 6 | KCM       | decrypt       |           | KCM        |
+    # | 7 | msg1      | decrypt       |           | msg1       |
 
-        # 1: instantiating the Record instance causes the outbound prologue
-        # to be sent
+    # 1: instantiating the Record instance causes the outbound prologue
+    # to be sent
 
-        # 2+3: receipt of the inbound prologue triggers creation of the
-        # ephemeral key (the "handshake") by calling noise.write_message()
-        # and then writes the handshake to the outbound transport
+    # 2+3: receipt of the inbound prologue triggers creation of the
+    # ephemeral key (the "handshake") by calling noise.write_message()
+    # and then writes the handshake to the outbound transport
 
-        # 4: when the peer's handshake is received, it is delivered to
-        # noise.read_message(), which generates the shared key (enabling
-        # noise.send() and noise.decrypt()). It also delivers the Handshake
-        # token upstairs, which might (on the Follower) trigger immediate
-        # transmission of the Key Confirmation Message (KCM)
+    # 4: when the peer's handshake is received, it is delivered to
+    # noise.read_message(), which generates the shared key (enabling
+    # noise.send() and noise.decrypt()). It also delivers the Handshake
+    # token upstairs, which might (on the Follower) trigger immediate
+    # transmission of the Key Confirmation Message (KCM)
 
-        # 5: the outbound KCM is framed and fed into noise.encrypt(), then
-        # sent outbound
+    # 5: the outbound KCM is framed and fed into noise.encrypt(), then
+    # sent outbound
 
-        # 6: the peer's KCM is decrypted then delivered upstairs. The
-        # Follower treats this as a signal that it should use this connection
-        # (and drop all others).
+    # 6: the peer's KCM is decrypted then delivered upstairs. The
+    # Follower treats this as a signal that it should use this connection
+    # (and drop all others).
 
-        # 7: the peer's first message is decrypted, parsed, and delivered
-        # upstairs. This might be an Open or a Data, depending upon what
-        # queued messages were left over from the previous connection
+    # 7: the peer's first message is decrypted, parsed, and delivered
+    # upstairs. This might be an Open or a Data, depending upon what
+    # queued messages were left over from the previous connection
 
-        r, f, n = make_record()
-        outbound_handshake = object()
-        kcm, msg1 = object(), object()
-        f_kcm, f_msg1 = object(), object()
-        n.write_message = mock.Mock(return_value=outbound_handshake)
-        n.decrypt = mock.Mock(side_effect=[kcm, msg1])
-        n.encrypt = mock.Mock(side_effect=[f_kcm, f_msg1])
-        f.add_and_parse = mock.Mock(side_effect=[[],  # no tokens yet
-                                                 [Prologue()],
-                                                 [Frame("f_handshake")],
-                                                 [Frame("f_kcm"),
-                                                  Frame("f_msg1")],
-                                                 ])
+    r, f, n = make_record()
+    outbound_handshake = object()
+    kcm, msg1 = object(), object()
+    f_kcm, f_msg1 = object(), object()
+    n.write_message = mock.Mock(return_value=outbound_handshake)
+    n.decrypt = mock.Mock(side_effect=[kcm, msg1])
+    n.encrypt = mock.Mock(side_effect=[f_kcm, f_msg1])
+    f.add_and_parse = mock.Mock(side_effect=[[],  # no tokens yet
+                                             [Prologue()],
+                                             [Frame("f_handshake")],
+                                             [Frame("f_kcm"),
+                                              Frame("f_msg1")],
+                                             ])
 
-        self.assertEqual(f.mock_calls, [])
-        self.assertEqual(n.mock_calls, [mock.call.start_handshake()])
-        n.mock_calls[:] = []
+    assert f.mock_calls == []
+    assert n.mock_calls == [mock.call.start_handshake()]
+    n.mock_calls[:] = []
 
-        # 1. The Framer is responsible for sending the prologue, so we don't
-        # have to check that here, we just check that the Framer was told
-        # about connectionMade properly.
-        r.connectionMade()
-        self.assertEqual(f.mock_calls, [mock.call.connectionMade()])
-        self.assertEqual(n.mock_calls, [])
-        f.mock_calls[:] = []
+    # 1. The Framer is responsible for sending the prologue, so we don't
+    # have to check that here, we just check that the Framer was told
+    # about connectionMade properly.
+    r.connectionMade()
+    assert f.mock_calls == [mock.call.connectionMade()]
+    assert n.mock_calls == []
+    f.mock_calls[:] = []
 
-        # 2
-        # we dribble the prologue in over two messages, to make sure we can
-        # handle a dataReceived that doesn't complete the token
+    # 2
+    # we dribble the prologue in over two messages, to make sure we can
+    # handle a dataReceived that doesn't complete the token
 
-        # remember, add_and_unframe is a generator
-        self.assertEqual(list(r.add_and_unframe(b"pro")), [])
-        self.assertEqual(f.mock_calls, [mock.call.add_and_parse(b"pro")])
-        self.assertEqual(n.mock_calls, [])
-        f.mock_calls[:] = []
+    # remember, add_and_unframe is a generator
+    assert list(r.add_and_unframe(b"pro")) == []
+    assert f.mock_calls == [mock.call.add_and_parse(b"pro")]
+    assert n.mock_calls == []
+    f.mock_calls[:] = []
 
-        self.assertEqual(list(r.add_and_unframe(b"logue")), [])
-        # 3: write_message, send outbound handshake
-        self.assertEqual(f.mock_calls, [mock.call.add_and_parse(b"logue"),
-                                        mock.call.send_frame(outbound_handshake),
-                                        ])
-        self.assertEqual(n.mock_calls, [mock.call.write_message()])
-        f.mock_calls[:] = []
-        n.mock_calls[:] = []
+    assert list(r.add_and_unframe(b"logue")) == []
+    # 3: write_message, send outbound handshake
+    assert f.mock_calls == [mock.call.add_and_parse(b"logue"),
+                                    mock.call.send_frame(outbound_handshake),
+                                    ]
+    assert n.mock_calls == [mock.call.write_message()]
+    f.mock_calls[:] = []
+    n.mock_calls[:] = []
 
-        # 4
-        # Now deliver the Noise "handshake", the ephemeral public key. This
-        # is framed, but not a record, so it shouldn't decrypt or parse
-        # anything, but the handshake is delivered to the Noise object, and
-        # it does return a Handshake token so we can let the next layer up
-        # react (by sending the KCM frame if we're a Follower, or not if
-        # we're the Leader)
+    # 4
+    # Now deliver the Noise "handshake", the ephemeral public key. This
+    # is framed, but not a record, so it shouldn't decrypt or parse
+    # anything, but the handshake is delivered to the Noise object, and
+    # it does return a Handshake token so we can let the next layer up
+    # react (by sending the KCM frame if we're a Follower, or not if
+    # we're the Leader)
 
-        self.assertEqual(list(r.add_and_unframe(b"handshake")), [Handshake()])
-        self.assertEqual(f.mock_calls, [mock.call.add_and_parse(b"handshake")])
-        self.assertEqual(n.mock_calls, [mock.call.read_message("f_handshake")])
-        f.mock_calls[:] = []
-        n.mock_calls[:] = []
+    assert list(r.add_and_unframe(b"handshake")) == [Handshake()]
+    assert f.mock_calls == [mock.call.add_and_parse(b"handshake")]
+    assert n.mock_calls == [mock.call.read_message("f_handshake")]
+    f.mock_calls[:] = []
+    n.mock_calls[:] = []
 
-        # 5: at this point we ought to be able to send a message, the KCM
-        with mock.patch("wormhole._dilation.connection.encode_record",
-                        side_effect=[b"r-kcm"]) as er:
-            r.send_record(kcm)
-        self.assertEqual(er.mock_calls, [mock.call(kcm)])
-        self.assertEqual(n.mock_calls, [mock.call.encrypt(b"r-kcm")])
-        self.assertEqual(f.mock_calls, [mock.call.send_frame(f_kcm)])
-        n.mock_calls[:] = []
-        f.mock_calls[:] = []
+    # 5: at this point we ought to be able to send a message, the KCM
+    with mock.patch("wormhole._dilation.connection.encode_record",
+                    side_effect=[b"r-kcm"]) as er:
+        r.send_record(kcm)
+    assert er.mock_calls == [mock.call(kcm)]
+    assert n.mock_calls == [mock.call.encrypt(b"r-kcm")]
+    assert f.mock_calls == [mock.call.send_frame(f_kcm)]
+    n.mock_calls[:] = []
+    f.mock_calls[:] = []
 
-        # 6: Now we deliver two messages stacked up: the KCM (Key
-        # Confirmation Message) and the first real message. Concatenating
-        # them tests that we can handle more than one token in a single
-        # chunk. We need to mock parse_record() because everything past the
-        # handshake is decrypted and parsed.
+    # 6: Now we deliver two messages stacked up: the KCM (Key
+    # Confirmation Message) and the first real message. Concatenating
+    # them tests that we can handle more than one token in a single
+    # chunk. We need to mock parse_record() because everything past the
+    # handshake is decrypted and parsed.
 
-        with mock.patch("wormhole._dilation.connection.parse_record",
-                        side_effect=[kcm, msg1]) as pr:
-            self.assertEqual(list(r.add_and_unframe(b"kcm,msg1")),
-                             [kcm, msg1])
-            self.assertEqual(f.mock_calls,
-                             [mock.call.add_and_parse(b"kcm,msg1")])
-            self.assertEqual(n.mock_calls, [mock.call.decrypt("f_kcm"),
-                                            mock.call.decrypt("f_msg1")])
-            self.assertEqual(pr.mock_calls, [mock.call(kcm), mock.call(msg1)])
-        n.mock_calls[:] = []
-        f.mock_calls[:] = []
+    with mock.patch("wormhole._dilation.connection.parse_record",
+                    side_effect=[kcm, msg1]) as pr:
+        assert list(r.add_and_unframe(b"kcm,msg1")) == \
+                         [kcm, msg1]
+        assert f.mock_calls == \
+                         [mock.call.add_and_parse(b"kcm,msg1")]
+        assert n.mock_calls == [mock.call.decrypt("f_kcm"),
+                                        mock.call.decrypt("f_msg1")]
+        assert pr.mock_calls == [mock.call(kcm), mock.call(msg1)]
+    n.mock_calls[:] = []
+    f.mock_calls[:] = []
 
-    def test_large_frame(self):
+def test_large_frame():
+    """
+    Noise only allows 64KiB message, but the API allows up to 4GiB
+    frames
+    """
+    if not NoiseConnection:
+        raise unittest.SkipTest("noiseprotocol unavailable")
+    # XXX could really benefit from some Hypothesis style
+    # exploration of more cases .. but we don't already depend on
+    # that library, so a future improvement
+
+    @implementer(ITransport)
+    class FakeTransport:
         """
-        Noise only allows 64KiB message, but the API allows up to 4GiB
-        frames
+        Record which write()s happen
         """
-        if not NoiseConnection:
-            raise unittest.SkipTest("noiseprotocol unavailable")
-        # XXX could really benefit from some Hypothesis style
-        # exploration of more cases .. but we don't already depend on
-        # that library, so a future improvement
+        def __init__(self):
+            self.data = []  # list of bytes
 
-        @implementer(ITransport)
-        class FakeTransport:
-            """
-            Record which write()s happen
-            """
-            def __init__(self):
-                self.data = []  # list of bytes
+        def write(self, data):
+            self.data.append(data)
 
-            def write(self, data):
-                self.data.append(data)
+    # we build both sides of a connection so that underlying Noise
+    # structures can be set up and paired properly. Essentially
+    # this test is acting like the L2 Protocol object, and can
+    # feed bytes to / from either side
+    pake_secret = b"\x00" * 32
+    transport0 = FakeTransport()
+    transport1 = FakeTransport()
+    noise0 = build_noise()
+    noise0.set_psks(pake_secret)
+    noise0.set_as_initiator()  # leader
+    noise1 = build_noise()
+    noise1.set_psks(pake_secret)
+    noise1.set_as_responder()  # follower
+    framer0 = _Framer(transport0, b"out prolog", b"in prolog")
+    record0 = _Record(framer0, noise0, LEADER)
+    record0.set_role_leader()
+    record0.connectionMade()
+    assert list(record0.add_and_unframe(b"in prolog")) == \
+        []
 
-        # we build both sides of a connection so that underlying Noise
-        # structures can be set up and paired properly. Essentially
-        # this test is acting like the L2 Protocol object, and can
-        # feed bytes to / from either side
-        pake_secret = b"\x00" * 32
-        transport0 = FakeTransport()
-        transport1 = FakeTransport()
-        noise0 = build_noise()
-        noise0.set_psks(pake_secret)
-        noise0.set_as_initiator()  # leader
-        noise1 = build_noise()
-        noise1.set_psks(pake_secret)
-        noise1.set_as_responder()  # follower
-        framer0 = _Framer(transport0, b"out prolog", b"in prolog")
-        record0 = _Record(framer0, noise0, LEADER)
-        record0.set_role_leader()
-        record0.connectionMade()
-        self.assertEqual(
-            list(record0.add_and_unframe(b"in prolog")),
-            []
+    # note that in connector the prologues flip around depending
+    # on who is the leader or follower
+    framer1 = _Framer(transport1, b"in prolog", b"out prolog")
+    record1 = _Record(framer1, noise1, FOLLOWER)
+    record1.set_role_follower()
+    record1.connectionMade()
+
+    # the leader has now sent the prolog and the opening handshake
+    # message, so we consume them on the follower side
+
+    assert list(record1.add_and_unframe(transport0.data[0])) == [] # b"out prolog"
+    assert list(record1.add_and_unframe(transport0.data[1])) == [Handshake()]
+
+    # the follower sends the first KCM; the leader is waiting for
+    # this and will complete the handshake after that
+    record1.send_record(KCM())
+    assert list(record0.add_and_unframe(transport1.data[1])) == \
+        [Handshake()]
+    record0.send_record(KCM())
+    assert list(record1.add_and_unframe(transport0.data[2])) == \
+        [KCM()]
+    # both sides are now done their handshakes
+
+    # Now, we send a message that's definitely bigger than a
+    # single Noise message can deal with
+    input_plaintext = b"\xff" * 65537
+    record0.send_record(
+        Data(
+            seqnum=123,
+            scid=456,
+            data=input_plaintext,
         )
+    )
 
-        # note that in connector the prologues flip around depending
-        # on who is the leader or follower
-        framer1 = _Framer(transport1, b"in prolog", b"out prolog")
-        record1 = _Record(framer1, noise1, FOLLOWER)
-        record1.set_role_follower()
-        record1.connectionMade()
+    # ...despite its size the message should still be sent out as
+    # a single Data, because _our_ framing handles 4-byte lengths
+    assert len(transport0.data[3]) == \
+        4 + 65537 + (16 * 2) + 1 + 4 + 4
+    #   ^-- frame-length
+    #       ^-- plaintext size
+    #               ^-- Noise associated data, x2 noise packets
+    #                          ^-- "data" kind, 0x04
+    #                              ^-- subchannel-id
+    #                                  ^-- sequence number
+    #
+    # (maybe we don't need the above assert, since if any of that
+    # isn't true the next step will fail)
 
-        # the leader has now sent the prolog and the opening handshake
-        # message, so we consume them on the follower side
-
-        self.assertEqual(
-            list(record1.add_and_unframe(transport0.data[0])),  # b"out prolog"
-            []
-        )
-        self.assertEqual(
-            list(record1.add_and_unframe(transport0.data[1])),
-            [Handshake()]
-        )
-
-        # the follower sends the first KCM; the leader is waiting for
-        # this and will complete the handshake after that
-        record1.send_record(KCM())
-        self.assertEqual(
-            list(record0.add_and_unframe(transport1.data[1])),
-            [Handshake()]
-        )
-        record0.send_record(KCM())
-        self.assertEqual(
-            list(record1.add_and_unframe(transport0.data[2])),
-            [KCM()]
-        )
-        # both sides are now done their handshakes
-
-        # Now, we send a message that's definitely bigger than a
-        # single Noise message can deal with
-        input_plaintext = b"\xff" * 65537
-        record0.send_record(
-            Data(
-                seqnum=123,
-                scid=456,
-                data=input_plaintext,
-            )
-        )
-
-        # ...despite its size the message should still be sent out as
-        # a single Data, because _our_ framing handles 4-byte lengths
-        self.assertEqual(
-            len(transport0.data[3]),
-            4 + 65537 + (16 * 2) + 1 + 4 + 4
-        )
-        #   ^-- frame-length
-        #       ^-- plaintext size
-        #               ^-- Noise associated data, x2 noise packets
-        #                          ^-- "data" kind, 0x04
-        #                              ^-- subchannel-id
-        #                                  ^-- sequence number
-        #
-        # (maybe we don't need the above assert, since if any of that
-        # isn't true the next step will fail)
-
-        # round-trip the data to the other side and ensure we get the
-        # plaintext back
-        outputs = list(
-            record1.add_and_unframe(transport0.data[3])
-        )
-        self.assertEqual(len(outputs), 1)
-        self.assertEqual(
-            outputs[0],
-            Data(
-                seqnum=123,
-                scid=456,
-                data=input_plaintext,
-            )
+    # round-trip the data to the other side and ensure we get the
+    # plaintext back
+    outputs = list(
+        record1.add_and_unframe(transport0.data[3])
+    )
+    assert len(outputs) == 1
+    assert outputs[0] == \
+        Data(
+            seqnum=123,
+            scid=456,
+            data=input_plaintext,
         )

--- a/src/wormhole/test/dilate/test_subchannel.py
+++ b/src/wormhole/test/dilate/test_subchannel.py
@@ -24,14 +24,14 @@ def make_sc(set_protocol=True, half_closeable=False):
     return sc, m, scid, hostaddr, peeraddr, p
 
 
-def test_once():
+def test_subchannel_once():
     o = Once(ValueError)
     o()
     with pytest.raises(ValueError):
         o()
 
 
-def test_create():
+def test_subchannel_create():
     sc, m, scid, hostaddr, peeraddr, p = make_sc()
     assert ITransport.providedBy(sc)
     assert m.mock_calls == []
@@ -39,7 +39,7 @@ def test_create():
     assert sc.getPeer() is peeraddr
 
 
-def test_write():
+def test_subchannel_write():
     sc, m, scid, hostaddr, peeraddr, p = make_sc()
 
     sc.write(b"data")
@@ -49,7 +49,7 @@ def test_write():
     assert m.mock_calls == [mock.call.send_data(scid, b"moredata")]
 
 
-def test_write_when_closing():
+def test_subchannel_write_when_closing():
     sc, m, scid, hostaddr, peeraddr, p = make_sc()
 
     sc.loseConnection()
@@ -61,7 +61,7 @@ def test_write_when_closing():
     assert str(e.value) == "write not allowed on closed subchannel"
 
 
-def test_local_close():
+def test_subchannel_local_close():
     sc, m, scid, hostaddr, peeraddr, p = make_sc()
 
     sc.loseConnection()
@@ -77,7 +77,7 @@ def test_local_close():
     assert_connectionDone(p.mock_calls)
 
 
-def test_local_double_close():
+def test_subchannel_local_double_close():
     sc, m, scid, hostaddr, peeraddr, p = make_sc()
 
     sc.loseConnection()
@@ -95,7 +95,7 @@ def assert_connectionDone(mock_calls):
     assert isinstance(mock_calls[0][1][0], ConnectionDone)
 
 
-def test_remote_close():
+def test_subchannel_remote_close():
     sc, m, scid, hostaddr, peeraddr, p = make_sc()
     sc.remote_close()
     assert m.mock_calls == [mock.call.send_close(scid),
@@ -103,7 +103,7 @@ def test_remote_close():
     assert_connectionDone(p.mock_calls)
 
 
-def test_data():
+def test_subchannel_data():
     sc, m, scid, hostaddr, peeraddr, p = make_sc()
     sc.remote_data(b"data")
     assert p.mock_calls == [mock.call.dataReceived(b"data")]
@@ -115,7 +115,7 @@ def test_data():
                                     ]
 
 
-def test_data_before_open():
+def test_subchannel_data_before_open():
     sc, m, scid, hostaddr, peeraddr, p = make_sc(set_protocol=False)
     sc.remote_data(b"data1")
     sc.remote_data(b"data2")
@@ -129,7 +129,7 @@ def test_data_before_open():
     assert p.mock_calls == [mock.call.dataReceived(b"more")]
 
 
-def test_close_before_open():
+def test_subchannel_close_before_open():
     sc, m, scid, hostaddr, peeraddr, p = make_sc(set_protocol=False)
     sc.remote_close()
     assert p.mock_calls == []
@@ -138,7 +138,7 @@ def test_close_before_open():
     assert_connectionDone(p.mock_calls)
 
 
-def test_producer():
+def test_subchannel_producer():
     sc, m, scid, hostaddr, peeraddr, p = make_sc()
 
     sc.pauseProducing()
@@ -152,7 +152,7 @@ def test_producer():
     m.mock_calls[:] = []
 
 
-def test_consumer():
+def test_subchannel_consumer():
     sc, m, scid, hostaddr, peeraddr, p = make_sc()
 
     # TODO: more, once this is implemented
@@ -160,7 +160,7 @@ def test_consumer():
     sc.unregisterProducer()
 
 
-def test_create():
+def test_halfcloseable_create():
     sc, m, scid, hostaddr, peeraddr, p = make_sc(half_closeable=True)
     assert ITransport.providedBy(sc)
     assert m.mock_calls == []
@@ -168,7 +168,7 @@ def test_create():
     assert sc.getPeer() is peeraddr
 
 
-def test_local_close():
+def test_halfcloseable_local_close():
     sc, m, scid, hostaddr, peeraddr, p = make_sc(half_closeable=True)
 
     sc.write(b"data")
@@ -214,7 +214,7 @@ def test_local_close():
     assert p.mock_calls == [mock.call.readConnectionLost()]
 
 
-def test_remote_close():
+def test_halfcloseable_remote_close():
     sc, m, scid, hostaddr, peeraddr, p = make_sc(half_closeable=True)
 
     sc.write(b"data")

--- a/src/wormhole/test/dilate/test_subchannel.py
+++ b/src/wormhole/test/dilate/test_subchannel.py
@@ -1,6 +1,5 @@
 from unittest import mock
 from zope.interface import directlyProvides
-from twisted.trial import unittest
 from twisted.internet.interfaces import ITransport, IHalfCloseableProtocol
 from twisted.internet.error import ConnectionDone
 from ..._dilation.subchannel import (Once, SubChannel,
@@ -8,6 +7,7 @@ from ..._dilation.subchannel import (Once, SubChannel,
                                      AlreadyClosedError,
                                      NormalCloseUsedOnHalfCloseable)
 from .common import mock_manager
+import pytest
 
 
 def make_sc(set_protocol=True, half_closeable=False):
@@ -24,213 +24,219 @@ def make_sc(set_protocol=True, half_closeable=False):
     return sc, m, scid, hostaddr, peeraddr, p
 
 
-class SubChannelAPI(unittest.TestCase):
-    def test_once(self):
-        o = Once(ValueError)
+def test_once():
+    o = Once(ValueError)
+    o()
+    with pytest.raises(ValueError):
         o()
-        with self.assertRaises(ValueError):
-            o()
 
-    def test_create(self):
-        sc, m, scid, hostaddr, peeraddr, p = make_sc()
-        self.assert_(ITransport.providedBy(sc))
-        self.assertEqual(m.mock_calls, [])
-        self.assertIdentical(sc.getHost(), hostaddr)
-        self.assertIdentical(sc.getPeer(), peeraddr)
 
-    def test_write(self):
-        sc, m, scid, hostaddr, peeraddr, p = make_sc()
+def test_create():
+    sc, m, scid, hostaddr, peeraddr, p = make_sc()
+    assert ITransport.providedBy(sc)
+    assert m.mock_calls == []
+    assert sc.getHost() is hostaddr
+    assert sc.getPeer() is peeraddr
 
+
+def test_write():
+    sc, m, scid, hostaddr, peeraddr, p = make_sc()
+
+    sc.write(b"data")
+    assert m.mock_calls == [mock.call.send_data(scid, b"data")]
+    m.mock_calls[:] = []
+    sc.writeSequence([b"more", b"data"])
+    assert m.mock_calls == [mock.call.send_data(scid, b"moredata")]
+
+
+def test_write_when_closing():
+    sc, m, scid, hostaddr, peeraddr, p = make_sc()
+
+    sc.loseConnection()
+    assert m.mock_calls == [mock.call.send_close(scid)]
+    m.mock_calls[:] = []
+
+    with pytest.raises(AlreadyClosedError) as e:
         sc.write(b"data")
-        self.assertEqual(m.mock_calls, [mock.call.send_data(scid, b"data")])
-        m.mock_calls[:] = []
-        sc.writeSequence([b"more", b"data"])
-        self.assertEqual(m.mock_calls, [mock.call.send_data(scid, b"moredata")])
+    assert str(e.value) == "write not allowed on closed subchannel"
 
-    def test_write_when_closing(self):
-        sc, m, scid, hostaddr, peeraddr, p = make_sc()
 
+def test_local_close():
+    sc, m, scid, hostaddr, peeraddr, p = make_sc()
+
+    sc.loseConnection()
+    assert m.mock_calls == [mock.call.send_close(scid)]
+    m.mock_calls[:] = []
+
+    # late arriving data is still delivered
+    sc.remote_data(b"late")
+    assert p.mock_calls == [mock.call.dataReceived(b"late")]
+    p.mock_calls[:] = []
+
+    sc.remote_close()
+    assert_connectionDone(p.mock_calls)
+
+
+def test_local_double_close():
+    sc, m, scid, hostaddr, peeraddr, p = make_sc()
+
+    sc.loseConnection()
+    assert m.mock_calls == [mock.call.send_close(scid)]
+    m.mock_calls[:] = []
+
+    with pytest.raises(AlreadyClosedError) as e:
         sc.loseConnection()
-        self.assertEqual(m.mock_calls, [mock.call.send_close(scid)])
-        m.mock_calls[:] = []
+    assert str(e.value) == "loseConnection not allowed on closed subchannel"
 
-        with self.assertRaises(AlreadyClosedError) as e:
-            sc.write(b"data")
-        self.assertEqual(str(e.exception),
-                         "write not allowed on closed subchannel")
-
-    def test_local_close(self):
-        sc, m, scid, hostaddr, peeraddr, p = make_sc()
-
-        sc.loseConnection()
-        self.assertEqual(m.mock_calls, [mock.call.send_close(scid)])
-        m.mock_calls[:] = []
-
-        # late arriving data is still delivered
-        sc.remote_data(b"late")
-        self.assertEqual(p.mock_calls, [mock.call.dataReceived(b"late")])
-        p.mock_calls[:] = []
-
-        sc.remote_close()
-        self.assert_connectionDone(p.mock_calls)
-
-    def test_local_double_close(self):
-        sc, m, scid, hostaddr, peeraddr, p = make_sc()
-
-        sc.loseConnection()
-        self.assertEqual(m.mock_calls, [mock.call.send_close(scid)])
-        m.mock_calls[:] = []
-
-        with self.assertRaises(AlreadyClosedError) as e:
-            sc.loseConnection()
-        self.assertEqual(str(e.exception),
-                         "loseConnection not allowed on closed subchannel")
-
-    def assert_connectionDone(self, mock_calls):
-        self.assertEqual(len(mock_calls), 1)
-        self.assertEqual(mock_calls[0][0], "connectionLost")
-        self.assertEqual(len(mock_calls[0][1]), 1)
-        self.assertIsInstance(mock_calls[0][1][0], ConnectionDone)
-
-    def test_remote_close(self):
-        sc, m, scid, hostaddr, peeraddr, p = make_sc()
-        sc.remote_close()
-        self.assertEqual(m.mock_calls, [mock.call.send_close(scid),
-                                        mock.call.subchannel_closed(scid, sc)])
-        self.assert_connectionDone(p.mock_calls)
-
-    def test_data(self):
-        sc, m, scid, hostaddr, peeraddr, p = make_sc()
-        sc.remote_data(b"data")
-        self.assertEqual(p.mock_calls, [mock.call.dataReceived(b"data")])
-        p.mock_calls[:] = []
-        sc.remote_data(b"not")
-        sc.remote_data(b"coalesced")
-        self.assertEqual(p.mock_calls, [mock.call.dataReceived(b"not"),
-                                        mock.call.dataReceived(b"coalesced"),
-                                        ])
-
-    def test_data_before_open(self):
-        sc, m, scid, hostaddr, peeraddr, p = make_sc(set_protocol=False)
-        sc.remote_data(b"data1")
-        sc.remote_data(b"data2")
-        self.assertEqual(p.mock_calls, [])
-        sc._set_protocol(p)
-        sc._deliver_queued_data()
-        self.assertEqual(p.mock_calls, [mock.call.dataReceived(b"data1"),
-                                        mock.call.dataReceived(b"data2")])
-        p.mock_calls[:] = []
-        sc.remote_data(b"more")
-        self.assertEqual(p.mock_calls, [mock.call.dataReceived(b"more")])
-
-    def test_close_before_open(self):
-        sc, m, scid, hostaddr, peeraddr, p = make_sc(set_protocol=False)
-        sc.remote_close()
-        self.assertEqual(p.mock_calls, [])
-        sc._set_protocol(p)
-        sc._deliver_queued_data()
-        self.assert_connectionDone(p.mock_calls)
-
-    def test_producer(self):
-        sc, m, scid, hostaddr, peeraddr, p = make_sc()
-
-        sc.pauseProducing()
-        self.assertEqual(m.mock_calls, [mock.call.subchannel_pauseProducing(sc)])
-        m.mock_calls[:] = []
-        sc.resumeProducing()
-        self.assertEqual(m.mock_calls, [mock.call.subchannel_resumeProducing(sc)])
-        m.mock_calls[:] = []
-        sc.stopProducing()
-        self.assertEqual(m.mock_calls, [mock.call.subchannel_stopProducing(sc)])
-        m.mock_calls[:] = []
-
-    def test_consumer(self):
-        sc, m, scid, hostaddr, peeraddr, p = make_sc()
-
-        # TODO: more, once this is implemented
-        sc.registerProducer(None, True)
-        sc.unregisterProducer()
+def assert_connectionDone(mock_calls):
+    assert len(mock_calls) == 1
+    assert mock_calls[0][0] == "connectionLost"
+    assert len(mock_calls[0][1]) == 1
+    assert isinstance(mock_calls[0][1][0], ConnectionDone)
 
 
-class HalfCloseable(unittest.TestCase):
+def test_remote_close():
+    sc, m, scid, hostaddr, peeraddr, p = make_sc()
+    sc.remote_close()
+    assert m.mock_calls == [mock.call.send_close(scid),
+                                    mock.call.subchannel_closed(scid, sc)]
+    assert_connectionDone(p.mock_calls)
 
-    def test_create(self):
-        sc, m, scid, hostaddr, peeraddr, p = make_sc(half_closeable=True)
-        self.assert_(ITransport.providedBy(sc))
-        self.assertEqual(m.mock_calls, [])
-        self.assertIdentical(sc.getHost(), hostaddr)
-        self.assertIdentical(sc.getPeer(), peeraddr)
 
-    def test_local_close(self):
-        sc, m, scid, hostaddr, peeraddr, p = make_sc(half_closeable=True)
+def test_data():
+    sc, m, scid, hostaddr, peeraddr, p = make_sc()
+    sc.remote_data(b"data")
+    assert p.mock_calls == [mock.call.dataReceived(b"data")]
+    p.mock_calls[:] = []
+    sc.remote_data(b"not")
+    sc.remote_data(b"coalesced")
+    assert p.mock_calls == [mock.call.dataReceived(b"not"),
+                                    mock.call.dataReceived(b"coalesced"),
+                                    ]
 
+
+def test_data_before_open():
+    sc, m, scid, hostaddr, peeraddr, p = make_sc(set_protocol=False)
+    sc.remote_data(b"data1")
+    sc.remote_data(b"data2")
+    assert p.mock_calls == []
+    sc._set_protocol(p)
+    sc._deliver_queued_data()
+    assert p.mock_calls == [mock.call.dataReceived(b"data1"),
+                                    mock.call.dataReceived(b"data2")]
+    p.mock_calls[:] = []
+    sc.remote_data(b"more")
+    assert p.mock_calls == [mock.call.dataReceived(b"more")]
+
+
+def test_close_before_open():
+    sc, m, scid, hostaddr, peeraddr, p = make_sc(set_protocol=False)
+    sc.remote_close()
+    assert p.mock_calls == []
+    sc._set_protocol(p)
+    sc._deliver_queued_data()
+    assert_connectionDone(p.mock_calls)
+
+
+def test_producer():
+    sc, m, scid, hostaddr, peeraddr, p = make_sc()
+
+    sc.pauseProducing()
+    assert m.mock_calls == [mock.call.subchannel_pauseProducing(sc)]
+    m.mock_calls[:] = []
+    sc.resumeProducing()
+    assert m.mock_calls == [mock.call.subchannel_resumeProducing(sc)]
+    m.mock_calls[:] = []
+    sc.stopProducing()
+    assert m.mock_calls == [mock.call.subchannel_stopProducing(sc)]
+    m.mock_calls[:] = []
+
+
+def test_consumer():
+    sc, m, scid, hostaddr, peeraddr, p = make_sc()
+
+    # TODO: more, once this is implemented
+    sc.registerProducer(None, True)
+    sc.unregisterProducer()
+
+
+def test_create():
+    sc, m, scid, hostaddr, peeraddr, p = make_sc(half_closeable=True)
+    assert ITransport.providedBy(sc)
+    assert m.mock_calls == []
+    assert sc.getHost() is hostaddr
+    assert sc.getPeer() is peeraddr
+
+
+def test_local_close():
+    sc, m, scid, hostaddr, peeraddr, p = make_sc(half_closeable=True)
+
+    sc.write(b"data")
+    assert m.mock_calls == [mock.call.send_data(scid, b"data")]
+    m.mock_calls[:] = []
+    sc.writeSequence([b"more", b"data"])
+    assert m.mock_calls == [mock.call.send_data(scid, b"moredata")]
+    m.mock_calls[:] = []
+
+    sc.remote_data(b"inbound1")
+    assert p.mock_calls == [mock.call.dataReceived(b"inbound1")]
+    p.mock_calls[:] = []
+
+    with pytest.raises(NormalCloseUsedOnHalfCloseable) as e:
+        sc.loseConnection()  # TODO: maybe this shouldn't be an error
+
+    # after a local close, we can't write anymore, but we can still
+    # receive data
+    sc.loseWriteConnection()  # TODO or loseConnection?
+    assert m.mock_calls == [mock.call.send_close(scid)]
+    m.mock_calls[:] = []
+    assert p.mock_calls == [mock.call.writeConnectionLost()]
+    p.mock_calls[:] = []
+
+    with pytest.raises(AlreadyClosedError) as e:
         sc.write(b"data")
-        self.assertEqual(m.mock_calls, [mock.call.send_data(scid, b"data")])
-        m.mock_calls[:] = []
-        sc.writeSequence([b"more", b"data"])
-        self.assertEqual(m.mock_calls, [mock.call.send_data(scid, b"moredata")])
-        m.mock_calls[:] = []
+    assert str(e.value) == "write not allowed on closed subchannel"
 
-        sc.remote_data(b"inbound1")
-        self.assertEqual(p.mock_calls, [mock.call.dataReceived(b"inbound1")])
-        p.mock_calls[:] = []
-
-        with self.assertRaises(NormalCloseUsedOnHalfCloseable) as e:
-            sc.loseConnection()  # TODO: maybe this shouldn't be an error
-
-        # after a local close, we can't write anymore, but we can still
-        # receive data
-        sc.loseWriteConnection()  # TODO or loseConnection?
-        self.assertEqual(m.mock_calls, [mock.call.send_close(scid)])
-        m.mock_calls[:] = []
-        self.assertEqual(p.mock_calls, [mock.call.writeConnectionLost()])
-        p.mock_calls[:] = []
-
-        with self.assertRaises(AlreadyClosedError) as e:
-            sc.write(b"data")
-        self.assertEqual(str(e.exception),
-                         "write not allowed on closed subchannel")
-
-        with self.assertRaises(AlreadyClosedError) as e:
-            sc.loseWriteConnection()
-        self.assertEqual(str(e.exception),
-                         "loseConnection not allowed on closed subchannel")
-
-        with self.assertRaises(NormalCloseUsedOnHalfCloseable) as e:
-            sc.loseConnection()  # TODO: maybe expect AlreadyClosedError
-
-        sc.remote_data(b"inbound2")
-        self.assertEqual(p.mock_calls, [mock.call.dataReceived(b"inbound2")])
-        p.mock_calls[:] = []
-
-        # the remote end will finally shut down the connection
-        sc.remote_close()
-        self.assertEqual(m.mock_calls, [mock.call.subchannel_closed(scid, sc)])
-        self.assertEqual(p.mock_calls, [mock.call.readConnectionLost()])
-
-    def test_remote_close(self):
-        sc, m, scid, hostaddr, peeraddr, p = make_sc(half_closeable=True)
-
-        sc.write(b"data")
-        self.assertEqual(m.mock_calls, [mock.call.send_data(scid, b"data")])
-        m.mock_calls[:] = []
-
-        sc.remote_data(b"inbound1")
-        self.assertEqual(p.mock_calls, [mock.call.dataReceived(b"inbound1")])
-        p.mock_calls[:] = []
-
-        # after a remote close, we can still write data
-        sc.remote_close()
-        self.assertEqual(m.mock_calls, [])
-        self.assertEqual(p.mock_calls, [mock.call.readConnectionLost()])
-        p.mock_calls[:] = []
-
-        sc.write(b"out2")
-        self.assertEqual(m.mock_calls, [mock.call.send_data(scid, b"out2")])
-        m.mock_calls[:] = []
-
-        # and a local close will shutdown the connection
+    with pytest.raises(AlreadyClosedError) as e:
         sc.loseWriteConnection()
-        self.assertEqual(m.mock_calls, [mock.call.send_close(scid),
-                                        mock.call.subchannel_closed(scid, sc)])
-        self.assertEqual(p.mock_calls, [mock.call.writeConnectionLost()])
+    assert str(e.value) == "loseConnection not allowed on closed subchannel"
+
+    with pytest.raises(NormalCloseUsedOnHalfCloseable) as e:
+        sc.loseConnection()  # TODO: maybe expect AlreadyClosedError
+
+    sc.remote_data(b"inbound2")
+    assert p.mock_calls == [mock.call.dataReceived(b"inbound2")]
+    p.mock_calls[:] = []
+
+    # the remote end will finally shut down the connection
+    sc.remote_close()
+    assert m.mock_calls == [mock.call.subchannel_closed(scid, sc)]
+    assert p.mock_calls == [mock.call.readConnectionLost()]
+
+
+def test_remote_close():
+    sc, m, scid, hostaddr, peeraddr, p = make_sc(half_closeable=True)
+
+    sc.write(b"data")
+    assert m.mock_calls == [mock.call.send_data(scid, b"data")]
+    m.mock_calls[:] = []
+
+    sc.remote_data(b"inbound1")
+    assert p.mock_calls == [mock.call.dataReceived(b"inbound1")]
+    p.mock_calls[:] = []
+
+    # after a remote close, we can still write data
+    sc.remote_close()
+    assert m.mock_calls == []
+    assert p.mock_calls == [mock.call.readConnectionLost()]
+    p.mock_calls[:] = []
+
+    sc.write(b"out2")
+    assert m.mock_calls == [mock.call.send_data(scid, b"out2")]
+    m.mock_calls[:] = []
+
+    # and a local close will shutdown the connection
+    sc.loseWriteConnection()
+    assert m.mock_calls == [mock.call.send_close(scid),
+                                    mock.call.subchannel_closed(scid, sc)]
+    assert p.mock_calls == [mock.call.writeConnectionLost()]

--- a/src/wormhole/test/dilate/test_traffic_timing.py
+++ b/src/wormhole/test/dilate/test_traffic_timing.py
@@ -1,65 +1,63 @@
-
-
-from twisted.trial import unittest
-
-
+import pytest
 from ..._dilation.manager import TrafficTimer
 
+# Correct operation of the TrafficTiming state-machine
 
-class TimingState(unittest.TestCase):
-    """
-    Correct operation of the TrafficTiming state-machine
-    """
-
-    def setUp(self):
+class TimerFixture:
+    def __init__(self):
         self.reconnects = []
         self.timers = []
 
-        timer_count = 0
-        reconnect_count = 0
+        self.timer_count = 0
+        self.reconnect_count = 0
+        self.t = TrafficTimer(self.do_reconnect, self.start_timer)
 
-        def start_timer():
-            nonlocal timer_count
-            self.timers.append(timer_count)
-            timer_count += 1
+    def start_timer(self):
+        self.timers.append(self.timer_count)
+        self.timer_count += 1
 
-        def do_reconnect():
-            nonlocal reconnect_count
-            self.reconnects.append(reconnect_count)
-            reconnect_count += 1
-        self.t = TrafficTimer(do_reconnect, start_timer)
+    def do_reconnect(self):
+        self.reconnects.append(self.reconnect_count)
+        self.reconnect_count += 1
 
-    def test_start(self):
-        """
-        We immedialte start a timer after connecting
-        """
-        self.t.got_connection()
-        self.assertEqual(self.timers, [0])
 
-    def test_one_interval(self):
-        """
-        No reconnect when only a single interval has passed
-        """
-        self.t.got_connection()
-        self.t.interval_elapsed()
-        # timer must be re-started after one elapsed interval
-        self.assertEqual(self.timers, [0, 1])
-        self.assertEqual(self.reconnects, [])
+@pytest.fixture()
+def traffic_timer():
+    yield TimerFixture()
 
-    def test_expired_connection(self):
-        """
-        Trigger a reconnect after two intervals pass with no traffic seen
-        """
-        self.t.got_connection()
-        self.t.interval_elapsed()
-        self.t.interval_elapsed()
-        # timer _not_ re-started after second interval, because now
-        # we're re-connecting
-        self.assertEqual(self.timers, [0, 1])
-        self.assertEqual(self.reconnects, [0])
 
-        # at some point after the re-connect trigger we would lose our
-        # connection
-        self.t.lost_connection()
-        self.assertEqual(self.timers, [0, 1])
-        self.assertEqual(self.reconnects, [0])
+def test_start(traffic_timer):
+    """
+    We immedialte start a timer after connecting
+    """
+    traffic_timer.t.got_connection()
+    assert traffic_timer.timers == [0]
+
+
+def test_one_interval(traffic_timer):
+    """
+    No reconnect when only a single interval has passed
+    """
+    traffic_timer.t.got_connection()
+    traffic_timer.t.interval_elapsed()
+    # timer must be re-started after one elapsed interval
+    assert traffic_timer.timers == [0, 1]
+    assert traffic_timer.reconnects == []
+
+def test_expired_connection(traffic_timer):
+    """
+    Trigger a reconnect after two intervals pass with no traffic seen
+    """
+    traffic_timer.t.got_connection()
+    traffic_timer.t.interval_elapsed()
+    traffic_timer.t.interval_elapsed()
+    # timer _not_ re-started after second interval, because now
+    # we're re-connecting
+    assert traffic_timer.timers == [0, 1]
+    assert traffic_timer.reconnects == [0]
+
+    # at some point after the re-connect trigger we would lose our
+    # connection
+    traffic_timer.t.lost_connection()
+    assert traffic_timer.timers == [0, 1]
+    assert traffic_timer.reconnects == [0]

--- a/src/wormhole/test/test_args.py
+++ b/src/wormhole/test/test_args.py
@@ -7,7 +7,7 @@ from ..cli.public_relay import RENDEZVOUS_RELAY, TRANSIT_RELAY
 from .common import config
 
 
-def test_baseline():
+def send_test_baseline():
     cfg = config("send", "--text", "hi")
     assert cfg.what == None
     assert cfg.code == None
@@ -23,55 +23,55 @@ def test_baseline():
     assert cfg.verify == False
     assert cfg.zeromode == False
 
-def test_appid():
+def send_test_appid():
     cfg = config("--appid", "xyz", "send", "--text", "hi")
     assert cfg.appid == "xyz"
     cfg = config("--appid=xyz", "send", "--text", "hi")
     assert cfg.appid == "xyz"
 
-def test_file():
+def send_test_file():
     cfg = config("send", "fn")
     assert cfg.what == u"fn"
     assert cfg.text == None
 
-def test_text():
+def send_test_text():
     cfg = config("send", "--text", "hi")
     assert cfg.what == None
     assert cfg.text == u"hi"
 
-def test_nolisten():
+def send_test_nolisten():
     cfg = config("send", "--no-listen", "fn")
     assert cfg.listen == False
 
-def test_code():
+def send_test_code():
     cfg = config("send", "--code", "1-abc", "fn")
     assert cfg.code == u"1-abc"
 
-def test_code_length():
+def send_test_code_length():
     cfg = config("send", "-c", "3", "fn")
     assert cfg.code_length == 3
 
-def test_dump_timing():
+def send_test_dump_timing():
     cfg = config("--dump-timing", "tx.json", "send", "fn")
     assert cfg.dump_timing == "tx.json"
 
-def test_hide_progress():
+def send_test_hide_progress():
     cfg = config("send", "--hide-progress", "fn")
     assert cfg.hide_progress == True
 
-def test_tor():
+def send_test_tor():
     cfg = config("send", "--tor", "fn")
     assert cfg.tor == True
 
-def test_verify():
+def send_test_verify():
     cfg = config("send", "--verify", "fn")
     assert cfg.verify == True
 
-def test_zeromode():
+def send_test_zeromode():
     cfg = config("send", "-0", "fn")
     assert cfg.zeromode == True
 
-def test_relay_env_var():
+def send_test_relay_env_var():
     relay_url = str(mock.sentinel.relay_url)
     with mock.patch.dict(os.environ, WORMHOLE_RELAY_URL=relay_url):
         cfg = config("send")
@@ -83,7 +83,7 @@ def test_relay_env_var():
         cfg = config("--relay-url", relay_url_2, "send")
     assert cfg.relay_url == relay_url_2
 
-def test_transit_env_var():
+def send_test_transit_env_var():
     transit_url = str(mock.sentinel.transit_url)
     with mock.patch.dict(os.environ, WORMHOLE_TRANSIT_HELPER=transit_url):
         cfg = config("send")
@@ -96,7 +96,7 @@ def test_transit_env_var():
     assert cfg.transit_helper == transit_url_2
 
 
-def test_baseline():
+def receive_test_baseline():
     cfg = config("receive")
     assert cfg.accept_file == False
     assert cfg.code is None
@@ -113,57 +113,57 @@ def test_baseline():
     assert cfg.verify == False
     assert cfg.zeromode == False
 
-def test_appid():
+def receive_test_appid():
     cfg = config("--appid", "xyz", "receive")
     assert cfg.appid == "xyz"
     cfg = config("--appid=xyz", "receive")
     assert cfg.appid == "xyz"
 
-def test_nolisten():
+def receive_test_nolisten():
     cfg = config("receive", "--no-listen")
     assert cfg.listen == False
 
-def test_code():
+def receive_test_code():
     cfg = config("receive", "1-abc")
     assert cfg.code == u"1-abc"
 
-def test_code_length():
+def receive_test_code_length():
     cfg = config("receive", "-c", "3", "--allocate")
     assert cfg.code_length == 3
 
-def test_dump_timing():
+def receive_test_dump_timing():
     cfg = config("--dump-timing", "tx.json", "receive")
     assert cfg.dump_timing == "tx.json"
 
-def test_hide_progress():
+def receive_test_hide_progress():
     cfg = config("receive", "--hide-progress")
     assert cfg.hide_progress
 
-def test_tor():
+def receive_test_tor():
     cfg = config("receive", "--tor")
     assert cfg.tor
 
-def test_verify():
+def receive_test_verify():
     cfg = config("receive", "--verify")
     assert cfg.verify
 
-def test_zeromode():
+def receive_test_zeromode():
     cfg = config("receive", "-0")
     assert cfg.zeromode
 
-def test_only_text():
+def receive_test_only_text():
     cfg = config("receive", "-t")
     assert cfg.only_text
 
-def test_accept_file():
+def receive_test_accept_file():
     cfg = config("receive", "--accept-file")
     assert cfg.accept_file
 
-def test_output_file():
+def receive_test_output_file():
     cfg = config("receive", "--output-file", "fn")
     assert cfg.output_file == u"fn"
 
-def test_relay_env_var():
+def receive_test_relay_env_var():
     relay_url = str(mock.sentinel.relay_url)
     with mock.patch.dict(os.environ, WORMHOLE_RELAY_URL=relay_url):
         cfg = config("receive")
@@ -175,7 +175,7 @@ def test_relay_env_var():
         cfg = config("--relay-url", relay_url_2, "receive")
     assert cfg.relay_url == relay_url_2
 
-def test_transit_env_var():
+def receive_test_transit_env_var():
     transit_url = str(mock.sentinel.transit_url)
     with mock.patch.dict(os.environ, WORMHOLE_TRANSIT_HELPER=transit_url):
         cfg = config("receive")
@@ -187,16 +187,16 @@ def test_transit_env_var():
         cfg = config("--transit-helper", transit_url_2, "receive")
     assert cfg.transit_helper == transit_url_2
 
-def test_accept_file_env_var():
+def receive_test_accept_file_env_var():
     with mock.patch.dict(os.environ, WORMHOLE_ACCEPT_FILE="true"):
         cfg = config("receive")
     assert cfg.accept_file
 
 
-def test_send():
+def receive_test_send():
     cfg = config("send")
     assert cfg.stdout == sys.stdout
 
-def test_receive():
+def receive_test_receive():
     cfg = config("receive")
     assert cfg.stdout == sys.stdout

--- a/src/wormhole/test/test_args.py
+++ b/src/wormhole/test/test_args.py
@@ -6,8 +6,7 @@ from unittest import mock
 from ..cli.public_relay import RENDEZVOUS_RELAY, TRANSIT_RELAY
 from .common import config
 
-
-def send_test_baseline():
+def test_send_baseline():
     cfg = config("send", "--text", "hi")
     assert cfg.what == None
     assert cfg.code == None
@@ -23,55 +22,55 @@ def send_test_baseline():
     assert cfg.verify == False
     assert cfg.zeromode == False
 
-def send_test_appid():
+def test_send_appid():
     cfg = config("--appid", "xyz", "send", "--text", "hi")
     assert cfg.appid == "xyz"
     cfg = config("--appid=xyz", "send", "--text", "hi")
     assert cfg.appid == "xyz"
 
-def send_test_file():
+def test_send_file():
     cfg = config("send", "fn")
     assert cfg.what == u"fn"
     assert cfg.text == None
 
-def send_test_text():
+def test_send_text():
     cfg = config("send", "--text", "hi")
     assert cfg.what == None
     assert cfg.text == u"hi"
 
-def send_test_nolisten():
+def test_send_nolisten():
     cfg = config("send", "--no-listen", "fn")
     assert cfg.listen == False
 
-def send_test_code():
+def test_send_code():
     cfg = config("send", "--code", "1-abc", "fn")
     assert cfg.code == u"1-abc"
 
-def send_test_code_length():
+def test_send_code_length():
     cfg = config("send", "-c", "3", "fn")
     assert cfg.code_length == 3
 
-def send_test_dump_timing():
+def test_send_dump_timing():
     cfg = config("--dump-timing", "tx.json", "send", "fn")
     assert cfg.dump_timing == "tx.json"
 
-def send_test_hide_progress():
+def test_send_hide_progress():
     cfg = config("send", "--hide-progress", "fn")
     assert cfg.hide_progress == True
 
-def send_test_tor():
+def test_send_tor():
     cfg = config("send", "--tor", "fn")
     assert cfg.tor == True
 
-def send_test_verify():
+def test_send_verify():
     cfg = config("send", "--verify", "fn")
     assert cfg.verify == True
 
-def send_test_zeromode():
+def test_send_zeromode():
     cfg = config("send", "-0", "fn")
     assert cfg.zeromode == True
 
-def send_test_relay_env_var():
+def test_send_relay_env_var():
     relay_url = str(mock.sentinel.relay_url)
     with mock.patch.dict(os.environ, WORMHOLE_RELAY_URL=relay_url):
         cfg = config("send")
@@ -83,7 +82,7 @@ def send_test_relay_env_var():
         cfg = config("--relay-url", relay_url_2, "send")
     assert cfg.relay_url == relay_url_2
 
-def send_test_transit_env_var():
+def test_send_transit_env_var():
     transit_url = str(mock.sentinel.transit_url)
     with mock.patch.dict(os.environ, WORMHOLE_TRANSIT_HELPER=transit_url):
         cfg = config("send")
@@ -96,7 +95,7 @@ def send_test_transit_env_var():
     assert cfg.transit_helper == transit_url_2
 
 
-def receive_test_baseline():
+def test_receive_baseline():
     cfg = config("receive")
     assert cfg.accept_file == False
     assert cfg.code is None
@@ -113,57 +112,57 @@ def receive_test_baseline():
     assert cfg.verify == False
     assert cfg.zeromode == False
 
-def receive_test_appid():
+def test_receive_appid():
     cfg = config("--appid", "xyz", "receive")
     assert cfg.appid == "xyz"
     cfg = config("--appid=xyz", "receive")
     assert cfg.appid == "xyz"
 
-def receive_test_nolisten():
+def test_receive_nolisten():
     cfg = config("receive", "--no-listen")
     assert cfg.listen == False
 
-def receive_test_code():
+def test_receive_code():
     cfg = config("receive", "1-abc")
     assert cfg.code == u"1-abc"
 
-def receive_test_code_length():
+def test_receive_code_length():
     cfg = config("receive", "-c", "3", "--allocate")
     assert cfg.code_length == 3
 
-def receive_test_dump_timing():
+def test_receive_dump_timing():
     cfg = config("--dump-timing", "tx.json", "receive")
     assert cfg.dump_timing == "tx.json"
 
-def receive_test_hide_progress():
+def test_receive_hide_progress():
     cfg = config("receive", "--hide-progress")
     assert cfg.hide_progress
 
-def receive_test_tor():
+def test_receive_tor():
     cfg = config("receive", "--tor")
     assert cfg.tor
 
-def receive_test_verify():
+def test_receive_verify():
     cfg = config("receive", "--verify")
     assert cfg.verify
 
-def receive_test_zeromode():
+def test_receive_zeromode():
     cfg = config("receive", "-0")
     assert cfg.zeromode
 
-def receive_test_only_text():
+def test_receive_only_text():
     cfg = config("receive", "-t")
     assert cfg.only_text
 
-def receive_test_accept_file():
+def test_receive_accept_file():
     cfg = config("receive", "--accept-file")
     assert cfg.accept_file
 
-def receive_test_output_file():
+def test_receive_output_file():
     cfg = config("receive", "--output-file", "fn")
     assert cfg.output_file == u"fn"
 
-def receive_test_relay_env_var():
+def test_receive_relay_env_var():
     relay_url = str(mock.sentinel.relay_url)
     with mock.patch.dict(os.environ, WORMHOLE_RELAY_URL=relay_url):
         cfg = config("receive")
@@ -175,7 +174,7 @@ def receive_test_relay_env_var():
         cfg = config("--relay-url", relay_url_2, "receive")
     assert cfg.relay_url == relay_url_2
 
-def receive_test_transit_env_var():
+def test_receive_transit_env_var():
     transit_url = str(mock.sentinel.transit_url)
     with mock.patch.dict(os.environ, WORMHOLE_TRANSIT_HELPER=transit_url):
         cfg = config("receive")
@@ -187,16 +186,16 @@ def receive_test_transit_env_var():
         cfg = config("--transit-helper", transit_url_2, "receive")
     assert cfg.transit_helper == transit_url_2
 
-def receive_test_accept_file_env_var():
+def test_receive_accept_file_env_var():
     with mock.patch.dict(os.environ, WORMHOLE_ACCEPT_FILE="true"):
         cfg = config("receive")
     assert cfg.accept_file
 
 
-def receive_test_send():
+def test_receive_send():
     cfg = config("send")
     assert cfg.stdout == sys.stdout
 
-def receive_test_receive():
+def test_receive_receive():
     cfg = config("receive")
     assert cfg.stdout == sys.stdout

--- a/src/wormhole/test/test_args.py
+++ b/src/wormhole/test/test_args.py
@@ -99,14 +99,14 @@ def test_transit_env_var():
 def test_baseline():
     cfg = config("receive")
     assert cfg.accept_file == False
-    assert cfg.code == None
+    assert cfg.code is None
     assert cfg.code_length == 2
-    assert cfg.dump_timing == None
+    assert cfg.dump_timing is None
     assert cfg.hide_progress == False
-    assert cfg.listen == True
+    assert cfg.listen
     assert cfg.only_text == False
-    assert cfg.output_file == None
-    assert cfg.appid == None
+    assert cfg.output_file is None
+    assert cfg.appid is None
     assert cfg.relay_url == RENDEZVOUS_RELAY
     assert cfg.transit_helper == TRANSIT_RELAY
     assert cfg.tor == False
@@ -137,27 +137,27 @@ def test_dump_timing():
 
 def test_hide_progress():
     cfg = config("receive", "--hide-progress")
-    assert cfg.hide_progress == True
+    assert cfg.hide_progress
 
 def test_tor():
     cfg = config("receive", "--tor")
-    assert cfg.tor == True
+    assert cfg.tor
 
 def test_verify():
     cfg = config("receive", "--verify")
-    assert cfg.verify == True
+    assert cfg.verify
 
 def test_zeromode():
     cfg = config("receive", "-0")
-    assert cfg.zeromode == True
+    assert cfg.zeromode
 
 def test_only_text():
     cfg = config("receive", "-t")
-    assert cfg.only_text == True
+    assert cfg.only_text
 
 def test_accept_file():
     cfg = config("receive", "--accept-file")
-    assert cfg.accept_file == True
+    assert cfg.accept_file
 
 def test_output_file():
     cfg = config("receive", "--output-file", "fn")
@@ -190,7 +190,7 @@ def test_transit_env_var():
 def test_accept_file_env_var():
     with mock.patch.dict(os.environ, WORMHOLE_ACCEPT_FILE="true"):
         cfg = config("receive")
-    assert cfg.accept_file == True
+    assert cfg.accept_file
 
 
 def test_send():

--- a/src/wormhole/test/test_args.py
+++ b/src/wormhole/test/test_args.py
@@ -1,207 +1,202 @@
 import os
 import sys
 
-from twisted.trial import unittest
-
 from unittest import mock
 
 from ..cli.public_relay import RENDEZVOUS_RELAY, TRANSIT_RELAY
 from .common import config
 
 
-class Send(unittest.TestCase):
-    def test_baseline(self):
-        cfg = config("send", "--text", "hi")
-        self.assertEqual(cfg.what, None)
-        self.assertEqual(cfg.code, None)
-        self.assertEqual(cfg.code_length, 2)
-        self.assertEqual(cfg.dump_timing, None)
-        self.assertEqual(cfg.hide_progress, False)
-        self.assertEqual(cfg.listen, True)
-        self.assertEqual(cfg.appid, None)
-        self.assertEqual(cfg.relay_url, RENDEZVOUS_RELAY)
-        self.assertEqual(cfg.transit_helper, TRANSIT_RELAY)
-        self.assertEqual(cfg.text, "hi")
-        self.assertEqual(cfg.tor, False)
-        self.assertEqual(cfg.verify, False)
-        self.assertEqual(cfg.zeromode, False)
+def test_baseline():
+    cfg = config("send", "--text", "hi")
+    assert cfg.what == None
+    assert cfg.code == None
+    assert cfg.code_length == 2
+    assert cfg.dump_timing == None
+    assert cfg.hide_progress == False
+    assert cfg.listen == True
+    assert cfg.appid == None
+    assert cfg.relay_url == RENDEZVOUS_RELAY
+    assert cfg.transit_helper == TRANSIT_RELAY
+    assert cfg.text == "hi"
+    assert cfg.tor == False
+    assert cfg.verify == False
+    assert cfg.zeromode == False
 
-    def test_appid(self):
-        cfg = config("--appid", "xyz", "send", "--text", "hi")
-        self.assertEqual(cfg.appid, "xyz")
-        cfg = config("--appid=xyz", "send", "--text", "hi")
-        self.assertEqual(cfg.appid, "xyz")
+def test_appid():
+    cfg = config("--appid", "xyz", "send", "--text", "hi")
+    assert cfg.appid == "xyz"
+    cfg = config("--appid=xyz", "send", "--text", "hi")
+    assert cfg.appid == "xyz"
 
-    def test_file(self):
-        cfg = config("send", "fn")
-        self.assertEqual(cfg.what, u"fn")
-        self.assertEqual(cfg.text, None)
+def test_file():
+    cfg = config("send", "fn")
+    assert cfg.what == u"fn"
+    assert cfg.text == None
 
-    def test_text(self):
-        cfg = config("send", "--text", "hi")
-        self.assertEqual(cfg.what, None)
-        self.assertEqual(cfg.text, u"hi")
+def test_text():
+    cfg = config("send", "--text", "hi")
+    assert cfg.what == None
+    assert cfg.text == u"hi"
 
-    def test_nolisten(self):
-        cfg = config("send", "--no-listen", "fn")
-        self.assertEqual(cfg.listen, False)
+def test_nolisten():
+    cfg = config("send", "--no-listen", "fn")
+    assert cfg.listen == False
 
-    def test_code(self):
-        cfg = config("send", "--code", "1-abc", "fn")
-        self.assertEqual(cfg.code, u"1-abc")
+def test_code():
+    cfg = config("send", "--code", "1-abc", "fn")
+    assert cfg.code == u"1-abc"
 
-    def test_code_length(self):
-        cfg = config("send", "-c", "3", "fn")
-        self.assertEqual(cfg.code_length, 3)
+def test_code_length():
+    cfg = config("send", "-c", "3", "fn")
+    assert cfg.code_length == 3
 
-    def test_dump_timing(self):
-        cfg = config("--dump-timing", "tx.json", "send", "fn")
-        self.assertEqual(cfg.dump_timing, "tx.json")
+def test_dump_timing():
+    cfg = config("--dump-timing", "tx.json", "send", "fn")
+    assert cfg.dump_timing == "tx.json"
 
-    def test_hide_progress(self):
-        cfg = config("send", "--hide-progress", "fn")
-        self.assertEqual(cfg.hide_progress, True)
+def test_hide_progress():
+    cfg = config("send", "--hide-progress", "fn")
+    assert cfg.hide_progress == True
 
-    def test_tor(self):
-        cfg = config("send", "--tor", "fn")
-        self.assertEqual(cfg.tor, True)
+def test_tor():
+    cfg = config("send", "--tor", "fn")
+    assert cfg.tor == True
 
-    def test_verify(self):
-        cfg = config("send", "--verify", "fn")
-        self.assertEqual(cfg.verify, True)
+def test_verify():
+    cfg = config("send", "--verify", "fn")
+    assert cfg.verify == True
 
-    def test_zeromode(self):
-        cfg = config("send", "-0", "fn")
-        self.assertEqual(cfg.zeromode, True)
+def test_zeromode():
+    cfg = config("send", "-0", "fn")
+    assert cfg.zeromode == True
 
-    def test_relay_env_var(self):
-        relay_url = str(mock.sentinel.relay_url)
-        with mock.patch.dict(os.environ, WORMHOLE_RELAY_URL=relay_url):
-            cfg = config("send")
-        self.assertEqual(cfg.relay_url, relay_url)
-
-        # Make sure cmd line option overrides environment variable
-        relay_url_2 = str(mock.sentinel.relay_url_2)
-        with mock.patch.dict(os.environ, WORMHOLE_RELAY_URL=relay_url):
-            cfg = config("--relay-url", relay_url_2, "send")
-        self.assertEqual(cfg.relay_url, relay_url_2)
-
-    def test_transit_env_var(self):
-        transit_url = str(mock.sentinel.transit_url)
-        with mock.patch.dict(os.environ, WORMHOLE_TRANSIT_HELPER=transit_url):
-            cfg = config("send")
-        self.assertEqual(cfg.transit_helper, transit_url)
-
-        # Make sure cmd line option overrides environment variable
-        transit_url_2 = str(mock.sentinel.transit_url_2)
-        with mock.patch.dict(os.environ, WORMHOLE_TRANSIT_HELPER=transit_url):
-            cfg = config("--transit-helper", transit_url_2, "send")
-        self.assertEqual(cfg.transit_helper, transit_url_2)
-
-
-class Receive(unittest.TestCase):
-    def test_baseline(self):
-        cfg = config("receive")
-        self.assertEqual(cfg.accept_file, False)
-        self.assertEqual(cfg.code, None)
-        self.assertEqual(cfg.code_length, 2)
-        self.assertEqual(cfg.dump_timing, None)
-        self.assertEqual(cfg.hide_progress, False)
-        self.assertEqual(cfg.listen, True)
-        self.assertEqual(cfg.only_text, False)
-        self.assertEqual(cfg.output_file, None)
-        self.assertEqual(cfg.appid, None)
-        self.assertEqual(cfg.relay_url, RENDEZVOUS_RELAY)
-        self.assertEqual(cfg.transit_helper, TRANSIT_RELAY)
-        self.assertEqual(cfg.tor, False)
-        self.assertEqual(cfg.verify, False)
-        self.assertEqual(cfg.zeromode, False)
-
-    def test_appid(self):
-        cfg = config("--appid", "xyz", "receive")
-        self.assertEqual(cfg.appid, "xyz")
-        cfg = config("--appid=xyz", "receive")
-        self.assertEqual(cfg.appid, "xyz")
-
-    def test_nolisten(self):
-        cfg = config("receive", "--no-listen")
-        self.assertEqual(cfg.listen, False)
-
-    def test_code(self):
-        cfg = config("receive", "1-abc")
-        self.assertEqual(cfg.code, u"1-abc")
-
-    def test_code_length(self):
-        cfg = config("receive", "-c", "3", "--allocate")
-        self.assertEqual(cfg.code_length, 3)
-
-    def test_dump_timing(self):
-        cfg = config("--dump-timing", "tx.json", "receive")
-        self.assertEqual(cfg.dump_timing, "tx.json")
-
-    def test_hide_progress(self):
-        cfg = config("receive", "--hide-progress")
-        self.assertEqual(cfg.hide_progress, True)
-
-    def test_tor(self):
-        cfg = config("receive", "--tor")
-        self.assertEqual(cfg.tor, True)
-
-    def test_verify(self):
-        cfg = config("receive", "--verify")
-        self.assertEqual(cfg.verify, True)
-
-    def test_zeromode(self):
-        cfg = config("receive", "-0")
-        self.assertEqual(cfg.zeromode, True)
-
-    def test_only_text(self):
-        cfg = config("receive", "-t")
-        self.assertEqual(cfg.only_text, True)
-
-    def test_accept_file(self):
-        cfg = config("receive", "--accept-file")
-        self.assertEqual(cfg.accept_file, True)
-
-    def test_output_file(self):
-        cfg = config("receive", "--output-file", "fn")
-        self.assertEqual(cfg.output_file, u"fn")
-
-    def test_relay_env_var(self):
-        relay_url = str(mock.sentinel.relay_url)
-        with mock.patch.dict(os.environ, WORMHOLE_RELAY_URL=relay_url):
-            cfg = config("receive")
-        self.assertEqual(cfg.relay_url, relay_url)
-
-        # Make sure cmd line option overrides environment variable
-        relay_url_2 = str(mock.sentinel.relay_url_2)
-        with mock.patch.dict(os.environ, WORMHOLE_RELAY_URL=relay_url):
-            cfg = config("--relay-url", relay_url_2, "receive")
-        self.assertEqual(cfg.relay_url, relay_url_2)
-
-    def test_transit_env_var(self):
-        transit_url = str(mock.sentinel.transit_url)
-        with mock.patch.dict(os.environ, WORMHOLE_TRANSIT_HELPER=transit_url):
-            cfg = config("receive")
-        self.assertEqual(cfg.transit_helper, transit_url)
-
-        # Make sure cmd line option overrides environment variable
-        transit_url_2 = str(mock.sentinel.transit_url_2)
-        with mock.patch.dict(os.environ, WORMHOLE_TRANSIT_HELPER=transit_url):
-            cfg = config("--transit-helper", transit_url_2, "receive")
-        self.assertEqual(cfg.transit_helper, transit_url_2)
-
-    def test_accept_file_env_var(self):
-        with mock.patch.dict(os.environ, WORMHOLE_ACCEPT_FILE="true"):
-            cfg = config("receive")
-        self.assertEqual(cfg.accept_file, True)
-
-
-class Config(unittest.TestCase):
-    def test_send(self):
+def test_relay_env_var():
+    relay_url = str(mock.sentinel.relay_url)
+    with mock.patch.dict(os.environ, WORMHOLE_RELAY_URL=relay_url):
         cfg = config("send")
-        self.assertEqual(cfg.stdout, sys.stdout)
+    assert cfg.relay_url == relay_url
 
-    def test_receive(self):
+    # Make sure cmd line option overrides environment variable
+    relay_url_2 = str(mock.sentinel.relay_url_2)
+    with mock.patch.dict(os.environ, WORMHOLE_RELAY_URL=relay_url):
+        cfg = config("--relay-url", relay_url_2, "send")
+    assert cfg.relay_url == relay_url_2
+
+def test_transit_env_var():
+    transit_url = str(mock.sentinel.transit_url)
+    with mock.patch.dict(os.environ, WORMHOLE_TRANSIT_HELPER=transit_url):
+        cfg = config("send")
+    assert cfg.transit_helper == transit_url
+
+    # Make sure cmd line option overrides environment variable
+    transit_url_2 = str(mock.sentinel.transit_url_2)
+    with mock.patch.dict(os.environ, WORMHOLE_TRANSIT_HELPER=transit_url):
+        cfg = config("--transit-helper", transit_url_2, "send")
+    assert cfg.transit_helper == transit_url_2
+
+
+def test_baseline():
+    cfg = config("receive")
+    assert cfg.accept_file == False
+    assert cfg.code == None
+    assert cfg.code_length == 2
+    assert cfg.dump_timing == None
+    assert cfg.hide_progress == False
+    assert cfg.listen == True
+    assert cfg.only_text == False
+    assert cfg.output_file == None
+    assert cfg.appid == None
+    assert cfg.relay_url == RENDEZVOUS_RELAY
+    assert cfg.transit_helper == TRANSIT_RELAY
+    assert cfg.tor == False
+    assert cfg.verify == False
+    assert cfg.zeromode == False
+
+def test_appid():
+    cfg = config("--appid", "xyz", "receive")
+    assert cfg.appid == "xyz"
+    cfg = config("--appid=xyz", "receive")
+    assert cfg.appid == "xyz"
+
+def test_nolisten():
+    cfg = config("receive", "--no-listen")
+    assert cfg.listen == False
+
+def test_code():
+    cfg = config("receive", "1-abc")
+    assert cfg.code == u"1-abc"
+
+def test_code_length():
+    cfg = config("receive", "-c", "3", "--allocate")
+    assert cfg.code_length == 3
+
+def test_dump_timing():
+    cfg = config("--dump-timing", "tx.json", "receive")
+    assert cfg.dump_timing == "tx.json"
+
+def test_hide_progress():
+    cfg = config("receive", "--hide-progress")
+    assert cfg.hide_progress == True
+
+def test_tor():
+    cfg = config("receive", "--tor")
+    assert cfg.tor == True
+
+def test_verify():
+    cfg = config("receive", "--verify")
+    assert cfg.verify == True
+
+def test_zeromode():
+    cfg = config("receive", "-0")
+    assert cfg.zeromode == True
+
+def test_only_text():
+    cfg = config("receive", "-t")
+    assert cfg.only_text == True
+
+def test_accept_file():
+    cfg = config("receive", "--accept-file")
+    assert cfg.accept_file == True
+
+def test_output_file():
+    cfg = config("receive", "--output-file", "fn")
+    assert cfg.output_file == u"fn"
+
+def test_relay_env_var():
+    relay_url = str(mock.sentinel.relay_url)
+    with mock.patch.dict(os.environ, WORMHOLE_RELAY_URL=relay_url):
         cfg = config("receive")
-        self.assertEqual(cfg.stdout, sys.stdout)
+    assert cfg.relay_url == relay_url
+
+    # Make sure cmd line option overrides environment variable
+    relay_url_2 = str(mock.sentinel.relay_url_2)
+    with mock.patch.dict(os.environ, WORMHOLE_RELAY_URL=relay_url):
+        cfg = config("--relay-url", relay_url_2, "receive")
+    assert cfg.relay_url == relay_url_2
+
+def test_transit_env_var():
+    transit_url = str(mock.sentinel.transit_url)
+    with mock.patch.dict(os.environ, WORMHOLE_TRANSIT_HELPER=transit_url):
+        cfg = config("receive")
+    assert cfg.transit_helper == transit_url
+
+    # Make sure cmd line option overrides environment variable
+    transit_url_2 = str(mock.sentinel.transit_url_2)
+    with mock.patch.dict(os.environ, WORMHOLE_TRANSIT_HELPER=transit_url):
+        cfg = config("--transit-helper", transit_url_2, "receive")
+    assert cfg.transit_helper == transit_url_2
+
+def test_accept_file_env_var():
+    with mock.patch.dict(os.environ, WORMHOLE_ACCEPT_FILE="true"):
+        cfg = config("receive")
+    assert cfg.accept_file == True
+
+
+def test_send():
+    cfg = config("send")
+    assert cfg.stdout == sys.stdout
+
+def test_receive():
+    cfg = config("receive")
+    assert cfg.stdout == sys.stdout

--- a/src/wormhole/test/test_args.py
+++ b/src/wormhole/test/test_args.py
@@ -8,19 +8,19 @@ from .common import config
 
 def test_send_baseline():
     cfg = config("send", "--text", "hi")
-    assert cfg.what == None
-    assert cfg.code == None
+    assert cfg.what is None
+    assert cfg.code is None
     assert cfg.code_length == 2
-    assert cfg.dump_timing == None
-    assert cfg.hide_progress == False
-    assert cfg.listen == True
-    assert cfg.appid == None
+    assert cfg.dump_timing is None
+    assert not cfg.hide_progress
+    assert cfg.listen
+    assert cfg.appid is None
     assert cfg.relay_url == RENDEZVOUS_RELAY
     assert cfg.transit_helper == TRANSIT_RELAY
     assert cfg.text == "hi"
-    assert cfg.tor == False
-    assert cfg.verify == False
-    assert cfg.zeromode == False
+    assert not cfg.tor
+    assert not cfg.verify
+    assert not cfg.zeromode
 
 def test_send_appid():
     cfg = config("--appid", "xyz", "send", "--text", "hi")
@@ -31,16 +31,16 @@ def test_send_appid():
 def test_send_file():
     cfg = config("send", "fn")
     assert cfg.what == u"fn"
-    assert cfg.text == None
+    assert cfg.text is None
 
 def test_send_text():
     cfg = config("send", "--text", "hi")
-    assert cfg.what == None
+    assert cfg.what is None
     assert cfg.text == u"hi"
 
 def test_send_nolisten():
     cfg = config("send", "--no-listen", "fn")
-    assert cfg.listen == False
+    assert not cfg.listen
 
 def test_send_code():
     cfg = config("send", "--code", "1-abc", "fn")
@@ -56,19 +56,19 @@ def test_send_dump_timing():
 
 def test_send_hide_progress():
     cfg = config("send", "--hide-progress", "fn")
-    assert cfg.hide_progress == True
+    assert cfg.hide_progress
 
 def test_send_tor():
     cfg = config("send", "--tor", "fn")
-    assert cfg.tor == True
+    assert cfg.tor
 
 def test_send_verify():
     cfg = config("send", "--verify", "fn")
-    assert cfg.verify == True
+    assert cfg.verify
 
 def test_send_zeromode():
     cfg = config("send", "-0", "fn")
-    assert cfg.zeromode == True
+    assert cfg.zeromode
 
 def test_send_relay_env_var():
     relay_url = str(mock.sentinel.relay_url)
@@ -97,20 +97,20 @@ def test_send_transit_env_var():
 
 def test_receive_baseline():
     cfg = config("receive")
-    assert cfg.accept_file == False
+    assert not cfg.accept_file
     assert cfg.code is None
     assert cfg.code_length == 2
     assert cfg.dump_timing is None
-    assert cfg.hide_progress == False
+    assert not cfg.hide_progress
     assert cfg.listen
-    assert cfg.only_text == False
+    assert not cfg.only_text
     assert cfg.output_file is None
     assert cfg.appid is None
     assert cfg.relay_url == RENDEZVOUS_RELAY
     assert cfg.transit_helper == TRANSIT_RELAY
-    assert cfg.tor == False
-    assert cfg.verify == False
-    assert cfg.zeromode == False
+    assert not cfg.tor
+    assert not cfg.verify
+    assert not cfg.zeromode
 
 def test_receive_appid():
     cfg = config("--appid", "xyz", "receive")
@@ -120,7 +120,7 @@ def test_receive_appid():
 
 def test_receive_nolisten():
     cfg = config("receive", "--no-listen")
-    assert cfg.listen == False
+    assert not cfg.listen
 
 def test_receive_code():
     cfg = config("receive", "1-abc")

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -20,8 +20,8 @@ from zope.interface import implementer
 
 from unittest import mock
 
-import pytest_twisted
 import pytest
+import pytest_twisted
 
 from .. import __version__
 from .._interfaces import ITorManager
@@ -751,52 +751,52 @@ async def _do_test(
                 os.stat(fn).st_mode))
 
 async def test_text(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox, tmpdir_factory)
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory)
 
 async def test_text_subprocess(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox, tmpdir_factory, as_subprocess=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, as_subprocess=True)
 
 async def test_text_tor(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox, tmpdir_factory, fake_tor=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, fake_tor=True)
 
 async def test_text_verify(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox, tmpdir_factory, verify=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, verify=True)
 
 async def test_file(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox, tmpdir_factory, mode="file")
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="file")
 
 async def test_file_override(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox, tmpdir_factory, mode="file", override_filename=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="file", override_filename=True)
 
 async def test_file_overwrite(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox, tmpdir_factory, mode="file", overwrite=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="file", overwrite=True)
 
 async def test_file_overwrite_mock_accept(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox, tmpdir_factory, mode="file", overwrite=True, mock_accept=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="file", overwrite=True, mock_accept=True)
 
 async def test_file_tor(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox, tmpdir_factory, mode="file", fake_tor=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="file", fake_tor=True)
 
 async def test_empty_file(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox, tmpdir_factory, mode="empty-file")
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="empty-file")
 
 async def test_directory(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox, tmpdir_factory, mode="directory")
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="directory")
 
 async def test_directory_addslash(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox, tmpdir_factory, mode="directory", addslash=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="directory", addslash=True)
 
 async def test_directory_override(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox, tmpdir_factory, mode="directory", override_filename=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="directory", override_filename=True)
 
 async def test_directory_overwrite(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox, tmpdir_factory, mode="directory", overwrite=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="directory", overwrite=True)
 
 async def test_directory_overwrite_mock_accept(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
     await _do_test(
         wormhole_executable,
         scripts_env,
-        mailbox,
+        mailbox.url,
         tmpdir_factory,
         mode="directory",
         overwrite=True,
@@ -804,10 +804,10 @@ async def test_directory_overwrite_mock_accept(wormhole_executable, scripts_env,
     )
 
 async def test_slow_text(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox, tmpdir_factory, mode="slow-text")
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="slow-text")
 
 async def test_slow_sender_text(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox, tmpdir_factory, mode="slow-sender-text")
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="slow-sender-text")
 
 
 @pytest_twisted.ensureDeferred
@@ -975,209 +975,219 @@ async def _do_test_fail(wormhole_executable, scripts_env, relayurl, tmpdir_facto
             self.failUnlessEqual(f.read(), PRESERVE)
 
 async def test_fail_file_noclobber(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_tests_fail(wormhole_executable, scripts_env, mailbox, tmpdir_factory, "file", "noclobber")
+    await _do_tests_fail(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, "file", "noclobber")
 
 async def test_fail_directory_noclobber(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_tests_fail(wormhole_executable, scripts_env, mailbox, tmpdir_factory, "directory", "noclobber")
+    await _do_tests_fail(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, "directory", "noclobber")
 
 async def test_fail_file_toobig(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_tests_fail(wormhole_executable, scripts_env, mailbox, tmpdir_factory, "file", "toobig")
+    await _do_tests_fail(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, "file", "toobig")
 
 async def test_fail_directory_toobig(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_tests_fail(wormhole_executable, scripts_env, mailbox, tmpdir_factory, "directory", "toobig")
+    await _do_tests_fail(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, "directory", "toobig")
 
 
-class ServerBase:
-    async def setUp(self):
-        pass
+@pytest_twisted.ensureDeferred
+async def test_text(mailbox):
+    send_cfg = config("send")
+    recv_cfg = config("receive")
+    message = "textponies"
 
-class ZeroMode(ServerBase, unittest.TestCase):
-    @pytest_twisted.ensureDeferred
-    async def test_text(self):
-        send_cfg = config("send")
-        recv_cfg = config("receive")
-        message = "textponies"
-
-        for cfg in [send_cfg, recv_cfg]:
-            cfg.hide_progress = True
-            cfg.relay_url = self.relayurl
-            cfg.transit_helper = ""
-            cfg.listen = True
-            cfg.zeromode = True
-            cfg.stdout = io.StringIO()
-            cfg.stderr = io.StringIO()
-
-        send_cfg.text = message
-
-        # send_cfg.cwd = send_dir
-        # recv_cfg.cwd = receive_dir
-
-        send_d = cmd_send.send(send_cfg)
-        receive_d = cmd_receive.receive(recv_cfg)
-
-        await gatherResults([send_d, receive_d], True)
-
-        send_stdout = send_cfg.stdout.getvalue()
-        send_stderr = send_cfg.stderr.getvalue()
-        receive_stdout = recv_cfg.stdout.getvalue()
-        receive_stderr = recv_cfg.stderr.getvalue()
-
-        # all output here comes from a StringIO, which uses \n for
-        # newlines, even if we're on windows
-        NL = "\n"
-
-        self.maxDiff = None  # show full output for assertion failures
-
-        self.assertEqual(send_stdout, "")
-
-        # check sender
-        expected = ("Sending text message ({bytes:d} Bytes){NL}"
-                    "On the other computer, please run:{NL}"
-                    "{NL}"
-                    "wormhole receive -0{NL}"
-                    "{NL}"
-                    "text message sent{NL}").format(
-                        bytes=len(message), NL=NL)
-        self.failUnlessEqual(send_stderr, expected)
-
-        # check receiver
-        self.assertEqual(receive_stdout, message + NL)
-        self.assertEqual(receive_stderr, "")
-
-
-class NotWelcome(ServerBase, unittest.TestCase):
-    @pytest_twisted.ensureDeferred
-    async def setUp(self):
-        await self._setup_relay(error="please upgrade XYZ")
-        self.cfg = cfg = config("send")
-        cfg.hide_progress = True
-        cfg.listen = False
-        cfg.relay_url = self.relayurl
-        cfg.transit_helper = ""
-        cfg.stdout = io.StringIO()
-        cfg.stderr = io.StringIO()
-
-    @pytest_twisted.ensureDeferred
-    async def test_sender(self):
-        self.cfg.text = "hi"
-        self.cfg.code = u"1-abc"
-
-        send_d = cmd_send.send(self.cfg)
-        f = await self.assertFailure(send_d, WelcomeError)
-        self.assertEqual(str(f), "please upgrade XYZ")
-
-    @pytest_twisted.ensureDeferred
-    async def test_receiver(self):
-        self.cfg.code = u"1-abc"
-
-        receive_d = cmd_receive.receive(self.cfg)
-        f = await self.assertFailure(receive_d, WelcomeError)
-        self.assertEqual(str(f), "please upgrade XYZ")
-
-
-class NoServer(ServerBase, unittest.TestCase):
-    @pytest_twisted.ensureDeferred
-    async def setUp(self):
-        await self._setup_relay(None)
-        await self._relay_server.disownServiceParent()
-
-    @pytest_twisted.ensureDeferred
-    async def test_sender(self):
-        cfg = config("send")
-        cfg.hide_progress = True
-        cfg.listen = False
-        cfg.relay_url = self.relayurl
-        cfg.transit_helper = ""
-        cfg.stdout = io.StringIO()
-        cfg.stderr = io.StringIO()
-
-        cfg.text = "hi"
-        cfg.code = u"1-abc"
-
-        send_d = cmd_send.send(cfg)
-        e = await self.assertFailure(send_d, ServerConnectionError)
-        self.assertIsInstance(e.reason, ConnectionRefusedError)
-
-    @pytest_twisted.ensureDeferred
-    async def test_sender_allocation(self):
-        cfg = config("send")
-        cfg.hide_progress = True
-        cfg.listen = False
-        cfg.relay_url = self.relayurl
-        cfg.transit_helper = ""
-        cfg.stdout = io.StringIO()
-        cfg.stderr = io.StringIO()
-
-        cfg.text = "hi"
-
-        send_d = cmd_send.send(cfg)
-        e = await self.assertFailure(send_d, ServerConnectionError)
-        self.assertIsInstance(e.reason, ConnectionRefusedError)
-
-    @pytest_twisted.ensureDeferred
-    async def test_receiver(self):
-        cfg = config("receive")
-        cfg.hide_progress = True
-        cfg.listen = False
-        cfg.relay_url = self.relayurl
-        cfg.transit_helper = ""
-        cfg.stdout = io.StringIO()
-        cfg.stderr = io.StringIO()
-
-        cfg.code = u"1-abc"
-
-        receive_d = cmd_receive.receive(cfg)
-        e = await self.assertFailure(receive_d, ServerConnectionError)
-        self.assertIsInstance(e.reason, ConnectionRefusedError)
-
-
-class Cleanup(ServerBase, unittest.TestCase):
-    def make_config(self):
-        cfg = config("send")
-        # common options for all tests in this suite
+    for cfg in [send_cfg, recv_cfg]:
         cfg.hide_progress = True
         cfg.relay_url = self.relayurl
         cfg.transit_helper = ""
+        cfg.listen = True
+        cfg.zeromode = True
         cfg.stdout = io.StringIO()
         cfg.stderr = io.StringIO()
-        return cfg
 
-    @pytest_twisted.ensureDeferred
-    @mock.patch('sys.stdout')
-    async def test_text(self, stdout):
+    send_cfg.text = message
+
+    # send_cfg.cwd = send_dir
+    # recv_cfg.cwd = receive_dir
+
+    send_d = cmd_send.send(send_cfg)
+    receive_d = cmd_receive.receive(recv_cfg)
+
+    await gatherResults([send_d, receive_d], True)
+
+    send_stdout = send_cfg.stdout.getvalue()
+    send_stderr = send_cfg.stderr.getvalue()
+    receive_stdout = recv_cfg.stdout.getvalue()
+    receive_stderr = recv_cfg.stderr.getvalue()
+
+    # all output here comes from a StringIO, which uses \n for
+    # newlines, even if we're on windows
+    NL = "\n"
+
+    assert send_stdout == ""
+
+    # check sender
+    expected = ("Sending text message ({bytes:d} Bytes){NL}"
+                "On the other computer, please run:{NL}"
+                "{NL}"
+                "wormhole receive -0{NL}"
+                "{NL}"
+                "text message sent{NL}").format(
+                    bytes=len(message), NL=NL)
+    assert send_stderr == expected
+    # check receiver
+    assert receive_stdout == message + NL
+    assert receive_stderr == ""
+
+
+from .common import setup_mailbox
+
+
+@pytest.fixture(scope="module")
+def unwelcome_mailbox(reactor):
+    url, service = setup_mailbox(reactor, error="please upgrade XYZ")
+    pytest_twisted.blockon(service.startService())
+    yield url
+    pytest_twisted.blockon(service.stopService())
+
+
+@pytest.fixture()
+def unwelcome_config(unwelcome_mailbox):
+    cfg = config("send")
+    cfg.hide_progress = True
+    cfg.listen = False
+    cfg.relay_url = unwelcome_mailbox
+    cfg.transit_helper = ""
+    cfg.stdout = io.StringIO()
+    cfg.stderr = io.StringIO()
+
+
+@pytest_twisted.ensureDeferred
+async def test_sender(unwelcome_config):
+    unwelcome_config.text = "hi"
+    unwelcome_config.code = u"1-abc"
+
+    send_d = cmd_send.send(unwelcome_config)
+    f = await self.assertFailure(send_d, WelcomeError)
+    self.assertEqual(str(f), "please upgrade XYZ")
+
+@pytest_twisted.ensureDeferred
+async def test_receiver(self):
+    unwelcome_config.code = u"1-abc"
+
+    receive_d = cmd_receive.receive(unwelcome_config)
+    f = await self.assertFailure(receive_d, WelcomeError)
+    self.assertEqual(str(f), "please upgrade XYZ")
+
+
+@pytest.fixture(scope="module")
+def no_mailbox(reactor):
+    url, service = setup_mailbox(reactor)
+    # the original tests these ported from did this ... seems like
+    # overkill, if Twisted is "working properly" this will be the same
+    # as selecting any non-listening port and just creating a url?
+    pytest_twisted.blockon(service.startService())
+    pytest_twisted.blockon(service.stopService())
+    yield url
+
+
+@pytest_twisted.ensureDeferred
+async def test_sender(no_mailbox):
+    cfg = config("send")
+    cfg.hide_progress = True
+    cfg.listen = False
+    cfg.relay_url = no_mailbox
+    cfg.transit_helper = ""
+    cfg.stdout = io.StringIO()
+    cfg.stderr = io.StringIO()
+
+    cfg.text = "hi"
+    cfg.code = u"1-abc"
+
+    with pytest.raises(ServerConnectionError) as e:
+        await cmd_send.send(cfg)
+        assert isinstance(e.reason, ConnectionRefusedError)
+
+@pytest_twisted.ensureDeferred
+async def test_sender_allocation(no_mailbox):
+    cfg = config("send")
+    cfg.hide_progress = True
+    cfg.listen = False
+    cfg.relay_url = no_mailbox
+    cfg.transit_helper = ""
+    cfg.stdout = io.StringIO()
+    cfg.stderr = io.StringIO()
+
+    cfg.text = "hi"
+
+    with pytest.raises(ServerConnectionError) as e:
+        await cmd_send.send(cfg)
+        assert isinstance(e.reason, ConnectionRefusedError)
+
+@pytest_twisted.ensureDeferred
+async def test_receiver(no_mailbox):
+    cfg = config("receive")
+    cfg.hide_progress = True
+    cfg.listen = False
+    cfg.relay_url = no_mailbox
+    cfg.transit_helper = ""
+    cfg.stdout = io.StringIO()
+    cfg.stderr = io.StringIO()
+
+    cfg.code = u"1-abc"
+
+    with pytest.raises(ServerConnectionError) as e:
+        await cmd_receive.receive(cfg)
+        assert isinstance(e.reason, ConnectionRefusedError)
+
+
+@pytest.fixture()
+def send_config(mailbox):
+    cfg = create_config("send", mailbox.url)
+    cfg.allocate = True
+    yield cfg
+
+
+def create_config(name, url):
+    cfg = config(name)
+    # common options for all tests in this suite
+    cfg.hide_progress = True
+    cfg.relay_url = url
+    cfg.transit_helper = ""
+    cfg.stdout = io.StringIO()
+    cfg.stderr = io.StringIO()
+    cfg.allocate = False
+    return cfg
+
+
+@pytest_twisted.ensureDeferred
+async def test_text(send_config):
+    with mock.patch('sys.stdout') as stdout:
         # the rendezvous channel should be deleted after success
-        cfg = self.make_config()
-        cfg.text = "hello"
-        cfg.code = u"1-abc"
-
-        send_d = cmd_send.send(cfg)
-        receive_d = cmd_receive.receive(cfg)
+        send_d = cmd_send.send(send_config)
+        receive_d = cmd_receive.receive(send_config)
 
         await send_d
         await receive_d
 
-        cids = self._rendezvous.get_app(cmd_send.APPID).get_nameplate_ids()
-        self.assertEqual(len(cids), 0)
+        # XXX FIXME: hard-mode to reach in this far with current fixture
+        ##cids = self._rendezvous.get_app(cmd_send.APPID).get_nameplate_ids()
+        ##assert len(cids) == 0
 
-    @pytest_twisted.ensureDeferred
-    async def test_text_wrong_password(self):
-        # if the password was wrong, the rendezvous channel should still be
-        # deleted
-        send_cfg = self.make_config()
-        send_cfg.text = "secret message"
-        send_cfg.code = u"1-abc"
-        send_d = cmd_send.send(send_cfg)
 
-        rx_cfg = self.make_config()
-        rx_cfg.code = u"1-WRONG"
-        receive_d = cmd_receive.receive(rx_cfg)
+@pytest_twisted.ensureDeferred
+async def test_text_wrong_password(send_config):
+    # if the password was wrong, the rendezvous channel should still be
+    # deleted
+    send_d = cmd_send.send(send_config)
 
-        # both sides should be capable of detecting the mismatch
-        await self.assertFailure(send_d, WrongPasswordError)
-        await self.assertFailure(receive_d, WrongPasswordError)
+    rx_cfg = self.make_config()
+    rx_cfg.code = u"1-WRONG"
+    receive_d = cmd_receive.receive(rx_cfg)
 
-        cids = self._rendezvous.get_app(cmd_send.APPID).get_nameplate_ids()
-        self.assertEqual(len(cids), 0)
+    # both sides should be capable of detecting the mismatch
+    await self.assertFailure(send_d, WrongPasswordError)
+    await self.assertFailure(receive_d, WrongPasswordError)
+
+    cids = self._rendezvous.get_app(cmd_send.APPID).get_nameplate_ids()
+    self.assertEqual(len(cids), 0)
 
 
 class ExtractFile(unittest.TestCase):
@@ -1194,15 +1204,15 @@ class ExtractFile(unittest.TestCase):
         expected = os.path.join(extract_dir, "ok")
         with mock.patch.object(cmd_receive.os, "chmod") as chmod:
             ef(zf, zi, extract_dir)
-            self.assertEqual(zf.extract.mock_calls,
-                             [mock.call(zi.filename, path=extract_dir)])
-            self.assertEqual(chmod.mock_calls, [mock.call(expected, 5)])
+            assert zf.extract.mock_calls == [mock.call(zi.filename, path=extract_dir)]
+            assert chmod.mock_calls == [mock.call(expected, 5)]
 
         zf = mock.Mock()
         zi = mock.Mock()
         zi.filename = "../haha"
-        e = self.assertRaises(ValueError, ef, zf, zi, extract_dir)
-        self.assertIn("malicious zipfile", str(e))
+        with pytest.raises(ValueError) as e:
+            ef(zf, zi, extract_dir)
+            assert "malicious zipfile" in str(e)
 
         zf = mock.Mock()
         zi = mock.Mock()
@@ -1212,46 +1222,30 @@ class ExtractFile(unittest.TestCase):
         expected = os.path.join(extract_dir, "haha", "root")
         with mock.patch.object(cmd_receive.os, "chmod") as chmod:
             ef(zf, zi, extract_dir)
-            self.assertEqual(zf.extract.mock_calls,
-                             [mock.call(zi.filename, path=extract_dir)])
-            self.assertEqual(chmod.mock_calls, [mock.call(expected, 5)])
+            assert zf.extract.mock_calls, [mock.call(zi.filename, path=extract_dir)]
+            assert chmod.mock_calls == [mock.call(expected, 5)]
 
         zf = mock.Mock()
         zi = mock.Mock()
         zi.filename = "/etc/passwd"
-        e = self.assertRaises(ValueError, ef, zf, zi, extract_dir)
-        self.assertIn("malicious zipfile", str(e))
+        with pytest.raises(ValueError) as e:
+            ef(zf, zi, extract_dir)
+            assert "malicious zipfile" in str(e)
 
 
-class AppID(ServerBase, unittest.TestCase):
-    @pytest_twisted.ensureDeferred
-    async def setUp(self):
-        await super(AppID, self).setUp()
-        self.cfg = cfg = config("send")
-        # common options for all tests in this suite
-        cfg.hide_progress = True
-        cfg.relay_url = self.relayurl
-        cfg.transit_helper = ""
-        cfg.stdout = io.StringIO()
-        cfg.stderr = io.StringIO()
+@pytest_twisted.ensureDeferred
+async def test_override(mailbox, send_config):
+    from twisted.internet.defer import ensureDeferred
+    send_config.text = "some text"
+    send_d = ensureDeferred(cmd_send.send(send_config))
+    receive_d = ensureDeferred(cmd_receive.receive(send_config))
 
-    @pytest_twisted.ensureDeferred
-    async def test_override(self):
-        # make sure we use the overridden appid, not the default
-        self.cfg.text = "hello"
-        self.cfg.appid = u"appid2"
-        self.cfg.code = u"1-abc"
+    await gatherResults([send_d, receive_d])
 
-        send_d = cmd_send.send(self.cfg)
-        receive_d = cmd_receive.receive(self.cfg)
-
-        await send_d
-        await receive_d
-
-        used = self._usage_db.execute("SELECT DISTINCT `app_id`"
-                                      " FROM `nameplates`").fetchall()
-        self.assertEqual(len(used), 1, used)
-        self.assertEqual(used[0]["app_id"], u"appid2")
+    used = mailbox.usage_db.execute(
+        "SELECT DISTINCT `app_id` FROM `nameplates`").fetchall()
+    assert len(used) == 1, f"Incorrect nameplates: {used}"
+    assert used[0]["app_id"] == u"appid2"
 
 
 class Welcome(unittest.TestCase):

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -190,7 +190,7 @@ class OfferData(unittest.TestCase):
 
         with pytest.raises(TypeError) as e:
             build_offer(self.cfg)
-        assert str(e) == "'%s' is neither file nor directory" % filename
+        assert str(e.value) == "'%s' is neither file nor directory" % filename
 
     def test_symlink(self):
         if not hasattr(os, 'symlink'):
@@ -1102,7 +1102,7 @@ async def test_sender(no_mailbox):
 
     with pytest.raises(ServerConnectionError) as e:
         await cmd_send.send(cfg)
-        assert isinstance(e.reason, ConnectionRefusedError)
+    assert isinstance(e.value.reason, ConnectionRefusedError)
 
 @pytest_twisted.ensureDeferred
 async def test_sender_allocation(no_mailbox):
@@ -1118,7 +1118,7 @@ async def test_sender_allocation(no_mailbox):
 
     with pytest.raises(ServerConnectionError) as e:
         await cmd_send.send(cfg)
-        assert isinstance(e.reason, ConnectionRefusedError)
+    assert isinstance(e.value.reason, ConnectionRefusedError)
 
 @pytest_twisted.ensureDeferred
 async def test_receiver(no_mailbox):
@@ -1134,7 +1134,7 @@ async def test_receiver(no_mailbox):
 
     with pytest.raises(ServerConnectionError) as e:
         await cmd_receive.receive(cfg)
-        assert isinstance(e.reason, ConnectionRefusedError)
+    assert isinstance(e.value.reason, ConnectionRefusedError)
 
 
 @pytest.fixture()
@@ -1232,7 +1232,7 @@ class ExtractFile(unittest.TestCase):
         zi.filename = "/etc/passwd"
         with pytest.raises(ValueError) as e:
             ef(zf, zi, extract_dir)
-            assert "malicious zipfile" in str(e)
+        assert "malicious zipfile" in str(e.value)
 
 
 @pytest_twisted.ensureDeferred

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -629,6 +629,7 @@ async def _do_test(
         if fake_tor:
             expected_endpoints = [("127.0.0.1", mailbox.port._realPortNumber, False)]
             if mode in ("file", "directory"):
+                transitport = int(transiturl.split(":")[2])
                 expected_endpoints.append(("127.0.0.1", transitport, False))
             tx_timing = mtx_tm.call_args[1]["timing"]
             assert tx_tm.endpoints == expected_endpoints
@@ -744,8 +745,8 @@ async def test_text(wormhole_executable, scripts_env, mailbox, transit_relay, tm
 async def test_text_subprocess(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
     await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, as_subprocess=True)
 
-##async def test_text_tor(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-##    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, fake_tor=True)
+async def test_text_tor(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, fake_tor=True)
 
 async def test_text_verify(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
     await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, verify=True)
@@ -762,8 +763,8 @@ async def test_file_overwrite(wormhole_executable, scripts_env, mailbox, transit
 async def test_file_overwrite_mock_accept(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
     await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, mode="file", overwrite=True, mock_accept=True)
 
-##async def test_file_tor(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-##    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, mode="file", fake_tor=True)
+async def test_file_tor(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, mode="file", fake_tor=True)
 
 async def test_empty_file(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
     await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, mode="empty-file")
@@ -930,14 +931,14 @@ async def _do_test_fail(wormhole_executable, scripts_env, relayurl, tmpdir_facto
 async def test_fail_file_noclobber(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
     await _do_test_fail(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, "file", "noclobber")
 
-#async def test_fail_directory_noclobber(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-#    await _do_test_fail(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, "directory", "noclobber")
+async def test_fail_directory_noclobber(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
+    await _do_test_fail(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, "directory", "noclobber")
 
 async def test_fail_file_toobig(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
     await _do_test_fail(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, "file", "toobig")
 
-#async def test_fail_directory_toobig(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-#    await _do_test_fail(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, "directory", "toobig")
+async def test_fail_directory_toobig(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
+    await _do_test_fail(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, "directory", "toobig")
 
 
 @pytest_twisted.ensureDeferred

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -893,13 +893,11 @@ async def _do_test_fail(wormhole_executable, scripts_env, relayurl, tmpdir_facto
             NL=NL) in send_stderr
         assert "Wormhole code is: {code}{NL}".format(code=send_cfg.code, NL=NL) in send_stderr
         assert "On the other computer, please run:{NL}{NL}wormhole receive {code}{NL}{NL}".format(code=send_cfg.code, NL=NL) in send_stderr
-        assert "File sent.. waiting for confirmation{NL}Confirmation received. Transfer complete.{NL}".format(NL=NL) not in send_stderr
     elif mode == "directory":
         assert "Sending directory" in send_stderr
         assert "named 'testdir'" in send_stderr
         assert "Wormhole code is: {code}{NL}".format(code=send_cfg.code, NL=NL) in send_stderr
         assert u"On the other computer, please run:{NL}{NL}wormhole receive {code}{NL}{NL}".format(code=send_cfg.code, NL=NL) in send_stderr
-        assert "File sent.. waiting for confirmation{NL}Confirmation received. Transfer complete.{NL}".format(NL=NL) in send_stderr
 
     # check receiver
     if mode == "file":

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -48,7 +48,7 @@ def create_config():
     return cfg
 
 
-def test_text():
+def test_text_offer():
     cfg = create_config()
     cfg.text = message = "blah blah blah ponies"
     d, fd_to_send = build_offer(cfg)
@@ -60,7 +60,7 @@ def test_text():
     assert fd_to_send is None
 
 
-def test_file(tmpdir_factory):
+def test_file_offer(tmpdir_factory):
     cfg = create_config()
     cfg.what = filename = "my file"
     message = b"yay ponies\n"
@@ -165,11 +165,11 @@ def _do_test_directory(parent_dir, addslash):
                              contents
 
 
-def test_directory(tmpdir_factory):
+def test_directory_simple(tmpdir_factory):
     return _do_test_directory(tmpdir_factory.mktemp("dir"), addslash=False)
 
 
-def test_directory_addslash(tmpdir_factory):
+def test_directory_addslash_simple(tmpdir_factory):
     return _do_test_directory(tmpdir_factory.mktemp("addslash"), addslash=True)
 
 
@@ -183,7 +183,7 @@ def test_unknown(request, tmpdir_factory):
     try:
         os.mkfifo(abs_filename)
     except AttributeError:
-        raise unittest.SkipTest("is mkfifo supported on this platform?")
+        return pytest.skip("is mkfifo supported on this platform?")
 
     # Delete the named pipe for the sake of users who might run "pip
     # wheel ." in this directory later. That command wants to copy
@@ -307,13 +307,13 @@ def wormhole_executable():
     """
     locations = procutils.which("wormhole")
     if not locations:
-        raise unittest.SkipTest("unable to find 'wormhole' in $PATH")
+        return pytest.skip("unable to find 'wormhole' in $PATH")
     wormhole = locations[0]
     if (os.path.dirname(os.path.abspath(wormhole)) != os.path.dirname(
             sys.executable)):
         log.msg("locations: %s" % (locations, ))
         log.msg("sys.executable: %s" % (sys.executable, ))
-        raise unittest.SkipTest(
+        return pytest.skip(
             "found the wrong 'wormhole' in $PATH: %s %s" %
             (wormhole, sys.executable))
     return wormhole

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -97,7 +97,7 @@ class OfferData(unittest.TestCase):
     def test_broken_symlink_raises_err(self):
         self._create_broken_symlink()
         self.cfg.ignore_unsendable_files = False
-        e = with pytest.raises(UnsendableFileError):
+        with pytest.raises(UnsendableFileError) as e:
             build_offer(self.cfg)
 
         # On english distributions of Linux, this will be
@@ -120,9 +120,9 @@ class OfferData(unittest.TestCase):
         os.mkdir(send_dir)
         self.cfg.cwd = send_dir
 
-        e = with pytest.raises(TransferError):
+        with pytest.raises(TransferError) as e:
             build_offer(self.cfg)
-        assert str(e) == "Cannot send: no file/directory named '%s'" % filename
+        assert str(e.value) == "Cannot send: no file/directory named '%s'" % filename
 
     def _do_test_directory(self, addslash):
         parent_dir = self.mktemp()
@@ -188,7 +188,7 @@ class OfferData(unittest.TestCase):
         assert not os.path.isfile(abs_filename)
         assert not os.path.isdir(abs_filename)
 
-        e = with pytest.raises(TypeError):
+        with pytest.raises(TypeError) as e:
             build_offer(self.cfg)
         assert str(e) == "'%s' is neither file nor directory" % filename
 
@@ -749,64 +749,65 @@ async def _do_test(
             assert modes[i] == stat.S_IMODE(
                 os.stat(fn).st_mode)
 
-async def test_text(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory)
+async def test_text(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory)
 
-async def test_text_subprocess(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, as_subprocess=True)
+async def test_text_subprocess(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, as_subprocess=True)
 
-async def test_text_tor(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, fake_tor=True)
+async def test_text_tor(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, fake_tor=True)
 
-async def test_text_verify(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, verify=True)
+async def test_text_verify(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, verify=True)
 
-async def test_file(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="file")
+async def test_file(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="file")
 
-async def test_file_override(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="file", override_filename=True)
+async def test_file_override(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="file", override_filename=True)
 
-async def test_file_overwrite(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="file", overwrite=True)
+async def test_file_overwrite(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="file", overwrite=True)
 
-async def test_file_overwrite_mock_accept(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="file", overwrite=True, mock_accept=True)
+async def test_file_overwrite_mock_accept(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="file", overwrite=True, mock_accept=True)
 
-async def test_file_tor(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="file", fake_tor=True)
+async def test_file_tor(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="file", fake_tor=True)
 
-async def test_empty_file(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="empty-file")
+async def test_empty_file(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="empty-file")
 
-async def test_directory(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="directory")
+async def test_directory(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="directory")
 
-async def test_directory_addslash(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="directory", addslash=True)
+async def test_directory_addslash(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="directory", addslash=True)
 
-async def test_directory_override(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="directory", override_filename=True)
+async def test_directory_override(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="directory", override_filename=True)
 
-async def test_directory_overwrite(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="directory", overwrite=True)
+async def test_directory_overwrite(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="directory", overwrite=True)
 
-async def test_directory_overwrite_mock_accept(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
+async def test_directory_overwrite_mock_accept(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
     await _do_test(
         wormhole_executable,
         scripts_env,
         mailbox.url,
+        transit_relay.url,
         tmpdir_factory,
         mode="directory",
         overwrite=True,
         mock_accept=True,
     )
 
-async def test_slow_text(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="slow-text")
+async def test_slow_text(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="slow-text")
 
-async def test_slow_sender_text(wormhole_executable, scripts_env, mailbox, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, tmpdir_factory, mode="slow-sender-text")
+async def test_slow_sender_text(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
+    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="slow-sender-text")
 
 
 @pytest_twisted.ensureDeferred

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -1043,7 +1043,7 @@ def no_mailbox(reactor):
     # basically just to get a port number. Having a hard time
     # "creating and killing" correctly in here, so short-cutting to "a
     # port that shouldn't be listening"
-    yield f"ws://127.0.0.1:1/v1"
+    yield "ws://127.0.0.1:1/v1"
 
 
 @pytest_twisted.ensureDeferred
@@ -1115,12 +1115,12 @@ def create_config(name, url):
 
 
 @pytest_twisted.ensureDeferred
-async def test_text(mailbox):
+async def test_text_send(mailbox):
     send_config = create_config("send", mailbox.url)
     recv_config = create_config("receive", mailbox.url)
     send_config.code = "1-test-situation"
     recv_config.code = "1-test-situation"
-    with mock.patch('sys.stdout') as stdout:
+    with mock.patch('sys.stdout'):
         # the rendezvous channel should be deleted after success
         send_config.text = "some text to send"
         send_d = cmd_send.send(send_config)
@@ -1129,9 +1129,8 @@ async def test_text(mailbox):
         await send_d
         await receive_d
 
-        # XXX FIXME: hard-mode to reach in this far with current fixture
-        ##cids = self._rendezvous.get_app(cmd_send.APPID).get_nameplate_ids()
-        ##assert len(cids) == 0
+        cids = mailbox.rendezvous.get_app(cmd_send.APPID).get_nameplate_ids()
+        assert len(cids) == 0
 
 
 @pytest_twisted.ensureDeferred

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -418,7 +418,7 @@ def strip_deprecations(stderr, NL):
 async def _do_test(
         wormhole_executable,
         scripts_env,
-        relayurl,
+        mailbox,
         transiturl,
         tmpdir_factory,
         as_subprocess=False,
@@ -439,7 +439,7 @@ async def _do_test(
 
     for cfg in [send_cfg, recv_cfg]:
         cfg.hide_progress = True
-        cfg.relay_url = relayurl
+        cfg.relay_url = mailbox.url
         cfg.transit_helper = ""
         cfg.listen = True
         cfg.code = u"1-abc"
@@ -526,7 +526,7 @@ async def _do_test(
         env["_MAGIC_WORMHOLE_TEST_VERIFY_TIMER"] = "999999"
         send_args = [
             '--relay-url',
-            relayurl,
+            mailbox.url,
             '--transit-helper',
             '',
             'send',
@@ -543,7 +543,7 @@ async def _do_test(
         )
         recv_args = [
             '--relay-url',
-            relayurl,
+            mailbox.url,
             '--transit-helper',
             '',
             'receive',
@@ -628,7 +628,7 @@ async def _do_test(
                     await gatherResults([send_d, receive_d], True)
 
         if fake_tor:
-            expected_endpoints = [("127.0.0.1", self.rdv_ws_port, False)]
+            expected_endpoints = [("127.0.0.1", mailbox.port._realPortNumber, False)]
             if mode in ("file", "directory"):
                 expected_endpoints.append(("127.0.0.1", self.transitport, False))
             tx_timing = mtx_tm.call_args[1]["timing"]
@@ -750,53 +750,53 @@ async def _do_test(
                 os.stat(fn).st_mode)
 
 async def test_text(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory)
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory)
 
 async def test_text_subprocess(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, as_subprocess=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, as_subprocess=True)
 
 async def test_text_tor(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, fake_tor=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, fake_tor=True)
 
 async def test_text_verify(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, verify=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, verify=True)
 
 async def test_file(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="file")
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, mode="file")
 
 async def test_file_override(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="file", override_filename=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, mode="file", override_filename=True)
 
 async def test_file_overwrite(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="file", overwrite=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, mode="file", overwrite=True)
 
 async def test_file_overwrite_mock_accept(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="file", overwrite=True, mock_accept=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, mode="file", overwrite=True, mock_accept=True)
 
 async def test_file_tor(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="file", fake_tor=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, mode="file", fake_tor=True)
 
 async def test_empty_file(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="empty-file")
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, mode="empty-file")
 
 async def test_directory(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="directory")
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, mode="directory")
 
 async def test_directory_addslash(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="directory", addslash=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, mode="directory", addslash=True)
 
 async def test_directory_override(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="directory", override_filename=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, mode="directory", override_filename=True)
 
 async def test_directory_overwrite(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="directory", overwrite=True)
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, mode="directory", overwrite=True)
 
 async def test_directory_overwrite_mock_accept(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
     await _do_test(
         wormhole_executable,
         scripts_env,
-        mailbox.url,
-        transit_relay.url,
+        mailbox,
+        transit_relay,
         tmpdir_factory,
         mode="directory",
         overwrite=True,
@@ -804,10 +804,10 @@ async def test_directory_overwrite_mock_accept(wormhole_executable, scripts_env,
     )
 
 async def test_slow_text(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="slow-text")
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, mode="slow-text")
 
 async def test_slow_sender_text(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-    await _do_test(wormhole_executable, scripts_env, mailbox.url, transit_relay.url, tmpdir_factory, mode="slow-sender-text")
+    await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, mode="slow-sender-text")
 
 
 @pytest_twisted.ensureDeferred
@@ -877,10 +877,13 @@ async def _do_test_fail(wormhole_executable, scripts_env, relayurl, tmpdir_facto
     with mock.patch(
             "wormhole.cli.cmd_receive.estimate_free_space",
             return_value=free_space):
-        f = await self.assertFailure(send_d, TransferError)
-        assert str(f) == "remote error, transfer abandoned: transfer rejected"
-        f = await self.assertFailure(receive_d, TransferError)
-        assert str(f) == "transfer rejected"
+        with pytest.raises(TransferError) as e:
+            await send_d
+        assert str(e.value) == "remote error, transfer abandoned: transfer rejected"
+
+        with pytest.raises(TransferError) as e:
+            await self.assertFailure(receive_d, TransferError)
+        assert str(e.value) == "transfer rejected"
 
     send_stdout = send_cfg.stdout.getvalue()
     send_stderr = send_cfg.stderr.getvalue()

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -57,7 +57,7 @@ class OfferData(unittest.TestCase):
         assert "file" not in d
         assert "directory" not in d
         assert d["message"] == message
-        assert fd_to_send == None
+        assert fd_to_send is None
 
     def test_file(self):
         self.cfg.what = filename = "my file"

--- a/src/wormhole/test/test_eventual.py
+++ b/src/wormhole/test/test_eventual.py
@@ -1,6 +1,5 @@
 from twisted.internet.defer import Deferred
 from twisted.internet.task import Clock
-from twisted.trial import unittest
 
 from unittest import mock
 

--- a/src/wormhole/test/test_eventual.py
+++ b/src/wormhole/test/test_eventual.py
@@ -13,7 +13,7 @@ class IntentionalError(Exception):
     pass
 
 
-def test_eventually():
+def test_eventually(observe_errors):
     c = Clock()
     eq = EventualQueue(c)
     c1 = mock.Mock()
@@ -34,110 +34,20 @@ def test_eventually():
     assert d3.result == "value"
 
 
+def test_error(observe_errors):
+    c = Clock()
+    eq = EventualQueue(c)
+    c1 = mock.Mock(side_effect=IntentionalError)
+    eq.eventually(c1, "arg1", "arg2", kwarg1="kw1")
+    assert c1.mock_calls == []
 
-class _LogObserver:
-    """
-    Observes the Twisted logs and catches any errors.
-
-    @ivar _errors: A C{list} of L{Failure} instances which were received as
-        error events from the Twisted logging system.
-
-    @ivar _added: A C{int} giving the number of times C{_add} has been called
-        less the number of times C{_remove} has been called; used to only add
-        this observer to the Twisted logging since once, regardless of the
-        number of calls to the add method.
-
-    @ivar _ignored: A C{list} of exception types which will not be recorded.
-    """
-
-    def __init__(self):
-        self._errors = []
-        self._added = 0
-        self._ignored = []
-
-    def _add(self):
-        from twisted.python import log
-        if self._added == 0:
-            log.addObserver(self.gotEvent)
-        self._added += 1
-
-    def _remove(self):
-        from twisted.python import log
-        self._added -= 1
-        if self._added == 0:
-            log.removeObserver(self.gotEvent)
-
-    def _ignoreErrors(self, *errorTypes):
-        """
-        Do not store any errors with any of the given types.
-        """
-        self._ignored.extend(errorTypes)
-
-    def _clearIgnores(self):
-        """
-        Stop ignoring any errors we might currently be ignoring.
-        """
-        self._ignored = []
-
-    def flushErrors(self, *errorTypes):
-        """
-        Flush errors from the list of caught errors. If no arguments are
-        specified, remove all errors. If arguments are specified, only remove
-        errors of those types from the stored list.
-        """
-        if errorTypes:
-            flushed = []
-            remainder = []
-            for f in self._errors:
-                if f.check(*errorTypes):
-                    flushed.append(f)
-                else:
-                    remainder.append(f)
-            self._errors = remainder
-        else:
-            flushed = self._errors
-            self._errors = []
-        return flushed
-
-    def getErrors(self):
-        """
-        Return a list of errors caught by this observer.
-        """
-        return self._errors
-
-    def gotEvent(self, event):
-        """
-        The actual observer method. Called whenever a message is logged.
-
-        @param event: A dictionary containing the log message. Actual
-        structure undocumented (see source for L{twisted.python.log}).
-        """
-        if event.get("isError", False) and "failure" in event:
-            f = event["failure"]
-            if len(self._ignored) == 0 or not f.check(*self._ignored):
-                self._errors.append(f)
-
-lo = _LogObserver()
-
-def test_error():
-    lo._add()
-    try:
-        c = Clock()
-        eq = EventualQueue(c)
-        c1 = mock.Mock(side_effect=IntentionalError)
-        eq.eventually(c1, "arg1", "arg2", kwarg1="kw1")
-        assert c1.mock_calls == []
-
-        eq.flush_sync()
-        assert c1.mock_calls == [mock.call("arg1", "arg2", kwarg1="kw1")]
-    finally:
-        lo._remove()
-
-    lo.flushErrors(IntentionalError)
+    eq.flush_sync()
+    assert c1.mock_calls == [mock.call("arg1", "arg2", kwarg1="kw1")]
+    observe_errors.flush(IntentionalError)
 
 
 @ensureDeferred
-async def test_flush(reactor):
+async def test_flush(reactor, observe_errors):
     eq = EventualQueue(reactor)
     d1 = eq.fire_eventually()
     d2 = Deferred()

--- a/src/wormhole/test/test_eventual.py
+++ b/src/wormhole/test/test_eventual.py
@@ -1,4 +1,3 @@
-from twisted.internet import reactor
 from twisted.internet.defer import Deferred
 from twisted.internet.task import Clock
 from twisted.trial import unittest
@@ -14,51 +13,140 @@ class IntentionalError(Exception):
     pass
 
 
-class Eventual(unittest.TestCase, object):
-    def test_eventually(self):
-        c = Clock()
-        eq = EventualQueue(c)
-        c1 = mock.Mock()
-        eq.eventually(c1, "arg1", "arg2", kwarg1="kw1")
-        eq.eventually(c1, "arg3", "arg4", kwarg5="kw5")
-        d2 = eq.fire_eventually()
-        d3 = eq.fire_eventually("value")
-        self.assertEqual(c1.mock_calls, [])
-        self.assertNoResult(d2)
-        self.assertNoResult(d3)
+def test_eventually():
+    c = Clock()
+    eq = EventualQueue(c)
+    c1 = mock.Mock()
+    eq.eventually(c1, "arg1", "arg2", kwarg1="kw1")
+    eq.eventually(c1, "arg3", "arg4", kwarg5="kw5")
+    d2 = eq.fire_eventually()
+    d3 = eq.fire_eventually("value")
+    assert c1.mock_calls == []
+    assert not d2.called
+    assert not d3.called
 
-        eq.flush_sync()
-        self.assertEqual(c1.mock_calls, [
-            mock.call("arg1", "arg2", kwarg1="kw1"),
-            mock.call("arg3", "arg4", kwarg5="kw5")
-        ])
-        self.assertEqual(self.successResultOf(d2), None)
-        self.assertEqual(self.successResultOf(d3), "value")
+    eq.flush_sync()
+    assert c1.mock_calls == [
+        mock.call("arg1", "arg2", kwarg1="kw1"),
+        mock.call("arg3", "arg4", kwarg5="kw5")
+    ]
+    assert d2.result is None
+    assert d3.result == "value"
 
-    def test_error(self):
+
+
+class _LogObserver:
+    """
+    Observes the Twisted logs and catches any errors.
+
+    @ivar _errors: A C{list} of L{Failure} instances which were received as
+        error events from the Twisted logging system.
+
+    @ivar _added: A C{int} giving the number of times C{_add} has been called
+        less the number of times C{_remove} has been called; used to only add
+        this observer to the Twisted logging since once, regardless of the
+        number of calls to the add method.
+
+    @ivar _ignored: A C{list} of exception types which will not be recorded.
+    """
+
+    def __init__(self):
+        self._errors = []
+        self._added = 0
+        self._ignored = []
+
+    def _add(self):
+        from twisted.python import log
+        if self._added == 0:
+            log.addObserver(self.gotEvent)
+        self._added += 1
+
+    def _remove(self):
+        from twisted.python import log
+        self._added -= 1
+        if self._added == 0:
+            log.removeObserver(self.gotEvent)
+
+    def _ignoreErrors(self, *errorTypes):
+        """
+        Do not store any errors with any of the given types.
+        """
+        self._ignored.extend(errorTypes)
+
+    def _clearIgnores(self):
+        """
+        Stop ignoring any errors we might currently be ignoring.
+        """
+        self._ignored = []
+
+    def flushErrors(self, *errorTypes):
+        """
+        Flush errors from the list of caught errors. If no arguments are
+        specified, remove all errors. If arguments are specified, only remove
+        errors of those types from the stored list.
+        """
+        if errorTypes:
+            flushed = []
+            remainder = []
+            for f in self._errors:
+                if f.check(*errorTypes):
+                    flushed.append(f)
+                else:
+                    remainder.append(f)
+            self._errors = remainder
+        else:
+            flushed = self._errors
+            self._errors = []
+        return flushed
+
+    def getErrors(self):
+        """
+        Return a list of errors caught by this observer.
+        """
+        return self._errors
+
+    def gotEvent(self, event):
+        """
+        The actual observer method. Called whenever a message is logged.
+
+        @param event: A dictionary containing the log message. Actual
+        structure undocumented (see source for L{twisted.python.log}).
+        """
+        if event.get("isError", False) and "failure" in event:
+            f = event["failure"]
+            if len(self._ignored) == 0 or not f.check(*self._ignored):
+                self._errors.append(f)
+
+lo = _LogObserver()
+
+def test_error():
+    lo._add()
+    try:
         c = Clock()
         eq = EventualQueue(c)
         c1 = mock.Mock(side_effect=IntentionalError)
         eq.eventually(c1, "arg1", "arg2", kwarg1="kw1")
-        self.assertEqual(c1.mock_calls, [])
+        assert c1.mock_calls == []
 
         eq.flush_sync()
-        self.assertEqual(c1.mock_calls,
-                         [mock.call("arg1", "arg2", kwarg1="kw1")])
+        assert c1.mock_calls == [mock.call("arg1", "arg2", kwarg1="kw1")]
+    finally:
+        lo._remove()
 
-        self.flushLoggedErrors(IntentionalError)
+    lo.flushErrors(IntentionalError)
 
-    @ensureDeferred
-    async def test_flush(self):
-        eq = EventualQueue(reactor)
-        d1 = eq.fire_eventually()
-        d2 = Deferred()
 
-        def _more(res):
-            eq.eventually(d2.callback, None)
+@ensureDeferred
+async def test_flush(reactor):
+    eq = EventualQueue(reactor)
+    d1 = eq.fire_eventually()
+    d2 = Deferred()
 
-        d1.addCallback(_more)
-        await eq.flush()
-        # d1 will fire, which will queue d2 to fire, and the flush() ought to
-        # wait for d2 too
-        self.successResultOf(d2)
+    def _more(res):
+        eq.eventually(d2.callback, None)
+
+    d1.addCallback(_more)
+    await eq.flush()
+    # d1 will fire, which will queue d2 to fire, and the flush() ought to
+    # wait for d2 too
+    assert d2.called

--- a/src/wormhole/test/test_hints.py
+++ b/src/wormhole/test/test_hints.py
@@ -14,11 +14,11 @@ def test_endpoint_from_hint_obj():
     def efho(hint, tor=None):
         return endpoint_from_hint_obj(hint, tor, reactor)
     assert isinstance(efho(DirectTCPV1Hint("host", 1234, 0.0)), endpoints.HostnameEndpoint)
-    assert efho("unknown:stuff:yowza:pivlor") == None
+    assert efho("unknown:stuff:yowza:pivlor") is None
 
     # tor=None
-    assert efho(TorTCPV1Hint("host", "port", 0)) == None
-    assert efho(UnknownHint("foo")) == None
+    assert efho(TorTCPV1Hint("host", "port", 0)) is None
+    assert efho(UnknownHint("foo")) is None
 
     tor = mock.Mock()
 
@@ -32,9 +32,9 @@ def test_endpoint_from_hint_obj():
                      ("tor_ep", "host", 1234)
     assert efho(TorTCPV1Hint("host2.onion", 1234, 0.0), tor) == \
                      ("tor_ep", "host2.onion", 1234)
-    assert efho(DirectTCPV1Hint("non-public", 1234, 0.0), tor) == None
+    assert efho(DirectTCPV1Hint("non-public", 1234, 0.0), tor) is None
 
-    assert efho(UnknownHint("foo"), tor) == None
+    assert efho(UnknownHint("foo"), tor) is None
 
 def test_comparable():
     h1 = DirectTCPV1Hint("hostname", "port1", 0.0)
@@ -49,7 +49,7 @@ def test_comparable():
 
 def test_parse_tcp_v1_hint():
     p = parse_tcp_v1_hint
-    assert p({"type": "unknown"}) == None
+    assert p({"type": "unknown"}) is None
     h = p({"type": "direct-tcp-v1", "hostname": "foo", "port": 1234})
     assert h == DirectTCPV1Hint("foo", 1234, 0.0)
     h = p({
@@ -70,20 +70,20 @@ def test_parse_tcp_v1_hint():
     assert h == TorTCPV1Hint("foo", 1234, 2.5)
     assert p({
         "type": "direct-tcp-v1"
-    }) == None  # missing hostname
+    }) is None  # missing hostname
     assert p({
         "type": "direct-tcp-v1",
         "hostname": 12
-    }) == None  # invalid hostname
+    }) is None  # invalid hostname
     assert p({
             "type": "direct-tcp-v1",
             "hostname": "foo"
-        }) == None  # missing port
+        }) is None  # missing port
     assert p({
             "type": "direct-tcp-v1",
             "hostname": "foo",
             "port": "not a number"
-        }) == None  # invalid port
+        }) is None  # invalid port
 
 def test_parse_hint():
     p = parse_hint
@@ -122,31 +122,31 @@ def test_parse_hint_argv():
     assert stderr == ""
 
     h, stderr = p("$!@#^")
-    assert h == None
+    assert h is None
     assert stderr == "unparseable hint '$!@#^'\n"
 
     h, stderr = p("unknown:stuff")
-    assert h == None
+    assert h is None
     assert stderr == \
                      "unknown hint type 'unknown' in 'unknown:stuff'\n"
 
     h, stderr = p("tcp:just-a-hostname")
-    assert h == None
+    assert h is None
     assert stderr == \
         "unparseable TCP hint (need more colons) 'tcp:just-a-hostname'\n"
 
     h, stderr = p("tcp:host:number")
-    assert h == None
+    assert h is None
     assert stderr == \
                      "non-numeric port in TCP hint 'tcp:host:number'\n"
 
     h, stderr = p("tcp:host:1234:priority=bad")
-    assert h == None
+    assert h is None
     assert stderr == \
         "non-float priority= in TCP hint 'tcp:host:1234:priority=bad'\n"
 
     h, stderr = p("tcp:[2001:0db8:85a3::8a2e:0370:7334]")
-    assert h == None
+    assert h is None
     assert stderr == "non-numeric port in TCP hint 'tcp:[2001:0db8:85a3::8a2e:0370:7334]'\n"
 
     h, stderr = p("tcp:[2001:0db8:85a3::8a2e:0370:7334]:1234")
@@ -160,7 +160,7 @@ def test_parse_hint_argv():
     assert stderr == ""
 
     h, stderr = p("tcp:[abc::xyz]:1234")
-    assert h == None
+    assert h is None
     assert stderr == "invalid IPv6 address in TCP hint 'tcp:[abc::xyz]:1234'\n"
 
 def test_describe_hint_obj():

--- a/src/wormhole/test/test_hints.py
+++ b/src/wormhole/test/test_hints.py
@@ -2,215 +2,208 @@ import io
 from collections import namedtuple
 from unittest import mock
 from twisted.internet import endpoints, reactor
-from twisted.trial import unittest
 from .._hints import (endpoint_from_hint_obj, parse_hint_argv, parse_tcp_v1_hint,
                       describe_hint_obj, parse_hint, encode_hint,
                       DirectTCPV1Hint, TorTCPV1Hint, RelayV1Hint)
+import pytest
 
 UnknownHint = namedtuple("UnknownHint", ["stuff"])
 
 
-class Hints(unittest.TestCase):
-    def test_endpoint_from_hint_obj(self):
-        def efho(hint, tor=None):
-            return endpoint_from_hint_obj(hint, tor, reactor)
-        self.assertIsInstance(efho(DirectTCPV1Hint("host", 1234, 0.0)),
-                              endpoints.HostnameEndpoint)
-        self.assertEqual(efho("unknown:stuff:yowza:pivlor"), None)
+def test_endpoint_from_hint_obj():
+    def efho(hint, tor=None):
+        return endpoint_from_hint_obj(hint, tor, reactor)
+    assert isinstance(efho(DirectTCPV1Hint("host", 1234, 0.0)), endpoints.HostnameEndpoint)
+    assert efho("unknown:stuff:yowza:pivlor") == None
 
-        # tor=None
-        self.assertEqual(efho(TorTCPV1Hint("host", "port", 0)), None)
-        self.assertEqual(efho(UnknownHint("foo")), None)
+    # tor=None
+    assert efho(TorTCPV1Hint("host", "port", 0)) == None
+    assert efho(UnknownHint("foo")) == None
 
-        tor = mock.Mock()
+    tor = mock.Mock()
 
-        def tor_ep(hostname, port):
-            if hostname == "non-public":
-                raise ValueError
-            return ("tor_ep", hostname, port)
-        tor.stream_via = mock.Mock(side_effect=tor_ep)
+    def tor_ep(hostname, port):
+        if hostname == "non-public":
+            raise ValueError
+        return ("tor_ep", hostname, port)
+    tor.stream_via = mock.Mock(side_effect=tor_ep)
 
-        self.assertEqual(efho(DirectTCPV1Hint("host", 1234, 0.0), tor),
-                         ("tor_ep", "host", 1234))
-        self.assertEqual(efho(TorTCPV1Hint("host2.onion", 1234, 0.0), tor),
-                         ("tor_ep", "host2.onion", 1234))
-        self.assertEqual(efho(DirectTCPV1Hint("non-public", 1234, 0.0), tor), None)
+    assert efho(DirectTCPV1Hint("host", 1234, 0.0), tor) == \
+                     ("tor_ep", "host", 1234)
+    assert efho(TorTCPV1Hint("host2.onion", 1234, 0.0), tor) == \
+                     ("tor_ep", "host2.onion", 1234)
+    assert efho(DirectTCPV1Hint("non-public", 1234, 0.0), tor) == None
 
-        self.assertEqual(efho(UnknownHint("foo"), tor), None)
+    assert efho(UnknownHint("foo"), tor) == None
 
-    def test_comparable(self):
-        h1 = DirectTCPV1Hint("hostname", "port1", 0.0)
-        h1b = DirectTCPV1Hint("hostname", "port1", 0.0)
-        h2 = DirectTCPV1Hint("hostname", "port2", 0.0)
-        r1 = RelayV1Hint(tuple(sorted([h1, h2])))
-        r2 = RelayV1Hint(tuple(sorted([h2, h1])))
-        r3 = RelayV1Hint(tuple(sorted([h1b, h2])))
-        self.assertEqual(r1, r2)
-        self.assertEqual(r2, r3)
-        self.assertEqual(len(set([r1, r2, r3])), 1)
+def test_comparable():
+    h1 = DirectTCPV1Hint("hostname", "port1", 0.0)
+    h1b = DirectTCPV1Hint("hostname", "port1", 0.0)
+    h2 = DirectTCPV1Hint("hostname", "port2", 0.0)
+    r1 = RelayV1Hint(tuple(sorted([h1, h2])))
+    r2 = RelayV1Hint(tuple(sorted([h2, h1])))
+    r3 = RelayV1Hint(tuple(sorted([h1b, h2])))
+    assert r1 == r2
+    assert r2 == r3
+    assert len(set([r1, r2, r3])) == 1
 
-    def test_parse_tcp_v1_hint(self):
-        p = parse_tcp_v1_hint
-        self.assertEqual(p({"type": "unknown"}), None)
-        h = p({"type": "direct-tcp-v1", "hostname": "foo", "port": 1234})
-        self.assertEqual(h, DirectTCPV1Hint("foo", 1234, 0.0))
-        h = p({
+def test_parse_tcp_v1_hint():
+    p = parse_tcp_v1_hint
+    assert p({"type": "unknown"}) == None
+    h = p({"type": "direct-tcp-v1", "hostname": "foo", "port": 1234})
+    assert h == DirectTCPV1Hint("foo", 1234, 0.0)
+    h = p({
+        "type": "direct-tcp-v1",
+        "hostname": "foo",
+        "port": 1234,
+        "priority": 2.5
+    })
+    assert h == DirectTCPV1Hint("foo", 1234, 2.5)
+    h = p({"type": "tor-tcp-v1", "hostname": "foo", "port": 1234})
+    assert h == TorTCPV1Hint("foo", 1234, 0.0)
+    h = p({
+        "type": "tor-tcp-v1",
+        "hostname": "foo",
+        "port": 1234,
+        "priority": 2.5
+    })
+    assert h == TorTCPV1Hint("foo", 1234, 2.5)
+    assert p({
+        "type": "direct-tcp-v1"
+    }) == None  # missing hostname
+    assert p({
+        "type": "direct-tcp-v1",
+        "hostname": 12
+    }) == None  # invalid hostname
+    assert p({
+            "type": "direct-tcp-v1",
+            "hostname": "foo"
+        }) == None  # missing port
+    assert p({
             "type": "direct-tcp-v1",
             "hostname": "foo",
-            "port": 1234,
-            "priority": 2.5
-        })
-        self.assertEqual(h, DirectTCPV1Hint("foo", 1234, 2.5))
-        h = p({"type": "tor-tcp-v1", "hostname": "foo", "port": 1234})
-        self.assertEqual(h, TorTCPV1Hint("foo", 1234, 0.0))
-        h = p({
-            "type": "tor-tcp-v1",
-            "hostname": "foo",
-            "port": 1234,
-            "priority": 2.5
-        })
-        self.assertEqual(h, TorTCPV1Hint("foo", 1234, 2.5))
-        self.assertEqual(p({
-            "type": "direct-tcp-v1"
-        }), None)  # missing hostname
-        self.assertEqual(p({
-            "type": "direct-tcp-v1",
-            "hostname": 12
-        }), None)  # invalid hostname
-        self.assertEqual(
-            p({
-                "type": "direct-tcp-v1",
-                "hostname": "foo"
-            }), None)  # missing port
-        self.assertEqual(
-            p({
-                "type": "direct-tcp-v1",
-                "hostname": "foo",
-                "port": "not a number"
-            }), None)  # invalid port
+            "port": "not a number"
+        }) == None  # invalid port
 
-    def test_parse_hint(self):
-        p = parse_hint
-        self.assertEqual(p({"type": "direct-tcp-v1",
-                            "hostname": "foo",
-                            "port": 12}),
-                         DirectTCPV1Hint("foo", 12, 0.0))
-        self.assertEqual(p({"type": "relay-v1",
-                            "hints": [
-                                {"type": "direct-tcp-v1",
-                                 "hostname": "foo",
-                                 "port": 12},
-                                {"type": "unrecognized"},
-                                {"type": "direct-tcp-v1",
-                                 "hostname": "bar",
-                                 "port": 13}]}),
-                         RelayV1Hint([DirectTCPV1Hint("foo", 12, 0.0),
-                                      DirectTCPV1Hint("bar", 13, 0.0)]))
+def test_parse_hint():
+    p = parse_hint
+    assert p({"type": "direct-tcp-v1",
+                        "hostname": "foo",
+                        "port": 12}) == \
+                     DirectTCPV1Hint("foo", 12, 0.0)
+    assert p({"type": "relay-v1",
+                        "hints": [
+                            {"type": "direct-tcp-v1",
+                             "hostname": "foo",
+                             "port": 12},
+                            {"type": "unrecognized"},
+                            {"type": "direct-tcp-v1",
+                             "hostname": "bar",
+                             "port": 13}]}) == \
+                     RelayV1Hint([DirectTCPV1Hint("foo", 12, 0.0),
+                                  DirectTCPV1Hint("bar", 13, 0.0)])
 
-    def test_parse_hint_argv(self):
-        def p(hint):
-            stderr = io.StringIO()
-            value = parse_hint_argv(hint, stderr=stderr)
-            return value, stderr.getvalue()
+def test_parse_hint_argv():
+    def p(hint):
+        stderr = io.StringIO()
+        value = parse_hint_argv(hint, stderr=stderr)
+        return value, stderr.getvalue()
 
-        h, stderr = p("tcp:host:1234")
-        self.assertEqual(h, DirectTCPV1Hint("host", 1234, 0.0))
-        self.assertEqual(stderr, "")
+    h, stderr = p("tcp:host:1234")
+    assert h == DirectTCPV1Hint("host", 1234, 0.0)
+    assert stderr == ""
 
-        h, stderr = p("tcp:host:1234:priority=2.6")
-        self.assertEqual(h, DirectTCPV1Hint("host", 1234, 2.6))
-        self.assertEqual(stderr, "")
+    h, stderr = p("tcp:host:1234:priority=2.6")
+    assert h == DirectTCPV1Hint("host", 1234, 2.6)
+    assert stderr == ""
 
-        h, stderr = p("tcp:host:1234:unknown=stuff")
-        self.assertEqual(h, DirectTCPV1Hint("host", 1234, 0.0))
-        self.assertEqual(stderr, "")
+    h, stderr = p("tcp:host:1234:unknown=stuff")
+    assert h == DirectTCPV1Hint("host", 1234, 0.0)
+    assert stderr == ""
 
-        h, stderr = p("$!@#^")
-        self.assertEqual(h, None)
-        self.assertEqual(stderr, "unparseable hint '$!@#^'\n")
+    h, stderr = p("$!@#^")
+    assert h == None
+    assert stderr == "unparseable hint '$!@#^'\n"
 
-        h, stderr = p("unknown:stuff")
-        self.assertEqual(h, None)
-        self.assertEqual(stderr,
-                         "unknown hint type 'unknown' in 'unknown:stuff'\n")
+    h, stderr = p("unknown:stuff")
+    assert h == None
+    assert stderr == \
+                     "unknown hint type 'unknown' in 'unknown:stuff'\n"
 
-        h, stderr = p("tcp:just-a-hostname")
-        self.assertEqual(h, None)
-        self.assertEqual(
-            stderr,
-            "unparseable TCP hint (need more colons) 'tcp:just-a-hostname'\n")
+    h, stderr = p("tcp:just-a-hostname")
+    assert h == None
+    assert stderr == \
+        "unparseable TCP hint (need more colons) 'tcp:just-a-hostname'\n"
 
-        h, stderr = p("tcp:host:number")
-        self.assertEqual(h, None)
-        self.assertEqual(stderr,
-                         "non-numeric port in TCP hint 'tcp:host:number'\n")
+    h, stderr = p("tcp:host:number")
+    assert h == None
+    assert stderr == \
+                     "non-numeric port in TCP hint 'tcp:host:number'\n"
 
-        h, stderr = p("tcp:host:1234:priority=bad")
-        self.assertEqual(h, None)
-        self.assertEqual(
-            stderr,
-            "non-float priority= in TCP hint 'tcp:host:1234:priority=bad'\n")
+    h, stderr = p("tcp:host:1234:priority=bad")
+    assert h == None
+    assert stderr == \
+        "non-float priority= in TCP hint 'tcp:host:1234:priority=bad'\n"
 
-        h, stderr = p("tcp:[2001:0db8:85a3::8a2e:0370:7334]")
-        self.assertEqual(h, None)
-        self.assertEqual(
-            stderr, "non-numeric port in TCP hint 'tcp:[2001:0db8:85a3::8a2e:0370:7334]'\n")
+    h, stderr = p("tcp:[2001:0db8:85a3::8a2e:0370:7334]")
+    assert h == None
+    assert stderr == "non-numeric port in TCP hint 'tcp:[2001:0db8:85a3::8a2e:0370:7334]'\n"
 
-        h, stderr = p("tcp:[2001:0db8:85a3::8a2e:0370:7334]:1234")
-        self.assertEqual(h, DirectTCPV1Hint(
-            "2001:0db8:85a3::8a2e:0370:7334", 1234, 0.0))
-        self.assertEqual(stderr, "")
+    h, stderr = p("tcp:[2001:0db8:85a3::8a2e:0370:7334]:1234")
+    assert h == DirectTCPV1Hint(
+        "2001:0db8:85a3::8a2e:0370:7334", 1234, 0.0)
+    assert stderr == ""
 
-        h, stderr = p("tcp:[2001:0db8:85a3::8a2e:0370:7334]:1234:priority=2.6")
-        self.assertEqual(h, DirectTCPV1Hint(
-            "2001:0db8:85a3::8a2e:0370:7334", 1234, 2.6))
-        self.assertEqual(stderr, "")
+    h, stderr = p("tcp:[2001:0db8:85a3::8a2e:0370:7334]:1234:priority=2.6")
+    assert h == DirectTCPV1Hint(
+        "2001:0db8:85a3::8a2e:0370:7334", 1234, 2.6)
+    assert stderr == ""
 
-        h, stderr = p("tcp:[abc::xyz]:1234")
-        self.assertEqual(h, None)
-        self.assertEqual(
-            stderr, "invalid IPv6 address in TCP hint 'tcp:[abc::xyz]:1234'\n")
+    h, stderr = p("tcp:[abc::xyz]:1234")
+    assert h == None
+    assert stderr == "invalid IPv6 address in TCP hint 'tcp:[abc::xyz]:1234'\n"
 
-    def test_describe_hint_obj(self):
-        d = describe_hint_obj
-        self.assertEqual(d(DirectTCPV1Hint("host", 1234, 0.0), False, False),
-                         "->tcp:host:1234")
-        self.assertEqual(d(DirectTCPV1Hint("host", 1234, 0.0), True, False),
-                         "->relay:tcp:host:1234")
-        self.assertEqual(d(DirectTCPV1Hint("host", 1234, 0.0), False, True),
-                         "tor->tcp:host:1234")
-        self.assertEqual(d(DirectTCPV1Hint("host", 1234, 0.0), True, True),
-                         "tor->relay:tcp:host:1234")
-        self.assertEqual(d(TorTCPV1Hint("host", 1234, 0.0), False, False),
-                         "->tor:host:1234")
-        self.assertEqual(d(UnknownHint("stuff"), False, False),
-                         "->%s" % str(UnknownHint("stuff")))
+def test_describe_hint_obj():
+    d = describe_hint_obj
+    assert d(DirectTCPV1Hint("host", 1234, 0.0), False, False) == \
+                     "->tcp:host:1234"
+    assert d(DirectTCPV1Hint("host", 1234, 0.0), True, False) == \
+                     "->relay:tcp:host:1234"
+    assert d(DirectTCPV1Hint("host", 1234, 0.0), False, True) == \
+                     "tor->tcp:host:1234"
+    assert d(DirectTCPV1Hint("host", 1234, 0.0), True, True) == \
+                     "tor->relay:tcp:host:1234"
+    assert d(TorTCPV1Hint("host", 1234, 0.0), False, False) == \
+                     "->tor:host:1234"
+    assert d(UnknownHint("stuff"), False, False) == \
+                     "->%s" % str(UnknownHint("stuff"))
 
-    def test_encode_hint(self):
-        e = encode_hint
-        self.assertEqual(e(DirectTCPV1Hint("host", 1234, 1.0)),
-                         {"type": "direct-tcp-v1",
-                          "priority": 1.0,
-                          "hostname": "host",
-                          "port": 1234})
-        self.assertEqual(e(RelayV1Hint([DirectTCPV1Hint("foo", 12, 0.0),
-                                        DirectTCPV1Hint("bar", 13, 0.0)])),
-                         {"type": "relay-v1",
-                          "hints": [
-                              {"type": "direct-tcp-v1",
-                               "hostname": "foo",
-                               "port": 12,
-                               "priority": 0.0},
-                              {"type": "direct-tcp-v1",
-                               "hostname": "bar",
-                               "port": 13,
-                               "priority": 0.0},
-                          ]})
-        self.assertEqual(e(TorTCPV1Hint("host", 1234, 1.0)),
-                         {"type": "tor-tcp-v1",
-                          "priority": 1.0,
-                          "hostname": "host",
-                          "port": 1234})
-        e = self.assertRaises(ValueError, e, "not a Hint")
-        self.assertIn("unknown hint type", str(e))
-        self.assertIn("not a Hint", str(e))
+def test_encode_hint():
+    e = encode_hint
+    assert e(DirectTCPV1Hint("host", 1234, 1.0)) == \
+                     {"type": "direct-tcp-v1",
+                      "priority": 1.0,
+                      "hostname": "host",
+                      "port": 1234}
+    assert e(RelayV1Hint([DirectTCPV1Hint("foo", 12, 0.0),
+                                    DirectTCPV1Hint("bar", 13, 0.0)])) == \
+                     {"type": "relay-v1",
+                      "hints": [
+                          {"type": "direct-tcp-v1",
+                           "hostname": "foo",
+                           "port": 12,
+                           "priority": 0.0},
+                          {"type": "direct-tcp-v1",
+                           "hostname": "bar",
+                           "port": 13,
+                           "priority": 0.0},
+                      ]}
+    assert e(TorTCPV1Hint("host", 1234, 1.0)) == \
+                     {"type": "tor-tcp-v1",
+                      "priority": 1.0,
+                      "hostname": "host",
+                      "port": 1234}
+    with pytest.raises(ValueError) as f:
+        e("not a Hint")
+    assert "unknown hint type" in str(f.value)
+    assert "not a Hint" in str(f.value)

--- a/src/wormhole/test/test_hkdf.py
+++ b/src/wormhole/test/test_hkdf.py
@@ -5,7 +5,6 @@ from cryptography.hazmat.primitives import hashes
 
 from .. import util
 
-import pytest
 # def generate_KAT():
 #     print("KAT = [")
 #     for salt in (b"", b"salt"):

--- a/src/wormhole/test/test_hkdf.py
+++ b/src/wormhole/test/test_hkdf.py
@@ -1,4 +1,3 @@
-import unittest
 from binascii import unhexlify  # , hexlify
 
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
@@ -6,6 +5,7 @@ from cryptography.hazmat.primitives import hashes
 
 from .. import util
 
+import pytest
 # def generate_KAT():
 #     print("KAT = [")
 #     for salt in (b"", b"salt"):
@@ -33,31 +33,29 @@ KAT = [
 ]
 
 
-class TestKAT(unittest.TestCase):
-    # note: this uses SHA256
-    def test_kat(self):
-        for (salt, context, skm, expected_hexout) in KAT:
-            expected_out = unhexlify(expected_hexout)
-            for outlen in range(0, len(expected_out)):
-                out = HKDF(
-                    algorithm=hashes.SHA256(),
-                    length=outlen,
-                    salt=salt.encode("ascii"),
-                    info=context.encode("ascii"),
-                ).derive(skm.encode("ascii"))
-                self.assertEqual(out, expected_out[:outlen])
+def test_kat():
+    for (salt, context, skm, expected_hexout) in KAT:
+        expected_out = unhexlify(expected_hexout)
+        for outlen in range(0, len(expected_out)):
+            out = HKDF(
+                algorithm=hashes.SHA256(),
+                length=outlen,
+                salt=salt.encode("ascii"),
+                info=context.encode("ascii"),
+            ).derive(skm.encode("ascii"))
+            assert out == expected_out[:outlen]
 
-    def test_util(self):
-        for (salt, context, skm, expected_hexout) in KAT:
-            expected_out = unhexlify(expected_hexout)
-            for outlen in range(0, len(expected_out)):
-                out = util.HKDF(
-                    skm.encode("ascii"),
-                    outlen,
-                    salt.encode("ascii"),
-                    context.encode("ascii"),
-                )
-                self.assertEqual(out, expected_out[:outlen])
+def test_util():
+    for (salt, context, skm, expected_hexout) in KAT:
+        expected_out = unhexlify(expected_hexout)
+        for outlen in range(0, len(expected_out)):
+            out = util.HKDF(
+                skm.encode("ascii"),
+                outlen,
+                salt.encode("ascii"),
+                context.encode("ascii"),
+            )
+            assert out == expected_out[:outlen]
 
 
 # if __name__ == '__main__':

--- a/src/wormhole/test/test_ipaddrs.py
+++ b/src/wormhole/test/test_ipaddrs.py
@@ -4,8 +4,6 @@ import re
 import subprocess
 from unittest import mock
 
-from twisted.trial import unittest
-
 from .. import ipaddrs
 
 DOTTED_QUAD_RE = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$")

--- a/src/wormhole/test/test_journal.py
+++ b/src/wormhole/test/test_journal.py
@@ -1,29 +1,27 @@
-from twisted.trial import unittest
-
 from .. import journal
 from .._interfaces import IJournal
 
+import pytest
 
-class Journal(unittest.TestCase):
-    def test_journal(self):
-        events = []
-        j = journal.Journal(lambda: events.append("checkpoint"))
-        self.assert_(IJournal.providedBy(j))
+def test_journal():
+    events = []
+    j = journal.Journal(lambda: events.append("checkpoint"))
+    assert (IJournal.providedBy(j))
 
-        with j.process():
-            j.queue_outbound(events.append, "message1")
-            j.queue_outbound(events.append, "message2")
-            self.assertEqual(events, [])
-        self.assertEqual(events, ["checkpoint", "message1", "message2"])
+    with j.process():
+        j.queue_outbound(events.append, "message1")
+        j.queue_outbound(events.append, "message2")
+        assert events == [],"test_journal: events list is not empty"
+    assert events == ["checkpoint", "message1", "message2"]
 
-    def test_immediate(self):
-        events = []
-        j = journal.ImmediateJournal()
-        self.assert_(IJournal.providedBy(j))
+def test_immediate():
+    events = []
+    j = journal.ImmediateJournal()
+    assert IJournal.providedBy(j)
 
-        with j.process():
-            j.queue_outbound(events.append, "message1")
-            self.assertEqual(events, ["message1"])
-            j.queue_outbound(events.append, "message2")
-            self.assertEqual(events, ["message1", "message2"])
-        self.assertEqual(events, ["message1", "message2"])
+    with j.process():
+        j.queue_outbound(events.append, "message1")
+        assert events == ["message1"]
+        j.queue_outbound(events.append, "message2")
+        assert events == ["message1", "message2"]
+    assert events == ["message1", "message2"]

--- a/src/wormhole/test/test_journal.py
+++ b/src/wormhole/test/test_journal.py
@@ -1,8 +1,6 @@
 from .. import journal
 from .._interfaces import IJournal
 
-import pytest
-
 def test_journal():
     events = []
     j = journal.Journal(lambda: events.append("checkpoint"))

--- a/src/wormhole/test/test_keys.py
+++ b/src/wormhole/test/test_keys.py
@@ -1,81 +1,81 @@
 from unittest import mock
 
-from twisted.trial import unittest
-
 from .._key import derive_key, derive_phase_key, encrypt_data, decrypt_data
 from ..util import bytes_to_hexstr, hexstr_to_bytes
+import pytest
 
 
-class Derive(unittest.TestCase):
-    def test_derive_errors(self):
-        self.assertRaises(TypeError, derive_key, 123, b"purpose")
-        self.assertRaises(TypeError, derive_key, b"key", 123)
-        self.assertRaises(TypeError, derive_key, b"key", b"purpose", "not len")
+def test_derive_errors():
+    with pytest.raises(TypeError):
+        derive_key(123, b"purpose")
+    with pytest.raises(TypeError):
+        derive_key(b"key", 123)
+    with pytest.raises(TypeError):
+        derive_key(b"key", b"purpose", "not len")
 
-    def test_derive_key(self):
-        m = "588ba9eef353778b074413a0140205d90d7479e36e0dd4ee35bb729d26131ef1"
-        main = hexstr_to_bytes(m)
+def test_derive_key():
+    m = "588ba9eef353778b074413a0140205d90d7479e36e0dd4ee35bb729d26131ef1"
+    main = hexstr_to_bytes(m)
 
-        dk1 = derive_key(main, b"purpose1")
-        self.assertEqual(bytes_to_hexstr(dk1),
-                         "835b5df80ce9ca46908e8524fb308649"
-                         "122cfbcefbeaa7e65061c6ef08ee1b2a")
+    dk1 = derive_key(main, b"purpose1")
+    assert bytes_to_hexstr(dk1) == \
+                     "835b5df80ce9ca46908e8524fb308649" \
+                     "122cfbcefbeaa7e65061c6ef08ee1b2a"
 
-        dk2 = derive_key(main, b"purpose2", 10)
-        self.assertEqual(bytes_to_hexstr(dk2), "f2238e84315b47eb6279")
+    dk2 = derive_key(main, b"purpose2", 10)
+    assert bytes_to_hexstr(dk2) == "f2238e84315b47eb6279"
 
-    def test_derive_phase_key(self):
-        m = "588ba9eef353778b074413a0140205d90d7479e36e0dd4ee35bb729d26131ef1"
-        main = hexstr_to_bytes(m)
+def test_derive_phase_key():
+    m = "588ba9eef353778b074413a0140205d90d7479e36e0dd4ee35bb729d26131ef1"
+    main = hexstr_to_bytes(m)
 
-        dk11 = derive_phase_key(main, "side1", "phase1")
-        self.assertEqual(bytes_to_hexstr(dk11),
-                         "3af6a61d1a111225cc8968c6ca6265ef"
-                         "e892065c3ab46de79dda21306b062990")
+    dk11 = derive_phase_key(main, "side1", "phase1")
+    assert bytes_to_hexstr(dk11) == \
+                     "3af6a61d1a111225cc8968c6ca6265ef" \
+                     "e892065c3ab46de79dda21306b062990"
 
-        dk12 = derive_phase_key(main, "side1", "phase2")
-        self.assertEqual(bytes_to_hexstr(dk12),
-                         "88a1dd12182d989ff498022a9656d1e2"
-                         "806f17328d8bf5d8d0c9753e4381a752")
+    dk12 = derive_phase_key(main, "side1", "phase2")
+    assert bytes_to_hexstr(dk12) == \
+                     "88a1dd12182d989ff498022a9656d1e2" \
+                     "806f17328d8bf5d8d0c9753e4381a752"
 
-        dk21 = derive_phase_key(main, "side2", "phase1")
-        self.assertEqual(bytes_to_hexstr(dk21),
-                         "a306627b436ec23bdae3af8fa90c9ac9"
-                         "27780d86be1831003e7f617c518ea689")
+    dk21 = derive_phase_key(main, "side2", "phase1")
+    assert bytes_to_hexstr(dk21) == \
+                     "a306627b436ec23bdae3af8fa90c9ac9" \
+                     "27780d86be1831003e7f617c518ea689"
 
-        dk22 = derive_phase_key(main, "side2", "phase2")
-        self.assertEqual(bytes_to_hexstr(dk22),
-                         "bf99e3e16420f2dad33f9b1ccb0be146"
-                         "2b253d639dacdb50ed9496fa528d8758")
+    dk22 = derive_phase_key(main, "side2", "phase2")
+    assert bytes_to_hexstr(dk22) == \
+                     "bf99e3e16420f2dad33f9b1ccb0be146" \
+                     "2b253d639dacdb50ed9496fa528d8758"
 
 
-class Encrypt(unittest.TestCase):
-    def test_encrypt(self):
-        k = "ddc543ef8e4629a603d39dd0307a51bb1e7adb9cb259f6b085c91d0842a18679"
-        key = hexstr_to_bytes(k)
-        plaintext = hexstr_to_bytes("edc089a518219ec1cee184e89d2d37af")
-        self.assertEqual(len(plaintext), 16)
-        nonce = hexstr_to_bytes("2d5e43eb465aa42e750f991e425bee48"
-                                "5f06abad7e04af80")
-        self.assertEqual(len(nonce), 24)
-        with mock.patch("nacl.utils.random", return_value=nonce):
-            encrypted = encrypt_data(key, plaintext)
-        self.assertEqual(len(encrypted), 24 + 16 + 16)
-        self.assertEqual(bytes_to_hexstr(encrypted),
-                         "2d5e43eb465aa42e750f991e425bee48"
-                         "5f06abad7e04af80fe318e39d0e4ce93"
-                         "2d2b54b300c56d2cda55ee5f0488d63e"
-                         "b1d5f76f7919a49a")
+def test_encrypt():
+    k = "ddc543ef8e4629a603d39dd0307a51bb1e7adb9cb259f6b085c91d0842a18679"
+    key = hexstr_to_bytes(k)
+    plaintext = hexstr_to_bytes("edc089a518219ec1cee184e89d2d37af")
+    assert len(plaintext) == 16
+    nonce = hexstr_to_bytes("2d5e43eb465aa42e750f991e425bee48"
+                            "5f06abad7e04af80")
+    assert len(nonce) == 24
+    with mock.patch("nacl.utils.random", return_value=nonce):
+        encrypted = encrypt_data(key, plaintext)
+    assert len(encrypted) == 24 + 16 + 16
+    assert bytes_to_hexstr(encrypted) == \
+                     "2d5e43eb465aa42e750f991e425bee48" \
+                     "5f06abad7e04af80fe318e39d0e4ce93" \
+                     "2d2b54b300c56d2cda55ee5f0488d63e" \
+                     "b1d5f76f7919a49a"
 
-    def test_decrypt(self):
-        k = "ddc543ef8e4629a603d39dd0307a51bb1e7adb9cb259f6b085c91d0842a18679"
-        key = hexstr_to_bytes(k)
-        encrypted = hexstr_to_bytes("2d5e43eb465aa42e750f991e425bee48"
-                                    "5f06abad7e04af80fe318e39d0e4ce93"
-                                    "2d2b54b300c56d2cda55ee5f0488d63e"
-                                    "b1d5f76f7919a49a")
+def test_decrypt():
+    k = "ddc543ef8e4629a603d39dd0307a51bb1e7adb9cb259f6b085c91d0842a18679"
+    key = hexstr_to_bytes(k)
+    encrypted = hexstr_to_bytes("2d5e43eb465aa42e750f991e425bee48"
+                                "5f06abad7e04af80fe318e39d0e4ce93"
+                                "2d2b54b300c56d2cda55ee5f0488d63e"
+                                "b1d5f76f7919a49a")
 
-        decrypted = decrypt_data(key, encrypted)
-        self.assertEqual(len(decrypted), len(encrypted) - 24 - 16)
-        self.assertEqual(bytes_to_hexstr(decrypted),
-                         "edc089a518219ec1cee184e89d2d37af")
+    decrypted = decrypt_data(key, encrypted)
+    assert len(decrypted) == len(encrypted) - 24 - 16
+    assert bytes_to_hexstr(decrypted) == \
+                     "edc089a518219ec1cee184e89d2d37af"

--- a/src/wormhole/test/test_machines.py
+++ b/src/wormhole/test/test_machines.py
@@ -156,7 +156,7 @@ def build_receive():
     return r, b, s, events
 
 
-def test_good():
+def test_good_receive():
     r, b, s, events = build_receive()
     key = b"key"
     r.got_key(key)
@@ -255,7 +255,7 @@ def build_key():
     return k, b, m, r, events
 
 
-def test_good():
+def test_good_key():
     k, b, m, r, events = build_key()
     code = u"1-foo"
     k.got_code(code)
@@ -501,7 +501,7 @@ def build_lister():
     return lister, rc, i, events
 
 
-def test_connect_first():
+def test_connect_first_lister():
     lister, rc, i, events = build_lister()
     lister.connected()
     lister.lost()
@@ -624,7 +624,7 @@ def test_allocate_first():
         ("c.allocated", "1", "1-word-word"),
     ]
 
-def test_connect_first():
+def test_connect_first_allocator():
     a, rc, c, events = build_allocator()
     a.connected()
     assert events == []
@@ -697,7 +697,7 @@ def test_set_first():
     n.rx_released()
     assert events == [("t.nameplate_done", )]
 
-def test_connect_first():
+def test_connect_first_nameplate():
     # connection remains up throughout
     n, m, i, rc, t, events = build_nameplate()
     n.connected()
@@ -818,10 +818,12 @@ def test_reconnect_while_done():
     n.connected()
     assert events == []
 
-def test_close_while_idle():
+
+def test_close_while_idle_nameplate():
     n, m, i, rc, t, events = build_nameplate()
     n.close()
     assert events == [("t.nameplate_done", )]
+
 
 def test_close_while_idle_connected():
     n, m, i, rc, t, events = build_nameplate()
@@ -829,6 +831,7 @@ def test_close_while_idle_connected():
     assert events == []
     n.close()
     assert events == [("t.nameplate_done", )]
+
 
 def test_close_while_unclaimed():
     n, m, i, rc, t, events = build_nameplate()
@@ -1063,7 +1066,7 @@ def assert_events(events, initial_events, tx_add_events):
     assert set(events[len(initial_events):]) == tx_add_events
 
 
-def test_connect_first():  # connect before got_mailbox
+def test_connect_first_mailbox():  # connect before got_mailbox
     m, n, rc, o, t, events = build_mailbox()
     m.add_message("phase1", b"msg1")
     assert events == []
@@ -1172,10 +1175,12 @@ def test_mailbox_first():  # got_mailbox before connect
         ("rc.tx_add", "phase2", b"msg2"),
     })
 
+
 def test_close_while_idle():
     m, n, rc, o, t, events = build_mailbox()
     m.close("happy")
     assert events == [("t.mailbox_done", )]
+
 
 def test_close_while_idle_but_connected():
     m, n, rc, o, t, events = build_mailbox()
@@ -1524,7 +1529,8 @@ def test_set_code_twice():
     with pytest.raises(errors.OnlyOneCodeError):
         b.set_code("1-code")
 
-def test_input_code():
+
+def test_input_code_boss():
     b, events = build_boss()
     b._C.retval = "helper"
     helper = b.input_code()
@@ -1533,7 +1539,8 @@ def test_input_code():
     with pytest.raises(errors.OnlyOneCodeError):
         b.input_code()
 
-def test_allocate_code():
+
+def test_allocate_code_boss():
     b, events = build_boss()
     wl = object()
     with mock.patch("wormhole._boss.PGPWordList", return_value=wl):
@@ -1602,7 +1609,7 @@ def test_websocket_lost():
     def sent_messages(ws):
         for c in ws.mock_calls:
             assert c[0] == "sendMessage", ws.mock_calls
-            assert c[1][1] == False, ws.mock_calls
+            assert not c[1][1]
             yield bytes_to_dict(c[1][0])
 
     assert list(sent_messages(ws)) == [

--- a/src/wormhole/test/test_machines.py
+++ b/src/wormhole/test/test_machines.py
@@ -472,10 +472,10 @@ async def test_with_completion():
     assert helper.get_word_completions("") == set()
     wl = FakeWordList()
     i.got_wordlist(wl)
-    assert await d == None
+    assert await d is None
     # a new Deferred should fire right away
     d = helper.when_wordlist_is_available()
-    assert await d == None
+    assert await d is None
 
     wl._completions = {"abc-", "abcd-", "ae-"}
     assert helper.get_word_completions("a") == wl._completions

--- a/src/wormhole/test/test_machines.py
+++ b/src/wormhole/test/test_machines.py
@@ -2,7 +2,6 @@ import json
 
 from nacl.secret import SecretBox
 from spake2 import SPAKE2_Symmetric
-from twisted.trial import unittest
 from zope.interface import directlyProvides, implementer
 
 from unittest import mock
@@ -19,6 +18,8 @@ from ..journal import ImmediateJournal
 from .._status import WormholeStatus
 from ..util import (bytes_to_dict, bytes_to_hexstr, dict_to_bytes,
                     hexstr_to_bytes, to_bytes)
+import pytest
+import pytest_twisted
 
 
 @implementer(IWordlist)
@@ -51,1247 +52,1244 @@ class Dummy:
         setattr(self, meth, log)
 
 
-class Send(unittest.TestCase):
-    def build(self):
-        events = []
-        s = _send.Send(u"side", timing.DebugTiming())
-        m = Dummy("m", events, IMailbox, "add_message")
-        s.wire(m)
-        return s, m, events
+def build_send():
+    events = []
+    s = _send.Send(u"side", timing.DebugTiming())
+    m = Dummy("m", events, IMailbox, "add_message")
+    s.wire(m)
+    return s, m, events
 
-    def test_send_first(self):
-        s, m, events = self.build()
-        s.send("phase1", b"msg")
-        self.assertEqual(events, [])
-        key = b"\x00" * 32
-        nonce1 = b"\x00" * SecretBox.NONCE_SIZE
-        with mock.patch("nacl.utils.random", side_effect=[nonce1]) as r:
-            s.got_verified_key(key)
-        self.assertEqual(r.mock_calls, [mock.call(SecretBox.NONCE_SIZE)])
-        # print(bytes_to_hexstr(events[0][2]))
-        enc1 = hexstr_to_bytes(
-            ("000000000000000000000000000000000000000000000000"
-             "22f1a46c3c3496423c394621a2a5a8cf275b08"))
-        self.assertEqual(events, [("m.add_message", "phase1", enc1)])
-        events[:] = []
 
-        nonce2 = b"\x02" * SecretBox.NONCE_SIZE
-        with mock.patch("nacl.utils.random", side_effect=[nonce2]) as r:
-            s.send("phase2", b"msg")
-        self.assertEqual(r.mock_calls, [mock.call(SecretBox.NONCE_SIZE)])
-        enc2 = hexstr_to_bytes(
-            ("0202020202020202020202020202020202020202"
-             "020202026660337c3eac6513c0dac9818b62ef16d9cd7e"))
-        self.assertEqual(events, [("m.add_message", "phase2", enc2)])
-
-    def test_key_first(self):
-        s, m, events = self.build()
-        key = b"\x00" * 32
+def test_send_first():
+    s, m, events = build_send()
+    s.send("phase1", b"msg")
+    assert events == []
+    key = b"\x00" * 32
+    nonce1 = b"\x00" * SecretBox.NONCE_SIZE
+    with mock.patch("nacl.utils.random", side_effect=[nonce1]) as r:
         s.got_verified_key(key)
-        self.assertEqual(events, [])
+    assert r.mock_calls == [mock.call(SecretBox.NONCE_SIZE)]
+    # print(bytes_to_hexstr(events[0][2]))
+    enc1 = hexstr_to_bytes(
+        ("000000000000000000000000000000000000000000000000"
+         "22f1a46c3c3496423c394621a2a5a8cf275b08"))
+    assert events == [("m.add_message", "phase1", enc1)]
+    events[:] = []
 
-        nonce1 = b"\x00" * SecretBox.NONCE_SIZE
-        with mock.patch("nacl.utils.random", side_effect=[nonce1]) as r:
-            s.send("phase1", b"msg")
-        self.assertEqual(r.mock_calls, [mock.call(SecretBox.NONCE_SIZE)])
-        enc1 = hexstr_to_bytes(("00000000000000000000000000000000000000000000"
-                                "000022f1a46c3c3496423c394621a2a5a8cf275b08"))
-        self.assertEqual(events, [("m.add_message", "phase1", enc1)])
-        events[:] = []
+    nonce2 = b"\x02" * SecretBox.NONCE_SIZE
+    with mock.patch("nacl.utils.random", side_effect=[nonce2]) as r:
+        s.send("phase2", b"msg")
+    assert r.mock_calls == [mock.call(SecretBox.NONCE_SIZE)]
+    enc2 = hexstr_to_bytes(
+        ("0202020202020202020202020202020202020202"
+         "020202026660337c3eac6513c0dac9818b62ef16d9cd7e"))
+    assert events == [("m.add_message", "phase2", enc2)]
 
-        nonce2 = b"\x02" * SecretBox.NONCE_SIZE
-        with mock.patch("nacl.utils.random", side_effect=[nonce2]) as r:
-            s.send("phase2", b"msg")
-        self.assertEqual(r.mock_calls, [mock.call(SecretBox.NONCE_SIZE)])
-        enc2 = hexstr_to_bytes(
-            ("0202020202020202020202020202020202020"
-             "202020202026660337c3eac6513c0dac9818b62ef16d9cd7e"))
-        self.assertEqual(events, [("m.add_message", "phase2", enc2)])
+def test_key_first():
+    s, m, events = build_send()
+    key = b"\x00" * 32
+    s.got_verified_key(key)
+    assert events == []
 
+    nonce1 = b"\x00" * SecretBox.NONCE_SIZE
+    with mock.patch("nacl.utils.random", side_effect=[nonce1]) as r:
+        s.send("phase1", b"msg")
+    assert r.mock_calls == [mock.call(SecretBox.NONCE_SIZE)]
+    enc1 = hexstr_to_bytes(("00000000000000000000000000000000000000000000"
+                            "000022f1a46c3c3496423c394621a2a5a8cf275b08"))
+    assert events == [("m.add_message", "phase1", enc1)]
+    events[:] = []
 
-class Order(unittest.TestCase):
-    def build(self):
-        events = []
-        o = _order.Order(u"side", timing.DebugTiming())
-        k = Dummy("k", events, IKey, "got_pake")
-        r = Dummy("r", events, IReceive, "got_message")
-        o.wire(k, r)
-        return o, k, r, events
-
-    def test_in_order(self):
-        o, k, r, events = self.build()
-        o.got_message(u"side", u"pake", b"body")
-        self.assertEqual(events, [("k.got_pake", b"body")])  # right away
-        o.got_message(u"side", u"version", b"body")
-        o.got_message(u"side", u"1", b"body")
-        self.assertEqual(events, [
-            ("k.got_pake", b"body"),
-            ("r.got_message", u"side", u"version", b"body"),
-            ("r.got_message", u"side", u"1", b"body"),
-        ])
-
-    def test_out_of_order(self):
-        o, k, r, events = self.build()
-        o.got_message(u"side", u"version", b"body")
-        self.assertEqual(events, [])  # nothing yet
-        o.got_message(u"side", u"1", b"body")
-        self.assertEqual(events, [])  # nothing yet
-        o.got_message(u"side", u"pake", b"body")
-        # got_pake is delivered first
-        self.assertEqual(events, [
-            ("k.got_pake", b"body"),
-            ("r.got_message", u"side", u"version", b"body"),
-            ("r.got_message", u"side", u"1", b"body"),
-        ])
+    nonce2 = b"\x02" * SecretBox.NONCE_SIZE
+    with mock.patch("nacl.utils.random", side_effect=[nonce2]) as r:
+        s.send("phase2", b"msg")
+    assert r.mock_calls == [mock.call(SecretBox.NONCE_SIZE)]
+    enc2 = hexstr_to_bytes(
+        ("0202020202020202020202020202020202020"
+         "202020202026660337c3eac6513c0dac9818b62ef16d9cd7e"))
+    assert events == [("m.add_message", "phase2", enc2)]
 
 
-class Receive(unittest.TestCase):
-    def build(self):
-        events = []
-        r = _receive.Receive(u"side", timing.DebugTiming())
-        b = Dummy("b", events, IBoss, "happy", "scared", "got_verifier",
-                  "got_message")
-        s = Dummy("s", events, ISend, "got_verified_key")
-        r.wire(b, s)
-        return r, b, s, events
-
-    def test_good(self):
-        r, b, s, events = self.build()
-        key = b"key"
-        r.got_key(key)
-        self.assertEqual(events, [])
-        verifier = derive_key(key, b"wormhole:verifier")
-        phase1_key = derive_phase_key(key, u"side", u"phase1")
-        data1 = b"data1"
-        good_body = encrypt_data(phase1_key, data1)
-        r.got_message(u"side", u"phase1", good_body)
-        self.assertEqual(events, [
-            ("s.got_verified_key", key),
-            ("b.happy", ),
-            ("b.got_verifier", verifier),
-            ("b.got_message", u"phase1", data1),
-        ])
-
-        phase2_key = derive_phase_key(key, u"side", u"phase2")
-        data2 = b"data2"
-        good_body = encrypt_data(phase2_key, data2)
-        r.got_message(u"side", u"phase2", good_body)
-        self.assertEqual(events, [
-            ("s.got_verified_key", key),
-            ("b.happy", ),
-            ("b.got_verifier", verifier),
-            ("b.got_message", u"phase1", data1),
-            ("b.got_message", u"phase2", data2),
-        ])
-
-    def test_early_bad(self):
-        r, b, s, events = self.build()
-        key = b"key"
-        r.got_key(key)
-        self.assertEqual(events, [])
-        phase1_key = derive_phase_key(key, u"side", u"bad")
-        data1 = b"data1"
-        bad_body = encrypt_data(phase1_key, data1)
-        r.got_message(u"side", u"phase1", bad_body)
-        self.assertEqual(events, [
-            ("b.scared", ),
-        ])
-
-        phase2_key = derive_phase_key(key, u"side", u"phase2")
-        data2 = b"data2"
-        good_body = encrypt_data(phase2_key, data2)
-        r.got_message(u"side", u"phase2", good_body)
-        self.assertEqual(events, [
-            ("b.scared", ),
-        ])
-
-    def test_late_bad(self):
-        r, b, s, events = self.build()
-        key = b"key"
-        r.got_key(key)
-        self.assertEqual(events, [])
-        verifier = derive_key(key, b"wormhole:verifier")
-        phase1_key = derive_phase_key(key, u"side", u"phase1")
-        data1 = b"data1"
-        good_body = encrypt_data(phase1_key, data1)
-        r.got_message(u"side", u"phase1", good_body)
-        self.assertEqual(events, [
-            ("s.got_verified_key", key),
-            ("b.happy", ),
-            ("b.got_verifier", verifier),
-            ("b.got_message", u"phase1", data1),
-        ])
-
-        phase2_key = derive_phase_key(key, u"side", u"bad")
-        data2 = b"data2"
-        bad_body = encrypt_data(phase2_key, data2)
-        r.got_message(u"side", u"phase2", bad_body)
-        self.assertEqual(events, [
-            ("s.got_verified_key", key),
-            ("b.happy", ),
-            ("b.got_verifier", verifier),
-            ("b.got_message", u"phase1", data1),
-            ("b.scared", ),
-        ])
-        r.got_message(u"side", u"phase1", good_body)
-        r.got_message(u"side", u"phase2", bad_body)
-        self.assertEqual(events, [
-            ("s.got_verified_key", key),
-            ("b.happy", ),
-            ("b.got_verifier", verifier),
-            ("b.got_message", u"phase1", data1),
-            ("b.scared", ),
-        ])
+def build_order():
+    events = []
+    o = _order.Order(u"side", timing.DebugTiming())
+    k = Dummy("k", events, IKey, "got_pake")
+    r = Dummy("r", events, IReceive, "got_message")
+    o.wire(k, r)
+    return o, k, r, events
 
 
-class Key(unittest.TestCase):
-    def build(self):
-        events = []
-        k = _key.Key(u"appid", {}, u"side", timing.DebugTiming())
-        b = Dummy("b", events, IBoss, "scared", "got_key")
-        m = Dummy("m", events, IMailbox, "add_message")
-        r = Dummy("r", events, IReceive, "got_key")
-        k.wire(b, m, r)
-        return k, b, m, r, events
+def test_in_order():
+    o, k, r, events = build_order()
+    o.got_message(u"side", u"pake", b"body")
+    assert events == [("k.got_pake", b"body")]  # right away
+    o.got_message(u"side", u"version", b"body")
+    o.got_message(u"side", u"1", b"body")
+    assert events == [
+        ("k.got_pake", b"body"),
+        ("r.got_message", u"side", u"version", b"body"),
+        ("r.got_message", u"side", u"1", b"body"),
+    ]
 
-    def test_good(self):
-        k, b, m, r, events = self.build()
-        code = u"1-foo"
-        k.got_code(code)
-        self.assertEqual(len(events), 1)
-        self.assertEqual(events[0][:2], ("m.add_message", "pake"))
-        msg1_json = events[0][2].decode("utf-8")
-        events[:] = []
-        msg1 = json.loads(msg1_json)
-        msg1_bytes = hexstr_to_bytes(msg1["pake_v1"])
-        sp = SPAKE2_Symmetric(to_bytes(code), idSymmetric=to_bytes(u"appid"))
-        msg2_bytes = sp.start()
-        key2 = sp.finish(msg1_bytes)
-        msg2 = dict_to_bytes({"pake_v1": bytes_to_hexstr(msg2_bytes)})
-        k.got_pake(msg2)
-        self.assertEqual(len(events), 3, events)
-        self.assertEqual(events[0], ("b.got_key", key2))
-        self.assertEqual(events[1][:2], ("m.add_message", "version"))
-        self.assertEqual(events[2], ("r.got_key", key2))
-
-    def test_bad(self):
-        k, b, m, r, events = self.build()
-        code = u"1-foo"
-        k.got_code(code)
-        self.assertEqual(len(events), 1)
-        self.assertEqual(events[0][:2], ("m.add_message", "pake"))
-        pake_1_json = events[0][2].decode("utf-8")
-        pake_1 = json.loads(pake_1_json)
-        self.assertEqual(list(pake_1.keys()),
-                         ["pake_v1"])  # value is PAKE stuff
-        events[:] = []
-        bad_pake_d = {"not_pake_v1": "stuff"}
-        k.got_pake(dict_to_bytes(bad_pake_d))
-        self.assertEqual(events, [("b.scared", )])
-
-    def test_reversed(self):
-        # A receiver using input_code() will choose the nameplate first, then
-        # the rest of the code. Once the nameplate is selected, we'll claim
-        # it and open the mailbox, which will cause the senders PAKE to
-        # arrive before the code has been set. Key() is supposed to stash the
-        # PAKE message until the code is set (allowing the PAKE computation
-        # to finish). This test exercises that PAKE-then-code sequence.
-        k, b, m, r, events = self.build()
-        code = u"1-foo"
-
-        sp = SPAKE2_Symmetric(to_bytes(code), idSymmetric=to_bytes(u"appid"))
-        msg2_bytes = sp.start()
-        msg2 = dict_to_bytes({"pake_v1": bytes_to_hexstr(msg2_bytes)})
-        k.got_pake(msg2)
-        self.assertEqual(len(events), 0)
-
-        k.got_code(code)
-        self.assertEqual(len(events), 4)
-        self.assertEqual(events[0][:2], ("m.add_message", "pake"))
-        msg1_json = events[0][2].decode("utf-8")
-        msg1 = json.loads(msg1_json)
-        msg1_bytes = hexstr_to_bytes(msg1["pake_v1"])
-        key2 = sp.finish(msg1_bytes)
-        self.assertEqual(events[1], ("b.got_key", key2))
-        self.assertEqual(events[2][:2], ("m.add_message", "version"))
-        self.assertEqual(events[3], ("r.got_key", key2))
+def test_out_of_order():
+    o, k, r, events = build_order()
+    o.got_message(u"side", u"version", b"body")
+    assert events == []  # nothing yet
+    o.got_message(u"side", u"1", b"body")
+    assert events == []  # nothing yet
+    o.got_message(u"side", u"pake", b"body")
+    # got_pake is delivered first
+    assert events == [
+        ("k.got_pake", b"body"),
+        ("r.got_message", u"side", u"version", b"body"),
+        ("r.got_message", u"side", u"1", b"body"),
+    ]
 
 
-class Code(unittest.TestCase):
-    def build(self):
-        events = []
-        c = _code.Code(timing.DebugTiming())
-        b = Dummy("b", events, IBoss, "got_code")
-        a = Dummy("a", events, IAllocator, "allocate")
-        n = Dummy("n", events, INameplate, "set_nameplate")
-        k = Dummy("k", events, IKey, "got_code")
-        i = Dummy("i", events, IInput, "start")
-        c.wire(b, a, n, k, i)
-        return c, b, a, n, k, i, events
-
-    def test_set_code(self):
-        c, b, a, n, k, i, events = self.build()
-        c.set_code(u"1-code")
-        self.assertEqual(events, [
-            ("n.set_nameplate", u"1"),
-            ("b.got_code", u"1-code"),
-            ("k.got_code", u"1-code"),
-        ])
-
-    def test_set_code_invalid(self):
-        c, b, a, n, k, i, events = self.build()
-        with self.assertRaises(errors.KeyFormatError) as e:
-            c.set_code(u"1-code ")
-        self.assertEqual(str(e.exception), "Code '1-code ' contains spaces.")
-        with self.assertRaises(errors.KeyFormatError) as e:
-            c.set_code(u" 1-code")
-        self.assertEqual(str(e.exception), "Code ' 1-code' contains spaces.")
-        with self.assertRaises(errors.KeyFormatError) as e:
-            c.set_code(u"code-code")
-        self.assertEqual(
-            str(e.exception),
-            "Nameplate 'code' must be numeric, with no spaces.")
-
-        # it should still be possible to use the wormhole at this point
-        c.set_code(u"1-code")
-        self.assertEqual(events, [
-            ("n.set_nameplate", u"1"),
-            ("b.got_code", u"1-code"),
-            ("k.got_code", u"1-code"),
-        ])
-
-    def test_allocate_code(self):
-        c, b, a, n, k, i, events = self.build()
-        wl = FakeWordList()
-        c.allocate_code(2, wl)
-        self.assertEqual(events, [("a.allocate", 2, wl)])
-        events[:] = []
-        c.allocated("1", "1-code")
-        self.assertEqual(events, [
-            ("n.set_nameplate", u"1"),
-            ("b.got_code", u"1-code"),
-            ("k.got_code", u"1-code"),
-        ])
-
-    def test_input_code(self):
-        c, b, a, n, k, i, events = self.build()
-        c.input_code()
-        self.assertEqual(events, [("i.start", )])
-        events[:] = []
-        c.got_nameplate("1")
-        self.assertEqual(events, [
-            ("n.set_nameplate", u"1"),
-        ])
-        events[:] = []
-        c.finished_input("1-code")
-        self.assertEqual(events, [
-            ("b.got_code", u"1-code"),
-            ("k.got_code", u"1-code"),
-        ])
+def build_receive():
+    events = []
+    r = _receive.Receive(u"side", timing.DebugTiming())
+    b = Dummy("b", events, IBoss, "happy", "scared", "got_verifier",
+              "got_message")
+    s = Dummy("s", events, ISend, "got_verified_key")
+    r.wire(b, s)
+    return r, b, s, events
 
 
-class Input(unittest.TestCase):
-    def build(self):
-        events = []
-        i = _input.Input(timing.DebugTiming())
-        code = Dummy("c", events, ICode, "got_nameplate", "finished_input")
-        lister = Dummy("l", events, ILister, "refresh")
-        i.wire(code, lister)
-        return i, code, lister, events
+def test_good():
+    r, b, s, events = build_receive()
+    key = b"key"
+    r.got_key(key)
+    assert events == []
+    verifier = derive_key(key, b"wormhole:verifier")
+    phase1_key = derive_phase_key(key, u"side", u"phase1")
+    data1 = b"data1"
+    good_body = encrypt_data(phase1_key, data1)
+    r.got_message(u"side", u"phase1", good_body)
+    assert events == [
+        ("s.got_verified_key", key),
+        ("b.happy", ),
+        ("b.got_verifier", verifier),
+        ("b.got_message", u"phase1", data1),
+    ]
 
-    def test_ignore_completion(self):
-        i, c, lister, events = self.build()
-        helper = i.start()
-        self.assertIsInstance(helper, _input.Helper)
-        self.assertEqual(events, [("l.refresh", )])
-        events[:] = []
-        with self.assertRaises(errors.MustChooseNameplateFirstError):
-            helper.choose_words("word-word")
-        helper.choose_nameplate("1")
-        self.assertEqual(events, [("c.got_nameplate", "1")])
-        events[:] = []
-        with self.assertRaises(errors.AlreadyChoseNameplateError):
-            helper.choose_nameplate("2")
+    phase2_key = derive_phase_key(key, u"side", u"phase2")
+    data2 = b"data2"
+    good_body = encrypt_data(phase2_key, data2)
+    r.got_message(u"side", u"phase2", good_body)
+    assert events == [
+        ("s.got_verified_key", key),
+        ("b.happy", ),
+        ("b.got_verifier", verifier),
+        ("b.got_message", u"phase1", data1),
+        ("b.got_message", u"phase2", data2),
+    ]
+
+def test_early_bad():
+    r, b, s, events = build_receive()
+    key = b"key"
+    r.got_key(key)
+    assert events == []
+    phase1_key = derive_phase_key(key, u"side", u"bad")
+    data1 = b"data1"
+    bad_body = encrypt_data(phase1_key, data1)
+    r.got_message(u"side", u"phase1", bad_body)
+    assert events == [
+        ("b.scared", ),
+    ]
+
+    phase2_key = derive_phase_key(key, u"side", u"phase2")
+    data2 = b"data2"
+    good_body = encrypt_data(phase2_key, data2)
+    r.got_message(u"side", u"phase2", good_body)
+    assert events == [
+        ("b.scared", ),
+    ]
+
+def test_late_bad():
+    r, b, s, events = build_receive()
+    key = b"key"
+    r.got_key(key)
+    assert events == []
+    verifier = derive_key(key, b"wormhole:verifier")
+    phase1_key = derive_phase_key(key, u"side", u"phase1")
+    data1 = b"data1"
+    good_body = encrypt_data(phase1_key, data1)
+    r.got_message(u"side", u"phase1", good_body)
+    assert events == [
+        ("s.got_verified_key", key),
+        ("b.happy", ),
+        ("b.got_verifier", verifier),
+        ("b.got_message", u"phase1", data1),
+    ]
+
+    phase2_key = derive_phase_key(key, u"side", u"bad")
+    data2 = b"data2"
+    bad_body = encrypt_data(phase2_key, data2)
+    r.got_message(u"side", u"phase2", bad_body)
+    assert events == [
+        ("s.got_verified_key", key),
+        ("b.happy", ),
+        ("b.got_verifier", verifier),
+        ("b.got_message", u"phase1", data1),
+        ("b.scared", ),
+    ]
+    r.got_message(u"side", u"phase1", good_body)
+    r.got_message(u"side", u"phase2", bad_body)
+    assert events == [
+        ("s.got_verified_key", key),
+        ("b.happy", ),
+        ("b.got_verifier", verifier),
+        ("b.got_message", u"phase1", data1),
+        ("b.scared", ),
+    ]
+
+
+def build_key():
+    events = []
+    k = _key.Key(u"appid", {}, u"side", timing.DebugTiming())
+    b = Dummy("b", events, IBoss, "scared", "got_key")
+    m = Dummy("m", events, IMailbox, "add_message")
+    r = Dummy("r", events, IReceive, "got_key")
+    k.wire(b, m, r)
+    return k, b, m, r, events
+
+
+def test_good():
+    k, b, m, r, events = build_key()
+    code = u"1-foo"
+    k.got_code(code)
+    assert len(events) == 1
+    assert events[0][:2] == ("m.add_message", "pake")
+    msg1_json = events[0][2].decode("utf-8")
+    events[:] = []
+    msg1 = json.loads(msg1_json)
+    msg1_bytes = hexstr_to_bytes(msg1["pake_v1"])
+    sp = SPAKE2_Symmetric(to_bytes(code), idSymmetric=to_bytes(u"appid"))
+    msg2_bytes = sp.start()
+    key2 = sp.finish(msg1_bytes)
+    msg2 = dict_to_bytes({"pake_v1": bytes_to_hexstr(msg2_bytes)})
+    k.got_pake(msg2)
+    assert len(events) == 3, events
+    assert events[0] == ("b.got_key", key2)
+    assert events[1][:2] == ("m.add_message", "version")
+    assert events[2] == ("r.got_key", key2)
+
+def test_bad():
+    k, b, m, r, events = build_key()
+    code = u"1-foo"
+    k.got_code(code)
+    assert len(events) == 1
+    assert events[0][:2] == ("m.add_message", "pake")
+    pake_1_json = events[0][2].decode("utf-8")
+    pake_1 = json.loads(pake_1_json)
+    assert list(pake_1.keys()) == \
+                     ["pake_v1"]  # value is PAKE stuff
+    events[:] = []
+    bad_pake_d = {"not_pake_v1": "stuff"}
+    k.got_pake(dict_to_bytes(bad_pake_d))
+    assert events == [("b.scared", )]
+
+def test_reversed():
+    # A receiver using input_code() will choose the nameplate first, then
+    # the rest of the code. Once the nameplate is selected, we'll claim
+    # it and open the mailbox, which will cause the senders PAKE to
+    # arrive before the code has been set. Key() is supposed to stash the
+    # PAKE message until the code is set (allowing the PAKE computation
+    # to finish). This test exercises that PAKE-then-code sequence.
+    k, b, m, r, events = build_key()
+    code = u"1-foo"
+
+    sp = SPAKE2_Symmetric(to_bytes(code), idSymmetric=to_bytes(u"appid"))
+    msg2_bytes = sp.start()
+    msg2 = dict_to_bytes({"pake_v1": bytes_to_hexstr(msg2_bytes)})
+    k.got_pake(msg2)
+    assert len(events) == 0
+
+    k.got_code(code)
+    assert len(events) == 4
+    assert events[0][:2] == ("m.add_message", "pake")
+    msg1_json = events[0][2].decode("utf-8")
+    msg1 = json.loads(msg1_json)
+    msg1_bytes = hexstr_to_bytes(msg1["pake_v1"])
+    key2 = sp.finish(msg1_bytes)
+    assert events[1] == ("b.got_key", key2)
+    assert events[2][:2] == ("m.add_message", "version")
+    assert events[3] == ("r.got_key", key2)
+
+
+def build_code():
+    events = []
+    c = _code.Code(timing.DebugTiming())
+    b = Dummy("b", events, IBoss, "got_code")
+    a = Dummy("a", events, IAllocator, "allocate")
+    n = Dummy("n", events, INameplate, "set_nameplate")
+    k = Dummy("k", events, IKey, "got_code")
+    i = Dummy("i", events, IInput, "start")
+    c.wire(b, a, n, k, i)
+    return c, b, a, n, k, i, events
+
+
+def test_set_code():
+    c, b, a, n, k, i, events = build_code()
+    c.set_code(u"1-code")
+    assert events == [
+        ("n.set_nameplate", u"1"),
+        ("b.got_code", u"1-code"),
+        ("k.got_code", u"1-code"),
+    ]
+
+def test_set_code_invalid():
+    c, b, a, n, k, i, events = build_code()
+    with pytest.raises(errors.KeyFormatError) as e:
+        c.set_code(u"1-code ")
+    assert str(e.value) == "Code '1-code ' contains spaces."
+    with pytest.raises(errors.KeyFormatError) as e:
+        c.set_code(u" 1-code")
+    assert str(e.value) == "Code ' 1-code' contains spaces."
+    with pytest.raises(errors.KeyFormatError) as e:
+        c.set_code(u"code-code")
+    assert str(e.value) == \
+        "Nameplate 'code' must be numeric, with no spaces."
+
+    # it should still be possible to use the wormhole at this point
+    c.set_code(u"1-code")
+    assert events == [
+        ("n.set_nameplate", u"1"),
+        ("b.got_code", u"1-code"),
+        ("k.got_code", u"1-code"),
+    ]
+
+def test_allocate_code():
+    c, b, a, n, k, i, events = build_code()
+    wl = FakeWordList()
+    c.allocate_code(2, wl)
+    assert events == [("a.allocate", 2, wl)]
+    events[:] = []
+    c.allocated("1", "1-code")
+    assert events == [
+        ("n.set_nameplate", u"1"),
+        ("b.got_code", u"1-code"),
+        ("k.got_code", u"1-code"),
+    ]
+
+def test_input_code():
+    c, b, a, n, k, i, events = build_code()
+    c.input_code()
+    assert events == [("i.start", )]
+    events[:] = []
+    c.got_nameplate("1")
+    assert events == [
+        ("n.set_nameplate", u"1"),
+    ]
+    events[:] = []
+    c.finished_input("1-code")
+    assert events == [
+        ("b.got_code", u"1-code"),
+        ("k.got_code", u"1-code"),
+    ]
+
+
+def build_input():
+    events = []
+    i = _input.Input(timing.DebugTiming())
+    code = Dummy("c", events, ICode, "got_nameplate", "finished_input")
+    lister = Dummy("l", events, ILister, "refresh")
+    i.wire(code, lister)
+    return i, code, lister, events
+
+
+def test_ignore_completion():
+    i, c, lister, events = build_input()
+    helper = i.start()
+    assert isinstance(helper, _input.Helper)
+    assert events == [("l.refresh", )]
+    events[:] = []
+    with pytest.raises(errors.MustChooseNameplateFirstError):
         helper.choose_words("word-word")
-        with self.assertRaises(errors.AlreadyChoseWordsError):
-            helper.choose_words("word-word")
-        self.assertEqual(events, [("c.finished_input", "1-word-word")])
-
-    def test_bad_nameplate(self):
-        i, c, lister, events = self.build()
-        helper = i.start()
-        self.assertIsInstance(helper, _input.Helper)
-        self.assertEqual(events, [("l.refresh", )])
-        events[:] = []
-        with self.assertRaises(errors.MustChooseNameplateFirstError):
-            helper.choose_words("word-word")
-        with self.assertRaises(errors.KeyFormatError):
-            helper.choose_nameplate(" 1")
-        # should still work afterwards
-        helper.choose_nameplate("1")
-        self.assertEqual(events, [("c.got_nameplate", "1")])
-        events[:] = []
-        with self.assertRaises(errors.AlreadyChoseNameplateError):
-            helper.choose_nameplate("2")
+    helper.choose_nameplate("1")
+    assert events == [("c.got_nameplate", "1")]
+    events[:] = []
+    with pytest.raises(errors.AlreadyChoseNameplateError):
+        helper.choose_nameplate("2")
+    helper.choose_words("word-word")
+    with pytest.raises(errors.AlreadyChoseWordsError):
         helper.choose_words("word-word")
-        with self.assertRaises(errors.AlreadyChoseWordsError):
-            helper.choose_words("word-word")
-        self.assertEqual(events, [("c.finished_input", "1-word-word")])
+    assert events == [("c.finished_input", "1-word-word")]
 
-    def test_with_completion(self):
-        i, c, lister, events = self.build()
-        helper = i.start()
-        self.assertIsInstance(helper, _input.Helper)
-        self.assertEqual(events, [("l.refresh", )])
-        events[:] = []
-        d = helper.when_wordlist_is_available()
-        self.assertNoResult(d)
+def test_bad_nameplate():
+    i, c, lister, events = build_input()
+    helper = i.start()
+    assert isinstance(helper, _input.Helper)
+    assert events == [("l.refresh", )]
+    events[:] = []
+    with pytest.raises(errors.MustChooseNameplateFirstError):
+        helper.choose_words("word-word")
+    with pytest.raises(errors.KeyFormatError):
+        helper.choose_nameplate(" 1")
+    # should still work afterwards
+    helper.choose_nameplate("1")
+    assert events == [("c.got_nameplate", "1")]
+    events[:] = []
+    with pytest.raises(errors.AlreadyChoseNameplateError):
+        helper.choose_nameplate("2")
+    helper.choose_words("word-word")
+    with pytest.raises(errors.AlreadyChoseWordsError):
+        helper.choose_words("word-word")
+    assert events == [("c.finished_input", "1-word-word")]
+
+
+@pytest_twisted.ensureDeferred
+async def test_with_completion():
+    i, c, lister, events = build_input()
+    helper = i.start()
+    assert isinstance(helper, _input.Helper)
+    assert events == [("l.refresh", )]
+    events[:] = []
+    d = helper.when_wordlist_is_available()
+    assert not d.called
+    helper.refresh_nameplates()
+    assert events == [("l.refresh", )]
+    events[:] = []
+    with pytest.raises(errors.MustChooseNameplateFirstError):
+        helper.get_word_completions("prefix")
+    i.got_nameplates({"1", "12", "34", "35", "367"})
+    assert not d.called
+    assert helper.get_nameplate_completions("") == \
+        {"1-", "12-", "34-", "35-", "367-"}
+    assert helper.get_nameplate_completions("1") == {"1-", "12-"}
+    assert helper.get_nameplate_completions("2") == set()
+    assert helper.get_nameplate_completions("3") == {"34-", "35-", "367-"}
+    helper.choose_nameplate("34")
+    with pytest.raises(errors.AlreadyChoseNameplateError):
         helper.refresh_nameplates()
-        self.assertEqual(events, [("l.refresh", )])
-        events[:] = []
-        with self.assertRaises(errors.MustChooseNameplateFirstError):
-            helper.get_word_completions("prefix")
-        i.got_nameplates({"1", "12", "34", "35", "367"})
-        self.assertNoResult(d)
-        self.assertEqual(
-            helper.get_nameplate_completions(""),
-            {"1-", "12-", "34-", "35-", "367-"})
-        self.assertEqual(helper.get_nameplate_completions("1"), {"1-", "12-"})
-        self.assertEqual(helper.get_nameplate_completions("2"), set())
-        self.assertEqual(
-            helper.get_nameplate_completions("3"), {"34-", "35-", "367-"})
-        helper.choose_nameplate("34")
-        with self.assertRaises(errors.AlreadyChoseNameplateError):
-            helper.refresh_nameplates()
-        with self.assertRaises(errors.AlreadyChoseNameplateError):
-            helper.get_nameplate_completions("1")
-        self.assertEqual(events, [("c.got_nameplate", "34")])
-        events[:] = []
-        # no wordlist yet
-        self.assertNoResult(d)
-        self.assertEqual(helper.get_word_completions(""), set())
-        wl = FakeWordList()
-        i.got_wordlist(wl)
-        self.assertEqual(self.successResultOf(d), None)
-        # a new Deferred should fire right away
-        d = helper.when_wordlist_is_available()
-        self.assertEqual(self.successResultOf(d), None)
+    with pytest.raises(errors.AlreadyChoseNameplateError):
+        helper.get_nameplate_completions("1")
+    assert events == [("c.got_nameplate", "34")]
+    events[:] = []
+    # no wordlist yet
+    assert not d.called
+    assert helper.get_word_completions("") == set()
+    wl = FakeWordList()
+    i.got_wordlist(wl)
+    assert await d == None
+    # a new Deferred should fire right away
+    d = helper.when_wordlist_is_available()
+    assert await d == None
 
-        wl._completions = {"abc-", "abcd-", "ae-"}
-        self.assertEqual(helper.get_word_completions("a"), wl._completions)
-        self.assertEqual(wl._get_completions_prefix, "a")
-        with self.assertRaises(errors.AlreadyChoseNameplateError):
-            helper.refresh_nameplates()
-        with self.assertRaises(errors.AlreadyChoseNameplateError):
-            helper.get_nameplate_completions("1")
+    wl._completions = {"abc-", "abcd-", "ae-"}
+    assert helper.get_word_completions("a") == wl._completions
+    assert wl._get_completions_prefix == "a"
+    with pytest.raises(errors.AlreadyChoseNameplateError):
+        helper.refresh_nameplates()
+    with pytest.raises(errors.AlreadyChoseNameplateError):
+        helper.get_nameplate_completions("1")
+    helper.choose_words("word-word")
+    with pytest.raises(errors.AlreadyChoseWordsError):
+        helper.get_word_completions("prefix")
+    with pytest.raises(errors.AlreadyChoseWordsError):
         helper.choose_words("word-word")
-        with self.assertRaises(errors.AlreadyChoseWordsError):
-            helper.get_word_completions("prefix")
-        with self.assertRaises(errors.AlreadyChoseWordsError):
-            helper.choose_words("word-word")
-        self.assertEqual(events, [("c.finished_input", "34-word-word")])
-
-
-class Lister(unittest.TestCase):
-    def build(self):
-        events = []
-        lister = _lister.Lister(timing.DebugTiming())
-        rc = Dummy("rc", events, IRendezvousConnector, "tx_list")
-        i = Dummy("i", events, IInput, "got_nameplates")
-        lister.wire(rc, i)
-        return lister, rc, i, events
-
-    def test_connect_first(self):
-        lister, rc, i, events = self.build()
-        lister.connected()
-        lister.lost()
-        lister.connected()
-        self.assertEqual(events, [])
-        lister.refresh()
-        self.assertEqual(events, [
-            ("rc.tx_list", ),
-        ])
-        events[:] = []
-        lister.rx_nameplates({"1", "2", "3"})
-        self.assertEqual(events, [
-            ("i.got_nameplates", {"1", "2", "3"}),
-        ])
-        events[:] = []
-        # now we're satisfied: disconnecting and reconnecting won't ask again
-        lister.lost()
-        lister.connected()
-        self.assertEqual(events, [])
-
-        # but if we're told to refresh, we'll do so
-        lister.refresh()
-        self.assertEqual(events, [
-            ("rc.tx_list", ),
-        ])
-
-    def test_connect_first_ask_twice(self):
-        lister, rc, i, events = self.build()
-        lister.connected()
-        self.assertEqual(events, [])
-        lister.refresh()
-        lister.refresh()
-        self.assertEqual(events, [
-            ("rc.tx_list", ),
-            ("rc.tx_list", ),
-        ])
-        lister.rx_nameplates({"1", "2", "3"})
-        self.assertEqual(events, [
-            ("rc.tx_list", ),
-            ("rc.tx_list", ),
-            ("i.got_nameplates", {"1", "2", "3"}),
-        ])
-        lister.rx_nameplates({"1", "2", "3", "4"})
-        self.assertEqual(events, [
-            ("rc.tx_list", ),
-            ("rc.tx_list", ),
-            ("i.got_nameplates", {"1", "2", "3"}),
-            ("i.got_nameplates", {"1", "2", "3", "4"}),
-        ])
-
-    def test_reconnect(self):
-        lister, rc, i, events = self.build()
-        lister.refresh()
-        lister.connected()
-        self.assertEqual(events, [
-            ("rc.tx_list", ),
-        ])
-        events[:] = []
-        lister.lost()
-        lister.connected()
-        self.assertEqual(events, [
-            ("rc.tx_list", ),
-        ])
-
-    def test_refresh_first(self):
-        lister, rc, i, events = self.build()
-        lister.refresh()
-        self.assertEqual(events, [])
-        lister.connected()
-        self.assertEqual(events, [
-            ("rc.tx_list", ),
-        ])
-        lister.rx_nameplates({"1", "2", "3"})
-        self.assertEqual(events, [
-            ("rc.tx_list", ),
-            ("i.got_nameplates", {"1", "2", "3"}),
-        ])
-
-    def test_unrefreshed(self):
-        lister, rc, i, events = self.build()
-        self.assertEqual(events, [])
-        # we receive a spontaneous rx_nameplates, without asking
-        lister.connected()
-        self.assertEqual(events, [])
-        lister.rx_nameplates({"1", "2", "3"})
-        self.assertEqual(events, [
-            ("i.got_nameplates", {"1", "2", "3"}),
-        ])
-
-
-class Allocator(unittest.TestCase):
-    def build(self):
-        events = []
-        a = _allocator.Allocator(timing.DebugTiming())
-        rc = Dummy("rc", events, IRendezvousConnector, "tx_allocate")
-        c = Dummy("c", events, ICode, "allocated")
-        a.wire(rc, c)
-        return a, rc, c, events
-
-    def test_no_allocation(self):
-        a, rc, c, events = self.build()
-        a.connected()
-        self.assertEqual(events, [])
-
-    def test_allocate_first(self):
-        a, rc, c, events = self.build()
-        a.allocate(2, FakeWordList())
-        self.assertEqual(events, [])
-        a.connected()
-        self.assertEqual(events, [("rc.tx_allocate", )])
-        events[:] = []
-        a.lost()
-        a.connected()
-        self.assertEqual(events, [
-            ("rc.tx_allocate", ),
-        ])
-        events[:] = []
-        a.rx_allocated("1")
-        self.assertEqual(events, [
-            ("c.allocated", "1", "1-word-word"),
-        ])
-
-    def test_connect_first(self):
-        a, rc, c, events = self.build()
-        a.connected()
-        self.assertEqual(events, [])
-        a.allocate(2, FakeWordList())
-        self.assertEqual(events, [("rc.tx_allocate", )])
-        events[:] = []
-        a.lost()
-        a.connected()
-        self.assertEqual(events, [
-            ("rc.tx_allocate", ),
-        ])
-        events[:] = []
-        a.rx_allocated("1")
-        self.assertEqual(events, [
-            ("c.allocated", "1", "1-word-word"),
-        ])
-
-
-class Nameplate(unittest.TestCase):
-    def build(self):
-        events = []
-        n = _nameplate.Nameplate()
-        m = Dummy("m", events, IMailbox, "got_mailbox")
-        i = Dummy("i", events, IInput, "got_wordlist")
-        rc = Dummy("rc", events, IRendezvousConnector, "tx_claim",
-                   "tx_release")
-        t = Dummy("t", events, ITerminator, "nameplate_done")
-        n.wire(m, i, rc, t)
-        return n, m, i, rc, t, events
-
-    def test_set_invalid(self):
-        n, m, i, rc, t, events = self.build()
-        with self.assertRaises(errors.KeyFormatError) as e:
-            n.set_nameplate(" 1")
-        self.assertEqual(
-            str(e.exception),
-            "Nameplate ' 1' must be numeric, with no spaces.")
-        with self.assertRaises(errors.KeyFormatError) as e:
-            n.set_nameplate("one")
-        self.assertEqual(
-            str(e.exception),
-            "Nameplate 'one' must be numeric, with no spaces.")
-
-        # wormhole should still be usable
-        n.set_nameplate("1")
-        self.assertEqual(events, [])
-        n.connected()
-        self.assertEqual(events, [("rc.tx_claim", "1")])
-
-    def test_set_first(self):
-        # connection remains up throughout
-        n, m, i, rc, t, events = self.build()
-        n.set_nameplate("1")
-        self.assertEqual(events, [])
-        n.connected()
-        self.assertEqual(events, [("rc.tx_claim", "1")])
-        events[:] = []
-
-        wl = object()
-        with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
-            n.rx_claimed("mbox1")
-        self.assertEqual(events, [
-            ("i.got_wordlist", wl),
-            ("m.got_mailbox", "mbox1"),
-        ])
-        events[:] = []
-
-        n.release()
-        self.assertEqual(events, [("rc.tx_release", "1")])
-        events[:] = []
-
-        n.rx_released()
-        self.assertEqual(events, [("t.nameplate_done", )])
-
-    def test_connect_first(self):
-        # connection remains up throughout
-        n, m, i, rc, t, events = self.build()
-        n.connected()
-        self.assertEqual(events, [])
-
-        n.set_nameplate("1")
-        self.assertEqual(events, [("rc.tx_claim", "1")])
-        events[:] = []
-
-        wl = object()
-        with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
-            n.rx_claimed("mbox1")
-        self.assertEqual(events, [
-            ("i.got_wordlist", wl),
-            ("m.got_mailbox", "mbox1"),
-        ])
-        events[:] = []
-
-        n.release()
-        self.assertEqual(events, [("rc.tx_release", "1")])
-        events[:] = []
-
-        n.rx_released()
-        self.assertEqual(events, [("t.nameplate_done", )])
-
-    def test_reconnect_while_claiming(self):
-        # connection bounced while waiting for rx_claimed
-        n, m, i, rc, t, events = self.build()
-        n.connected()
-        self.assertEqual(events, [])
-
-        n.set_nameplate("1")
-        self.assertEqual(events, [("rc.tx_claim", "1")])
-        events[:] = []
-
-        n.lost()
-        n.connected()
-        self.assertEqual(events, [("rc.tx_claim", "1")])
-
-    def test_reconnect_while_claimed(self):
-        # connection bounced while claimed: no retransmits should be sent
-        n, m, i, rc, t, events = self.build()
-        n.connected()
-        self.assertEqual(events, [])
-
-        n.set_nameplate("1")
-        self.assertEqual(events, [("rc.tx_claim", "1")])
-        events[:] = []
-
-        wl = object()
-        with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
-            n.rx_claimed("mbox1")
-        self.assertEqual(events, [
-            ("i.got_wordlist", wl),
-            ("m.got_mailbox", "mbox1"),
-        ])
-        events[:] = []
-
-        n.lost()
-        n.connected()
-        self.assertEqual(events, [])
-
-    def test_reconnect_while_releasing(self):
-        # connection bounced while waiting for rx_released
-        n, m, i, rc, t, events = self.build()
-        n.connected()
-        self.assertEqual(events, [])
-
-        n.set_nameplate("1")
-        self.assertEqual(events, [("rc.tx_claim", "1")])
-        events[:] = []
-
-        wl = object()
-        with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
-            n.rx_claimed("mbox1")
-        self.assertEqual(events, [
-            ("i.got_wordlist", wl),
-            ("m.got_mailbox", "mbox1"),
-        ])
-        events[:] = []
-
-        n.release()
-        self.assertEqual(events, [("rc.tx_release", "1")])
-        events[:] = []
-
-        n.lost()
-        n.connected()
-        self.assertEqual(events, [("rc.tx_release", "1")])
-
-    def test_reconnect_while_done(self):
-        # connection bounces after we're done
-        n, m, i, rc, t, events = self.build()
-        n.connected()
-        self.assertEqual(events, [])
-
-        n.set_nameplate("1")
-        self.assertEqual(events, [("rc.tx_claim", "1")])
-        events[:] = []
-
-        wl = object()
-        with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
-            n.rx_claimed("mbox1")
-        self.assertEqual(events, [
-            ("i.got_wordlist", wl),
-            ("m.got_mailbox", "mbox1"),
-        ])
-        events[:] = []
-
-        n.release()
-        self.assertEqual(events, [("rc.tx_release", "1")])
-        events[:] = []
-
-        n.rx_released()
-        self.assertEqual(events, [("t.nameplate_done", )])
-        events[:] = []
-
-        n.lost()
-        n.connected()
-        self.assertEqual(events, [])
-
-    def test_close_while_idle(self):
-        n, m, i, rc, t, events = self.build()
-        n.close()
-        self.assertEqual(events, [("t.nameplate_done", )])
-
-    def test_close_while_idle_connected(self):
-        n, m, i, rc, t, events = self.build()
-        n.connected()
-        self.assertEqual(events, [])
-        n.close()
-        self.assertEqual(events, [("t.nameplate_done", )])
-
-    def test_close_while_unclaimed(self):
-        n, m, i, rc, t, events = self.build()
-        n.set_nameplate("1")
-        n.close()  # before ever being connected
-        self.assertEqual(events, [("t.nameplate_done", )])
-
-    def test_close_while_claiming(self):
-        n, m, i, rc, t, events = self.build()
-        n.set_nameplate("1")
-        self.assertEqual(events, [])
-        n.connected()
-        self.assertEqual(events, [("rc.tx_claim", "1")])
-        events[:] = []
-
-        n.close()
-        self.assertEqual(events, [("rc.tx_release", "1")])
-        events[:] = []
-
-        n.rx_released()
-        self.assertEqual(events, [("t.nameplate_done", )])
-
-    def test_close_while_claiming_but_disconnected(self):
-        n, m, i, rc, t, events = self.build()
-        n.set_nameplate("1")
-        self.assertEqual(events, [])
-        n.connected()
-        self.assertEqual(events, [("rc.tx_claim", "1")])
-        events[:] = []
-
-        n.lost()
-        n.close()
-        self.assertEqual(events, [])
-        # we're now waiting for a connection, so we can release the nameplate
-        n.connected()
-        self.assertEqual(events, [("rc.tx_release", "1")])
-        events[:] = []
-
-        n.rx_released()
-        self.assertEqual(events, [("t.nameplate_done", )])
-
-    def test_close_while_claimed(self):
-        n, m, i, rc, t, events = self.build()
-        n.set_nameplate("1")
-        self.assertEqual(events, [])
-        n.connected()
-        self.assertEqual(events, [("rc.tx_claim", "1")])
-        events[:] = []
-
-        wl = object()
-        with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
-            n.rx_claimed("mbox1")
-        self.assertEqual(events, [
-            ("i.got_wordlist", wl),
-            ("m.got_mailbox", "mbox1"),
-        ])
-        events[:] = []
-
-        n.close()
-        # this path behaves just like a deliberate release()
-        self.assertEqual(events, [("rc.tx_release", "1")])
-        events[:] = []
-
-        n.rx_released()
-        self.assertEqual(events, [("t.nameplate_done", )])
-
-    def test_close_while_claimed_but_disconnected(self):
-        n, m, i, rc, t, events = self.build()
-        n.set_nameplate("1")
-        self.assertEqual(events, [])
-        n.connected()
-        self.assertEqual(events, [("rc.tx_claim", "1")])
-        events[:] = []
-
-        wl = object()
-        with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
-            n.rx_claimed("mbox1")
-        self.assertEqual(events, [
-            ("i.got_wordlist", wl),
-            ("m.got_mailbox", "mbox1"),
-        ])
-        events[:] = []
-
-        n.lost()
-        n.close()
-        # we're now waiting for a connection, so we can release the nameplate
-        n.connected()
-        self.assertEqual(events, [("rc.tx_release", "1")])
-        events[:] = []
-
-        n.rx_released()
-        self.assertEqual(events, [("t.nameplate_done", )])
-
-    def test_close_while_releasing(self):
-        n, m, i, rc, t, events = self.build()
-        n.set_nameplate("1")
-        self.assertEqual(events, [])
-        n.connected()
-        self.assertEqual(events, [("rc.tx_claim", "1")])
-        events[:] = []
-
-        wl = object()
-        with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
-            n.rx_claimed("mbox1")
-        self.assertEqual(events, [
-            ("i.got_wordlist", wl),
-            ("m.got_mailbox", "mbox1"),
-        ])
-        events[:] = []
-
-        n.release()
-        self.assertEqual(events, [("rc.tx_release", "1")])
-        events[:] = []
-
-        n.close()  # ignored, we're already on our way out the door
-        self.assertEqual(events, [])
-        n.rx_released()
-        self.assertEqual(events, [("t.nameplate_done", )])
-
-    def test_close_while_releasing_but_disconnecteda(self):
-        n, m, i, rc, t, events = self.build()
-        n.set_nameplate("1")
-        self.assertEqual(events, [])
-        n.connected()
-        self.assertEqual(events, [("rc.tx_claim", "1")])
-        events[:] = []
-
-        wl = object()
-        with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
-            n.rx_claimed("mbox1")
-        self.assertEqual(events, [
-            ("i.got_wordlist", wl),
-            ("m.got_mailbox", "mbox1"),
-        ])
-        events[:] = []
-
-        n.release()
-        self.assertEqual(events, [("rc.tx_release", "1")])
-        events[:] = []
-
-        n.lost()
-        n.close()
-        # we must retransmit the tx_release when we reconnect
-        self.assertEqual(events, [])
-
-        n.connected()
-        self.assertEqual(events, [("rc.tx_release", "1")])
-        events[:] = []
-
-        n.rx_released()
-        self.assertEqual(events, [("t.nameplate_done", )])
-
-    def test_close_while_done(self):
-        # connection remains up throughout
-        n, m, i, rc, t, events = self.build()
-        n.connected()
-        self.assertEqual(events, [])
-
-        n.set_nameplate("1")
-        self.assertEqual(events, [("rc.tx_claim", "1")])
-        events[:] = []
-
-        wl = object()
-        with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
-            n.rx_claimed("mbox1")
-        self.assertEqual(events, [
-            ("i.got_wordlist", wl),
-            ("m.got_mailbox", "mbox1"),
-        ])
-        events[:] = []
-
-        n.release()
-        self.assertEqual(events, [("rc.tx_release", "1")])
-        events[:] = []
-
-        n.rx_released()
-        self.assertEqual(events, [("t.nameplate_done", )])
-        events[:] = []
-
-        n.close()  # NOP
-        self.assertEqual(events, [])
-
-    def test_close_while_done_but_disconnected(self):
-        # connection remains up throughout
-        n, m, i, rc, t, events = self.build()
-        n.connected()
-        self.assertEqual(events, [])
-
-        n.set_nameplate("1")
-        self.assertEqual(events, [("rc.tx_claim", "1")])
-        events[:] = []
-
-        wl = object()
-        with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
-            n.rx_claimed("mbox1")
-        self.assertEqual(events, [
-            ("i.got_wordlist", wl),
-            ("m.got_mailbox", "mbox1"),
-        ])
-        events[:] = []
-
-        n.release()
-        self.assertEqual(events, [("rc.tx_release", "1")])
-        events[:] = []
-
-        n.rx_released()
-        self.assertEqual(events, [("t.nameplate_done", )])
-        events[:] = []
-
-        n.lost()
-        n.close()  # NOP
-        self.assertEqual(events, [])
-
-
-class Mailbox(unittest.TestCase):
-    def build(self):
-        events = []
-        m = _mailbox.Mailbox("side1")
-        n = Dummy("n", events, INameplate, "release")
-        rc = Dummy("rc", events, IRendezvousConnector, "tx_add", "tx_open",
-                   "tx_close")
-        o = Dummy("o", events, IOrder, "got_message")
-        t = Dummy("t", events, ITerminator, "mailbox_done")
-        m.wire(n, rc, o, t)
-        return m, n, rc, o, t, events
+    assert events == [("c.finished_input", "34-word-word")]
+
+
+def build_lister():
+    events = []
+    lister = _lister.Lister(timing.DebugTiming())
+    rc = Dummy("rc", events, IRendezvousConnector, "tx_list")
+    i = Dummy("i", events, IInput, "got_nameplates")
+    lister.wire(rc, i)
+    return lister, rc, i, events
+
+
+def test_connect_first():
+    lister, rc, i, events = build_lister()
+    lister.connected()
+    lister.lost()
+    lister.connected()
+    assert events == []
+    lister.refresh()
+    assert events == [
+        ("rc.tx_list", ),
+    ]
+    events[:] = []
+    lister.rx_nameplates({"1", "2", "3"})
+    assert events == [
+        ("i.got_nameplates", {"1", "2", "3"}),
+    ]
+    events[:] = []
+    # now we're satisfied: disconnecting and reconnecting won't ask again
+    lister.lost()
+    lister.connected()
+    assert events == []
+
+    # but if we're told to refresh, we'll do so
+    lister.refresh()
+    assert events == [
+        ("rc.tx_list", ),
+    ]
+
+def test_connect_first_ask_twice():
+    lister, rc, i, events = build_lister()
+    lister.connected()
+    assert events == []
+    lister.refresh()
+    lister.refresh()
+    assert events == [
+        ("rc.tx_list", ),
+        ("rc.tx_list", ),
+    ]
+    lister.rx_nameplates({"1", "2", "3"})
+    assert events == [
+        ("rc.tx_list", ),
+        ("rc.tx_list", ),
+        ("i.got_nameplates", {"1", "2", "3"}),
+    ]
+    lister.rx_nameplates({"1", "2", "3", "4"})
+    assert events == [
+        ("rc.tx_list", ),
+        ("rc.tx_list", ),
+        ("i.got_nameplates", {"1", "2", "3"}),
+        ("i.got_nameplates", {"1", "2", "3", "4"}),
+    ]
+
+def test_reconnect():
+    lister, rc, i, events = build_lister()
+    lister.refresh()
+    lister.connected()
+    assert events == [
+        ("rc.tx_list", ),
+    ]
+    events[:] = []
+    lister.lost()
+    lister.connected()
+    assert events == [
+        ("rc.tx_list", ),
+    ]
+
+def test_refresh_first():
+    lister, rc, i, events = build_lister()
+    lister.refresh()
+    assert events == []
+    lister.connected()
+    assert events == [
+        ("rc.tx_list", ),
+    ]
+    lister.rx_nameplates({"1", "2", "3"})
+    assert events == [
+        ("rc.tx_list", ),
+        ("i.got_nameplates", {"1", "2", "3"}),
+    ]
+
+def test_unrefreshed():
+    lister, rc, i, events = build_lister()
+    assert events == []
+    # we receive a spontaneous rx_nameplates, without asking
+    lister.connected()
+    assert events == []
+    lister.rx_nameplates({"1", "2", "3"})
+    assert events == [
+        ("i.got_nameplates", {"1", "2", "3"}),
+    ]
+
+
+def build_allocator():
+    events = []
+    a = _allocator.Allocator(timing.DebugTiming())
+    rc = Dummy("rc", events, IRendezvousConnector, "tx_allocate")
+    c = Dummy("c", events, ICode, "allocated")
+    a.wire(rc, c)
+    return a, rc, c, events
+
+
+def test_no_allocation():
+    a, rc, c, events = build_allocator()
+    a.connected()
+    assert events == []
+
+def test_allocate_first():
+    a, rc, c, events = build_allocator()
+    a.allocate(2, FakeWordList())
+    assert events == []
+    a.connected()
+    assert events == [("rc.tx_allocate", )]
+    events[:] = []
+    a.lost()
+    a.connected()
+    assert events == [
+        ("rc.tx_allocate", ),
+    ]
+    events[:] = []
+    a.rx_allocated("1")
+    assert events == [
+        ("c.allocated", "1", "1-word-word"),
+    ]
+
+def test_connect_first():
+    a, rc, c, events = build_allocator()
+    a.connected()
+    assert events == []
+    a.allocate(2, FakeWordList())
+    assert events == [("rc.tx_allocate", )]
+    events[:] = []
+    a.lost()
+    a.connected()
+    assert events == [
+        ("rc.tx_allocate", ),
+    ]
+    events[:] = []
+    a.rx_allocated("1")
+    assert events == [
+        ("c.allocated", "1", "1-word-word"),
+    ]
+
+
+def build_nameplate():
+    events = []
+    n = _nameplate.Nameplate()
+    m = Dummy("m", events, IMailbox, "got_mailbox")
+    i = Dummy("i", events, IInput, "got_wordlist")
+    rc = Dummy("rc", events, IRendezvousConnector, "tx_claim",
+               "tx_release")
+    t = Dummy("t", events, ITerminator, "nameplate_done")
+    n.wire(m, i, rc, t)
+    return n, m, i, rc, t, events
+
+
+def test_set_invalid():
+    n, m, i, rc, t, events = build_nameplate()
+    with pytest.raises(errors.KeyFormatError) as e:
+        n.set_nameplate(" 1")
+    assert str(e.value) == \
+        "Nameplate ' 1' must be numeric, with no spaces."
+    with pytest.raises(errors.KeyFormatError) as e:
+        n.set_nameplate("one")
+    assert str(e.value) == \
+        "Nameplate 'one' must be numeric, with no spaces."
+
+    # wormhole should still be usable
+    n.set_nameplate("1")
+    assert events == []
+    n.connected()
+    assert events == [("rc.tx_claim", "1")]
+
+def test_set_first():
+    # connection remains up throughout
+    n, m, i, rc, t, events = build_nameplate()
+    n.set_nameplate("1")
+    assert events == []
+    n.connected()
+    assert events == [("rc.tx_claim", "1")]
+    events[:] = []
+
+    wl = object()
+    with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
+        n.rx_claimed("mbox1")
+    assert events == [
+        ("i.got_wordlist", wl),
+        ("m.got_mailbox", "mbox1"),
+    ]
+    events[:] = []
+
+    n.release()
+    assert events == [("rc.tx_release", "1")]
+    events[:] = []
+
+    n.rx_released()
+    assert events == [("t.nameplate_done", )]
+
+def test_connect_first():
+    # connection remains up throughout
+    n, m, i, rc, t, events = build_nameplate()
+    n.connected()
+    assert events == []
+
+    n.set_nameplate("1")
+    assert events == [("rc.tx_claim", "1")]
+    events[:] = []
+
+    wl = object()
+    with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
+        n.rx_claimed("mbox1")
+    assert events == [
+        ("i.got_wordlist", wl),
+        ("m.got_mailbox", "mbox1"),
+    ]
+    events[:] = []
+
+    n.release()
+    assert events == [("rc.tx_release", "1")]
+    events[:] = []
+
+    n.rx_released()
+    assert events == [("t.nameplate_done", )]
+
+def test_reconnect_while_claiming():
+    # connection bounced while waiting for rx_claimed
+    n, m, i, rc, t, events = build_nameplate()
+    n.connected()
+    assert events == []
+
+    n.set_nameplate("1")
+    assert events == [("rc.tx_claim", "1")]
+    events[:] = []
+
+    n.lost()
+    n.connected()
+    assert events == [("rc.tx_claim", "1")]
+
+def test_reconnect_while_claimed():
+    # connection bounced while claimed: no retransmits should be sent
+    n, m, i, rc, t, events = build_nameplate()
+    n.connected()
+    assert events == []
+
+    n.set_nameplate("1")
+    assert events == [("rc.tx_claim", "1")]
+    events[:] = []
+
+    wl = object()
+    with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
+        n.rx_claimed("mbox1")
+    assert events == [
+        ("i.got_wordlist", wl),
+        ("m.got_mailbox", "mbox1"),
+    ]
+    events[:] = []
+
+    n.lost()
+    n.connected()
+    assert events == []
+
+def test_reconnect_while_releasing():
+    # connection bounced while waiting for rx_released
+    n, m, i, rc, t, events = build_nameplate()
+    n.connected()
+    assert events == []
+
+    n.set_nameplate("1")
+    assert events == [("rc.tx_claim", "1")]
+    events[:] = []
+
+    wl = object()
+    with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
+        n.rx_claimed("mbox1")
+    assert events == [
+        ("i.got_wordlist", wl),
+        ("m.got_mailbox", "mbox1"),
+    ]
+    events[:] = []
+
+    n.release()
+    assert events == [("rc.tx_release", "1")]
+    events[:] = []
+
+    n.lost()
+    n.connected()
+    assert events == [("rc.tx_release", "1")]
+
+def test_reconnect_while_done():
+    # connection bounces after we're done
+    n, m, i, rc, t, events = build_nameplate()
+    n.connected()
+    assert events == []
+
+    n.set_nameplate("1")
+    assert events == [("rc.tx_claim", "1")]
+    events[:] = []
+
+    wl = object()
+    with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
+        n.rx_claimed("mbox1")
+    assert events == [
+        ("i.got_wordlist", wl),
+        ("m.got_mailbox", "mbox1"),
+    ]
+    events[:] = []
+
+    n.release()
+    assert events == [("rc.tx_release", "1")]
+    events[:] = []
+
+    n.rx_released()
+    assert events == [("t.nameplate_done", )]
+    events[:] = []
+
+    n.lost()
+    n.connected()
+    assert events == []
+
+def test_close_while_idle():
+    n, m, i, rc, t, events = build_nameplate()
+    n.close()
+    assert events == [("t.nameplate_done", )]
+
+def test_close_while_idle_connected():
+    n, m, i, rc, t, events = build_nameplate()
+    n.connected()
+    assert events == []
+    n.close()
+    assert events == [("t.nameplate_done", )]
+
+def test_close_while_unclaimed():
+    n, m, i, rc, t, events = build_nameplate()
+    n.set_nameplate("1")
+    n.close()  # before ever being connected
+    assert events == [("t.nameplate_done", )]
+
+def test_close_while_claiming():
+    n, m, i, rc, t, events = build_nameplate()
+    n.set_nameplate("1")
+    assert events == []
+    n.connected()
+    assert events == [("rc.tx_claim", "1")]
+    events[:] = []
+
+    n.close()
+    assert events == [("rc.tx_release", "1")]
+    events[:] = []
+
+    n.rx_released()
+    assert events == [("t.nameplate_done", )]
+
+def test_close_while_claiming_but_disconnected():
+    n, m, i, rc, t, events = build_nameplate()
+    n.set_nameplate("1")
+    assert events == []
+    n.connected()
+    assert events == [("rc.tx_claim", "1")]
+    events[:] = []
+
+    n.lost()
+    n.close()
+    assert events == []
+    # we're now waiting for a connection, so we can release the nameplate
+    n.connected()
+    assert events == [("rc.tx_release", "1")]
+    events[:] = []
+
+    n.rx_released()
+    assert events == [("t.nameplate_done", )]
+
+def test_close_while_claimed():
+    n, m, i, rc, t, events = build_nameplate()
+    n.set_nameplate("1")
+    assert events == []
+    n.connected()
+    assert events == [("rc.tx_claim", "1")]
+    events[:] = []
+
+    wl = object()
+    with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
+        n.rx_claimed("mbox1")
+    assert events == [
+        ("i.got_wordlist", wl),
+        ("m.got_mailbox", "mbox1"),
+    ]
+    events[:] = []
+
+    n.close()
+    # this path behaves just like a deliberate release()
+    assert events == [("rc.tx_release", "1")]
+    events[:] = []
+
+    n.rx_released()
+    assert events == [("t.nameplate_done", )]
+
+def test_close_while_claimed_but_disconnected():
+    n, m, i, rc, t, events = build_nameplate()
+    n.set_nameplate("1")
+    assert events == []
+    n.connected()
+    assert events == [("rc.tx_claim", "1")]
+    events[:] = []
+
+    wl = object()
+    with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
+        n.rx_claimed("mbox1")
+    assert events == [
+        ("i.got_wordlist", wl),
+        ("m.got_mailbox", "mbox1"),
+    ]
+    events[:] = []
+
+    n.lost()
+    n.close()
+    # we're now waiting for a connection, so we can release the nameplate
+    n.connected()
+    assert events == [("rc.tx_release", "1")]
+    events[:] = []
+
+    n.rx_released()
+    assert events == [("t.nameplate_done", )]
+
+def test_close_while_releasing():
+    n, m, i, rc, t, events = build_nameplate()
+    n.set_nameplate("1")
+    assert events == []
+    n.connected()
+    assert events == [("rc.tx_claim", "1")]
+    events[:] = []
+
+    wl = object()
+    with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
+        n.rx_claimed("mbox1")
+    assert events == [
+        ("i.got_wordlist", wl),
+        ("m.got_mailbox", "mbox1"),
+    ]
+    events[:] = []
+
+    n.release()
+    assert events == [("rc.tx_release", "1")]
+    events[:] = []
+
+    n.close()  # ignored, we're already on our way out the door
+    assert events == []
+    n.rx_released()
+    assert events == [("t.nameplate_done", )]
+
+def test_close_while_releasing_but_disconnecteda():
+    n, m, i, rc, t, events = build_nameplate()
+    n.set_nameplate("1")
+    assert events == []
+    n.connected()
+    assert events == [("rc.tx_claim", "1")]
+    events[:] = []
+
+    wl = object()
+    with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
+        n.rx_claimed("mbox1")
+    assert events == [
+        ("i.got_wordlist", wl),
+        ("m.got_mailbox", "mbox1"),
+    ]
+    events[:] = []
+
+    n.release()
+    assert events == [("rc.tx_release", "1")]
+    events[:] = []
+
+    n.lost()
+    n.close()
+    # we must retransmit the tx_release when we reconnect
+    assert events == []
+
+    n.connected()
+    assert events == [("rc.tx_release", "1")]
+    events[:] = []
+
+    n.rx_released()
+    assert events == [("t.nameplate_done", )]
+
+def test_close_while_done():
+    # connection remains up throughout
+    n, m, i, rc, t, events = build_nameplate()
+    n.connected()
+    assert events == []
+
+    n.set_nameplate("1")
+    assert events == [("rc.tx_claim", "1")]
+    events[:] = []
+
+    wl = object()
+    with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
+        n.rx_claimed("mbox1")
+    assert events == [
+        ("i.got_wordlist", wl),
+        ("m.got_mailbox", "mbox1"),
+    ]
+    events[:] = []
+
+    n.release()
+    assert events == [("rc.tx_release", "1")]
+    events[:] = []
+
+    n.rx_released()
+    assert events == [("t.nameplate_done", )]
+    events[:] = []
+
+    n.close()  # NOP
+    assert events == []
+
+def test_close_while_done_but_disconnected():
+    # connection remains up throughout
+    n, m, i, rc, t, events = build_nameplate()
+    n.connected()
+    assert events == []
+
+    n.set_nameplate("1")
+    assert events == [("rc.tx_claim", "1")]
+    events[:] = []
+
+    wl = object()
+    with mock.patch("wormhole._nameplate.PGPWordList", return_value=wl):
+        n.rx_claimed("mbox1")
+    assert events == [
+        ("i.got_wordlist", wl),
+        ("m.got_mailbox", "mbox1"),
+    ]
+    events[:] = []
+
+    n.release()
+    assert events == [("rc.tx_release", "1")]
+    events[:] = []
+
+    n.rx_released()
+    assert events == [("t.nameplate_done", )]
+    events[:] = []
+
+    n.lost()
+    n.close()  # NOP
+    assert events == []
+
+
+def build_mailbox():
+    events = []
+    m = _mailbox.Mailbox("side1")
+    n = Dummy("n", events, INameplate, "release")
+    rc = Dummy("rc", events, IRendezvousConnector, "tx_add", "tx_open",
+               "tx_close")
+    o = Dummy("o", events, IOrder, "got_message")
+    t = Dummy("t", events, ITerminator, "mailbox_done")
+    m.wire(n, rc, o, t)
+    return m, n, rc, o, t, events
 
     # TODO: test moods
 
-    def assert_events(self, events, initial_events, tx_add_events):
-        self.assertEqual(
-            len(events),
-            len(initial_events) + len(tx_add_events), events)
-        self.assertEqual(events[:len(initial_events)], initial_events)
-        self.assertEqual(set(events[len(initial_events):]), tx_add_events)
+def assert_events(events, initial_events, tx_add_events):
+    assert len(events) == \
+        len(initial_events) + len(tx_add_events), events
+    assert events[:len(initial_events)] == initial_events
+    assert set(events[len(initial_events):]) == tx_add_events
 
-    def test_connect_first(self):  # connect before got_mailbox
-        m, n, rc, o, t, events = self.build()
-        m.add_message("phase1", b"msg1")
-        self.assertEqual(events, [])
 
-        m.connected()
-        self.assertEqual(events, [])
+def test_connect_first():  # connect before got_mailbox
+    m, n, rc, o, t, events = build_mailbox()
+    m.add_message("phase1", b"msg1")
+    assert events == []
 
-        m.got_mailbox("mbox1")
-        self.assertEqual(events, [("rc.tx_open", "mbox1"),
-                                  ("rc.tx_add", "phase1", b"msg1")])
-        events[:] = []
+    m.connected()
+    assert events == []
 
-        m.add_message("phase2", b"msg2")
-        self.assertEqual(events, [("rc.tx_add", "phase2", b"msg2")])
-        events[:] = []
+    m.got_mailbox("mbox1")
+    assert events == [("rc.tx_open", "mbox1"),
+                              ("rc.tx_add", "phase1", b"msg1")]
+    events[:] = []
 
-        # bouncing the connection should retransmit everything, even the open()
-        m.lost()
-        self.assertEqual(events, [])
-        # and messages sent while here should be queued
-        m.add_message("phase3", b"msg3")
-        self.assertEqual(events, [])
+    m.add_message("phase2", b"msg2")
+    assert events == [("rc.tx_add", "phase2", b"msg2")]
+    events[:] = []
 
-        m.connected()
-        # the other messages are allowed to be sent in any order
-        self.assert_events(
-            events, [("rc.tx_open", "mbox1")], {
-                ("rc.tx_add", "phase1", b"msg1"),
-                ("rc.tx_add", "phase2", b"msg2"),
-                ("rc.tx_add", "phase3", b"msg3"),
-            })
-        events[:] = []
+    # bouncing the connection should retransmit everything, even the open()
+    m.lost()
+    assert events == []
+    # and messages sent while here should be queued
+    m.add_message("phase3", b"msg3")
+    assert events == []
 
-        m.rx_message("side1", "phase1",
-                     b"msg1")  # echo of our message, dequeue
-        self.assertEqual(events, [])
-
-        m.lost()
-        m.connected()
-        self.assert_events(events, [("rc.tx_open", "mbox1")], {
+    m.connected()
+    # the other messages are allowed to be sent in any order
+    assert_events(
+        events, [("rc.tx_open", "mbox1")], {
+            ("rc.tx_add", "phase1", b"msg1"),
             ("rc.tx_add", "phase2", b"msg2"),
             ("rc.tx_add", "phase3", b"msg3"),
         })
-        events[:] = []
+    events[:] = []
 
-        # a new message from the peer gets delivered, and the Nameplate is
-        # released since the message proves that our peer opened the Mailbox
-        # and therefore no longer needs the Nameplate
-        m.rx_message("side2", "phase1", b"msg1them")  # new message from peer
-        self.assertEqual(events, [
-            ("n.release", ),
-            ("o.got_message", "side2", "phase1", b"msg1them"),
-        ])
-        events[:] = []
+    m.rx_message("side1", "phase1",
+                 b"msg1")  # echo of our message, dequeue
+    assert events == []
 
-        # we de-duplicate peer messages, but still re-release the nameplate
-        # since Nameplate is smart enough to ignore that
-        m.rx_message("side2", "phase1", b"msg1them")
-        self.assertEqual(events, [
-            ("n.release", ),
-        ])
-        events[:] = []
+    m.lost()
+    m.connected()
+    assert_events(events, [("rc.tx_open", "mbox1")], {
+        ("rc.tx_add", "phase2", b"msg2"),
+        ("rc.tx_add", "phase3", b"msg3"),
+    })
+    events[:] = []
 
-        m.close("happy")
-        self.assertEqual(events, [("rc.tx_close", "mbox1", "happy")])
-        events[:] = []
+    # a new message from the peer gets delivered, and the Nameplate is
+    # released since the message proves that our peer opened the Mailbox
+    # and therefore no longer needs the Nameplate
+    m.rx_message("side2", "phase1", b"msg1them")  # new message from peer
+    assert events == [
+        ("n.release", ),
+        ("o.got_message", "side2", "phase1", b"msg1them"),
+    ]
+    events[:] = []
 
-        # while closing, we ignore a lot
-        m.add_message("phase-late", b"late")
-        m.rx_message("side1", "phase2", b"msg2")
-        m.close("happy")
-        self.assertEqual(events, [])
+    # we de-duplicate peer messages, but still re-release the nameplate
+    # since Nameplate is smart enough to ignore that
+    m.rx_message("side2", "phase1", b"msg1them")
+    assert events == [
+        ("n.release", ),
+    ]
+    events[:] = []
 
-        # bouncing the connection forces a retransmit of the tx_close
-        m.lost()
-        self.assertEqual(events, [])
-        m.connected()
-        self.assertEqual(events, [("rc.tx_close", "mbox1", "happy")])
-        events[:] = []
+    m.close("happy")
+    assert events == [("rc.tx_close", "mbox1", "happy")]
+    events[:] = []
 
-        m.rx_closed()
-        self.assertEqual(events, [("t.mailbox_done", )])
-        events[:] = []
+    # while closing, we ignore a lot
+    m.add_message("phase-late", b"late")
+    m.rx_message("side1", "phase2", b"msg2")
+    m.close("happy")
+    assert events == []
 
-        # while closed, we ignore everything
-        m.add_message("phase-late", b"late")
-        m.rx_message("side1", "phase2", b"msg2")
-        m.close("happy")
-        m.lost()
-        m.connected()
-        self.assertEqual(events, [])
+    # bouncing the connection forces a retransmit of the tx_close
+    m.lost()
+    assert events == []
+    m.connected()
+    assert events == [("rc.tx_close", "mbox1", "happy")]
+    events[:] = []
 
-    def test_mailbox_first(self):  # got_mailbox before connect
-        m, n, rc, o, t, events = self.build()
-        m.add_message("phase1", b"msg1")
-        self.assertEqual(events, [])
+    m.rx_closed()
+    assert events == [("t.mailbox_done", )]
+    events[:] = []
 
-        m.got_mailbox("mbox1")
-        m.add_message("phase2", b"msg2")
-        self.assertEqual(events, [])
+    # while closed, we ignore everything
+    m.add_message("phase-late", b"late")
+    m.rx_message("side1", "phase2", b"msg2")
+    m.close("happy")
+    m.lost()
+    m.connected()
+    assert events == []
 
-        m.connected()
+def test_mailbox_first():  # got_mailbox before connect
+    m, n, rc, o, t, events = build_mailbox()
+    m.add_message("phase1", b"msg1")
+    assert events == []
 
-        self.assert_events(events, [("rc.tx_open", "mbox1")], {
-            ("rc.tx_add", "phase1", b"msg1"),
-            ("rc.tx_add", "phase2", b"msg2"),
-        })
+    m.got_mailbox("mbox1")
+    m.add_message("phase2", b"msg2")
+    assert events == []
 
-    def test_close_while_idle(self):
-        m, n, rc, o, t, events = self.build()
-        m.close("happy")
-        self.assertEqual(events, [("t.mailbox_done", )])
+    m.connected()
 
-    def test_close_while_idle_but_connected(self):
-        m, n, rc, o, t, events = self.build()
-        m.connected()
-        m.close("happy")
-        self.assertEqual(events, [("t.mailbox_done", )])
+    assert_events(events, [("rc.tx_open", "mbox1")], {
+        ("rc.tx_add", "phase1", b"msg1"),
+        ("rc.tx_add", "phase2", b"msg2"),
+    })
 
-    def test_close_while_mailbox_disconnected(self):
-        m, n, rc, o, t, events = self.build()
-        m.got_mailbox("mbox1")
-        m.close("happy")
-        self.assertEqual(events, [("t.mailbox_done", )])
+def test_close_while_idle():
+    m, n, rc, o, t, events = build_mailbox()
+    m.close("happy")
+    assert events == [("t.mailbox_done", )]
 
-    def test_close_while_reconnecting(self):
-        m, n, rc, o, t, events = self.build()
-        m.got_mailbox("mbox1")
-        m.connected()
-        self.assertEqual(events, [("rc.tx_open", "mbox1")])
-        events[:] = []
+def test_close_while_idle_but_connected():
+    m, n, rc, o, t, events = build_mailbox()
+    m.connected()
+    m.close("happy")
+    assert events == [("t.mailbox_done", )]
 
-        m.lost()
-        self.assertEqual(events, [])
-        m.close("happy")
-        self.assertEqual(events, [])
-        # we now wait to connect, so we can send the tx_close
+def test_close_while_mailbox_disconnected():
+    m, n, rc, o, t, events = build_mailbox()
+    m.got_mailbox("mbox1")
+    m.close("happy")
+    assert events == [("t.mailbox_done", )]
 
-        m.connected()
-        self.assertEqual(events, [("rc.tx_close", "mbox1", "happy")])
-        events[:] = []
+def test_close_while_reconnecting():
+    m, n, rc, o, t, events = build_mailbox()
+    m.got_mailbox("mbox1")
+    m.connected()
+    assert events == [("rc.tx_open", "mbox1")]
+    events[:] = []
 
-        m.rx_closed()
-        self.assertEqual(events, [("t.mailbox_done", )])
-        events[:] = []
+    m.lost()
+    assert events == []
+    m.close("happy")
+    assert events == []
+    # we now wait to connect, so we can send the tx_close
+
+    m.connected()
+    assert events == [("rc.tx_close", "mbox1", "happy")]
+    events[:] = []
+
+    m.rx_closed()
+    assert events == [("t.mailbox_done", )]
+    events[:] = []
 
 
-class Terminator(unittest.TestCase):
-    def build(self):
-        events = []
-        t = _terminator.Terminator()
-        b = Dummy("b", events, IBoss, "closed")
-        rc = Dummy("rc", events, IRendezvousConnector, "stop")
-        n = Dummy("n", events, INameplate, "close")
-        m = Dummy("m", events, IMailbox, "close")
-        d = Dummy("d", events, IDilator, "stop")
-        t.wire(b, rc, n, m, d)
-        return t, b, rc, n, m, events
+def build_terminator():
+    events = []
+    t = _terminator.Terminator()
+    b = Dummy("b", events, IBoss, "closed")
+    rc = Dummy("rc", events, IRendezvousConnector, "stop")
+    n = Dummy("n", events, INameplate, "close")
+    m = Dummy("m", events, IMailbox, "close")
+    d = Dummy("d", events, IDilator, "stop")
+    t.wire(b, rc, n, m, d)
+    return t, b, rc, n, m, events
 
-    # there are three events, and we need to test all orderings of them
-    def _do_test(self, ev1, ev2, ev3):
-        t, b, rc, n, m, events = self.build()
-        input_events = {
-            "mailbox": lambda: t.mailbox_done(),
-            "nameplate": lambda: t.nameplate_done(),
-            "rc": lambda: t.close("happy"),
-        }
-        close_events = [
-            ("n.close", ),
-            ("m.close", "happy"),
-        ]
 
-        if ev1 == "mailbox":
-            close_events.remove(("m.close", "happy"))
-        elif ev1 == "nameplate":
-            close_events.remove(("n.close",))
+# there are three events, and we need to test all orderings of them
+def _do_test(ev1, ev2, ev3):
+    t, b, rc, n, m, events = build_terminator()
+    input_events = {
+        "mailbox": lambda: t.mailbox_done(),
+        "nameplate": lambda: t.nameplate_done(),
+        "rc": lambda: t.close("happy"),
+    }
+    close_events = [
+        ("n.close", ),
+        ("m.close", "happy"),
+    ]
 
-        input_events[ev1]()
-        expected = []
-        if ev1 == "rc":
-            expected.extend(close_events)
-        self.assertEqual(events, expected)
-        events[:] = []
+    if ev1 == "mailbox":
+        close_events.remove(("m.close", "happy"))
+    elif ev1 == "nameplate":
+        close_events.remove(("n.close",))
 
-        if ev2 == "mailbox":
-            close_events.remove(("m.close", "happy"))
-        elif ev2 == "nameplate":
-            close_events.remove(("n.close",))
+    input_events[ev1]()
+    expected = []
+    if ev1 == "rc":
+        expected.extend(close_events)
+    assert events == expected
+    events[:] = []
 
-        input_events[ev2]()
-        expected = []
-        if ev2 == "rc":
-            expected.extend(close_events)
-        self.assertEqual(events, expected)
-        events[:] = []
+    if ev2 == "mailbox":
+        close_events.remove(("m.close", "happy"))
+    elif ev2 == "nameplate":
+        close_events.remove(("n.close",))
 
-        if ev3 == "mailbox":
-            close_events.remove(("m.close", "happy"))
-        elif ev3 == "nameplate":
-            close_events.remove(("n.close",))
+    input_events[ev2]()
+    expected = []
+    if ev2 == "rc":
+        expected.extend(close_events)
+    assert events == expected
+    events[:] = []
 
-        input_events[ev3]()
-        expected = []
-        if ev3 == "rc":
-            expected.extend(close_events)
-        expected.append(("rc.stop", ))
-        self.assertEqual(events, expected)
-        events[:] = []
+    if ev3 == "mailbox":
+        close_events.remove(("m.close", "happy"))
+    elif ev3 == "nameplate":
+        close_events.remove(("n.close",))
 
-        t.stoppedRC()
-        self.assertEqual(events, [("d.stop", )])
-        events[:] = []
+    input_events[ev3]()
+    expected = []
+    if ev3 == "rc":
+        expected.extend(close_events)
+    expected.append(("rc.stop", ))
+    assert events == expected
+    events[:] = []
 
-        t.stoppedD()
-        self.assertEqual(events, [("b.closed", )])
+    t.stoppedRC()
+    assert events == [("d.stop", )]
+    events[:] = []
 
-    def test_terminate(self):
-        self._do_test("mailbox", "nameplate", "rc")
-        self._do_test("mailbox", "rc", "nameplate")
-        self._do_test("nameplate", "mailbox", "rc")
-        self._do_test("nameplate", "rc", "mailbox")
-        self._do_test("rc", "nameplate", "mailbox")
-        self._do_test("rc", "mailbox", "nameplate")
+    t.stoppedD()
+    assert events == [("b.closed", )]
 
-    # TODO: test moods
+def test_terminate():
+    _do_test("mailbox", "nameplate", "rc")
+    _do_test("mailbox", "rc", "nameplate")
+    _do_test("nameplate", "mailbox", "rc")
+    _do_test("nameplate", "rc", "mailbox")
+    _do_test("rc", "nameplate", "mailbox")
+    _do_test("rc", "mailbox", "nameplate")
+
+
+# TODO: test moods
 
 
 class MockBoss(_boss.Boss):
@@ -1301,392 +1299,392 @@ class MockBoss(_boss.Boss):
         self._init_other_state()
 
 
-class Boss(unittest.TestCase):
-    def build(self):
-        events = []
-        wormhole = Dummy("w", events, None, "got_welcome", "got_code",
-                         "got_key", "got_verifier", "got_versions", "received",
-                         "closed")
-        versions = {"app": "version1"}
-        reactor = None
-        eq = None
-        cooperator = None
-        journal = ImmediateJournal()
-        tor_manager = None
-        client_version = ("python", __version__)
-        b = MockBoss(wormhole, "side", "url", "appid", versions,
-                     client_version, reactor, eq, cooperator, journal,
-                     tor_manager,
-                     timing.DebugTiming())
-        b._T = Dummy("t", events, ITerminator, "close")
-        b._S = Dummy("s", events, ISend, "send")
-        b._RC = Dummy("rc", events, IRendezvousConnector, "start")
-        b._C = Dummy("c", events, ICode, "allocate_code", "input_code",
-                     "set_code")
-        b._D = Dummy("d", events, IDilator, "got_wormhole_versions", "got_key", _manager=None)
-        return b, events
+def build_boss():
+    events = []
+    wormhole = Dummy("w", events, None, "got_welcome", "got_code",
+                     "got_key", "got_verifier", "got_versions", "received",
+                     "closed")
+    versions = {"app": "version1"}
+    reactor = None
+    eq = None
+    cooperator = None
+    journal = ImmediateJournal()
+    tor_manager = None
+    client_version = ("python", __version__)
+    b = MockBoss(wormhole, "side", "url", "appid", versions,
+                 client_version, reactor, eq, cooperator, journal,
+                 tor_manager,
+                 timing.DebugTiming())
+    b._T = Dummy("t", events, ITerminator, "close")
+    b._S = Dummy("s", events, ISend, "send")
+    b._RC = Dummy("rc", events, IRendezvousConnector, "start")
+    b._C = Dummy("c", events, ICode, "allocate_code", "input_code",
+                 "set_code")
+    b._D = Dummy("d", events, IDilator, "got_wormhole_versions", "got_key", _manager=None)
+    return b, events
 
-    def test_basic(self):
-        b, events = self.build()
+def test_boss_basic():
+    b, events = build_boss()
+    b.set_code("1-code")
+    assert events == [("c.set_code", "1-code")]
+    events[:] = []
+
+    b.got_code("1-code")
+    assert events == [("w.got_code", "1-code")]
+    events[:] = []
+
+    welcome = {"howdy": "how are ya"}
+    b.rx_welcome(welcome)
+    assert events == [
+        ("w.got_welcome", welcome),
+    ]
+    events[:] = []
+
+    # pretend a peer message was correctly decrypted
+    b.got_key(b"key")
+    b.happy()
+    b.got_verifier(b"verifier")
+    b.got_message("version", b"{}")
+    b.got_message("0", b"msg1")
+    assert events == [
+        ("w.got_key", b"key"),
+        ("d.got_key", b"key"),
+        ("w.got_verifier", b"verifier"),
+        ("d.got_wormhole_versions", {}),
+        ("w.got_versions", {}),
+        ("w.received", b"msg1"),
+    ]
+    events[:] = []
+
+    b.send(b"msg2")
+    assert events == [("s.send", "0", b"msg2")]
+    events[:] = []
+
+    b.close()
+    assert events == [("t.close", "happy")]
+    events[:] = []
+
+    b.closed()
+    assert events == [("w.closed", "happy")]
+
+def test_unwelcome():
+    b, events = build_boss()
+    unwelcome = {"error": "go away"}
+    b.rx_welcome(unwelcome)
+    assert events == [("t.close", "unwelcome")]
+
+def test_lonely():
+    b, events = build_boss()
+    b.set_code("1-code")
+    assert events == [("c.set_code", "1-code")]
+    events[:] = []
+
+    b.got_code("1-code")
+    assert events == [("w.got_code", "1-code")]
+    events[:] = []
+
+    b.close()
+    assert events == [("t.close", "lonely")]
+    events[:] = []
+
+    b.closed()
+    assert len(events) == 1, events
+    assert events[0][0] == "w.closed"
+    assert isinstance(events[0][1], errors.LonelyError)
+
+def test_server_error():
+    b, events = build_boss()
+    b.set_code("1-code")
+    assert events == [("c.set_code", "1-code")]
+    events[:] = []
+
+    orig = {}
+    b.rx_error("server-error-msg", orig)
+    assert events == [("t.close", "errory")]
+    events[:] = []
+
+    b.closed()
+    assert len(events) == 1, events
+    assert events[0][0] == "w.closed"
+    assert isinstance(events[0][1], errors.ServerError)
+    assert events[0][1].args[0] == "server-error-msg"
+
+def test_internal_error():
+    b, events = build_boss()
+    b.set_code("1-code")
+    assert events == [("c.set_code", "1-code")]
+    events[:] = []
+
+    b.error(ValueError("catch me"))
+    assert len(events) == 1, events
+    assert events[0][0] == "w.closed"
+    assert isinstance(events[0][1], ValueError)
+    assert events[0][1].args[0] == "catch me"
+
+def test_close_early():
+    b, events = build_boss()
+    b.set_code("1-code")
+    assert events == [("c.set_code", "1-code")]
+    events[:] = []
+
+    b.close()  # before even w.got_code
+    assert events == [("t.close", "lonely")]
+    events[:] = []
+
+    b.closed()
+    assert len(events) == 1, events
+    assert events[0][0] == "w.closed"
+    assert isinstance(events[0][1], errors.LonelyError)
+
+def test_error_while_closing():
+    b, events = build_boss()
+    b.set_code("1-code")
+    assert events == [("c.set_code", "1-code")]
+    events[:] = []
+
+    b.close()
+    assert events == [("t.close", "lonely")]
+    events[:] = []
+
+    b.error(ValueError("oops"))
+    assert len(events) == 1, events
+    assert events[0][0] == "w.closed"
+    assert isinstance(events[0][1], ValueError)
+
+def test_scary_version():
+    b, events = build_boss()
+    b.set_code("1-code")
+    assert events == [("c.set_code", "1-code")]
+    events[:] = []
+
+    b.got_code("1-code")
+    assert events == [("w.got_code", "1-code")]
+    events[:] = []
+
+    b.scared()
+    assert events == [("t.close", "scary")]
+    events[:] = []
+
+    b.closed()
+    assert len(events) == 1, events
+    assert events[0][0] == "w.closed"
+    assert isinstance(events[0][1], errors.WrongPasswordError)
+
+def test_scary_phase():
+    b, events = build_boss()
+    b.set_code("1-code")
+    assert events == [("c.set_code", "1-code")]
+    events[:] = []
+
+    b.got_code("1-code")
+    assert events == [("w.got_code", "1-code")]
+    events[:] = []
+
+    b.happy()  # phase=version
+
+    b.scared()  # phase=0
+    assert events == [("t.close", "scary")]
+    events[:] = []
+
+    b.closed()
+    assert len(events) == 1, events
+    assert events[0][0] == "w.closed"
+    assert isinstance(events[0][1], errors.WrongPasswordError)
+
+
+def test_unknown_phase(observe_errors):
+    b, events = build_boss()
+    b.set_code("1-code")
+    assert events == [("c.set_code", "1-code")]
+    events[:] = []
+
+    b.got_code("1-code")
+    assert events == [("w.got_code", "1-code")]
+    events[:] = []
+
+    b.happy()  # phase=version
+
+    b.got_message("unknown-phase", b"spooky")
+    assert events == []
+    observe_errors.flush(errors._UnknownPhaseError)
+
+
+def test_set_code_bad_format():
+    b, events = build_boss()
+    with pytest.raises(errors.KeyFormatError):
+        b.set_code("1 code")
+    # wormhole should still be usable
+    b.set_code("1-code")
+    assert events == [("c.set_code", "1-code")]
+
+
+def test_set_code_twice():
+    b, events = build_boss()
+    b.set_code("1-code")
+    with pytest.raises(errors.OnlyOneCodeError):
         b.set_code("1-code")
-        self.assertEqual(events, [("c.set_code", "1-code")])
-        events[:] = []
 
-        b.got_code("1-code")
-        self.assertEqual(events, [("w.got_code", "1-code")])
-        events[:] = []
+def test_input_code():
+    b, events = build_boss()
+    b._C.retval = "helper"
+    helper = b.input_code()
+    assert events == [("c.input_code", )]
+    assert helper == "helper"
+    with pytest.raises(errors.OnlyOneCodeError):
+        b.input_code()
 
-        welcome = {"howdy": "how are ya"}
-        b.rx_welcome(welcome)
-        self.assertEqual(events, [
-            ("w.got_welcome", welcome),
-        ])
-        events[:] = []
-
-        # pretend a peer message was correctly decrypted
-        b.got_key(b"key")
-        b.happy()
-        b.got_verifier(b"verifier")
-        b.got_message("version", b"{}")
-        b.got_message("0", b"msg1")
-        self.assertEqual(events, [
-            ("w.got_key", b"key"),
-            ("d.got_key", b"key"),
-            ("w.got_verifier", b"verifier"),
-            ("d.got_wormhole_versions", {}),
-            ("w.got_versions", {}),
-            ("w.received", b"msg1"),
-        ])
-        events[:] = []
-
-        b.send(b"msg2")
-        self.assertEqual(events, [("s.send", "0", b"msg2")])
-        events[:] = []
-
-        b.close()
-        self.assertEqual(events, [("t.close", "happy")])
-        events[:] = []
-
-        b.closed()
-        self.assertEqual(events, [("w.closed", "happy")])
-
-    def test_unwelcome(self):
-        b, events = self.build()
-        unwelcome = {"error": "go away"}
-        b.rx_welcome(unwelcome)
-        self.assertEqual(events, [("t.close", "unwelcome")])
-
-    def test_lonely(self):
-        b, events = self.build()
-        b.set_code("1-code")
-        self.assertEqual(events, [("c.set_code", "1-code")])
-        events[:] = []
-
-        b.got_code("1-code")
-        self.assertEqual(events, [("w.got_code", "1-code")])
-        events[:] = []
-
-        b.close()
-        self.assertEqual(events, [("t.close", "lonely")])
-        events[:] = []
-
-        b.closed()
-        self.assertEqual(len(events), 1, events)
-        self.assertEqual(events[0][0], "w.closed")
-        self.assertIsInstance(events[0][1], errors.LonelyError)
-
-    def test_server_error(self):
-        b, events = self.build()
-        b.set_code("1-code")
-        self.assertEqual(events, [("c.set_code", "1-code")])
-        events[:] = []
-
-        orig = {}
-        b.rx_error("server-error-msg", orig)
-        self.assertEqual(events, [("t.close", "errory")])
-        events[:] = []
-
-        b.closed()
-        self.assertEqual(len(events), 1, events)
-        self.assertEqual(events[0][0], "w.closed")
-        self.assertIsInstance(events[0][1], errors.ServerError)
-        self.assertEqual(events[0][1].args[0], "server-error-msg")
-
-    def test_internal_error(self):
-        b, events = self.build()
-        b.set_code("1-code")
-        self.assertEqual(events, [("c.set_code", "1-code")])
-        events[:] = []
-
-        b.error(ValueError("catch me"))
-        self.assertEqual(len(events), 1, events)
-        self.assertEqual(events[0][0], "w.closed")
-        self.assertIsInstance(events[0][1], ValueError)
-        self.assertEqual(events[0][1].args[0], "catch me")
-
-    def test_close_early(self):
-        b, events = self.build()
-        b.set_code("1-code")
-        self.assertEqual(events, [("c.set_code", "1-code")])
-        events[:] = []
-
-        b.close()  # before even w.got_code
-        self.assertEqual(events, [("t.close", "lonely")])
-        events[:] = []
-
-        b.closed()
-        self.assertEqual(len(events), 1, events)
-        self.assertEqual(events[0][0], "w.closed")
-        self.assertIsInstance(events[0][1], errors.LonelyError)
-
-    def test_error_while_closing(self):
-        b, events = self.build()
-        b.set_code("1-code")
-        self.assertEqual(events, [("c.set_code", "1-code")])
-        events[:] = []
-
-        b.close()
-        self.assertEqual(events, [("t.close", "lonely")])
-        events[:] = []
-
-        b.error(ValueError("oops"))
-        self.assertEqual(len(events), 1, events)
-        self.assertEqual(events[0][0], "w.closed")
-        self.assertIsInstance(events[0][1], ValueError)
-
-    def test_scary_version(self):
-        b, events = self.build()
-        b.set_code("1-code")
-        self.assertEqual(events, [("c.set_code", "1-code")])
-        events[:] = []
-
-        b.got_code("1-code")
-        self.assertEqual(events, [("w.got_code", "1-code")])
-        events[:] = []
-
-        b.scared()
-        self.assertEqual(events, [("t.close", "scary")])
-        events[:] = []
-
-        b.closed()
-        self.assertEqual(len(events), 1, events)
-        self.assertEqual(events[0][0], "w.closed")
-        self.assertIsInstance(events[0][1], errors.WrongPasswordError)
-
-    def test_scary_phase(self):
-        b, events = self.build()
-        b.set_code("1-code")
-        self.assertEqual(events, [("c.set_code", "1-code")])
-        events[:] = []
-
-        b.got_code("1-code")
-        self.assertEqual(events, [("w.got_code", "1-code")])
-        events[:] = []
-
-        b.happy()  # phase=version
-
-        b.scared()  # phase=0
-        self.assertEqual(events, [("t.close", "scary")])
-        events[:] = []
-
-        b.closed()
-        self.assertEqual(len(events), 1, events)
-        self.assertEqual(events[0][0], "w.closed")
-        self.assertIsInstance(events[0][1], errors.WrongPasswordError)
-
-    def test_unknown_phase(self):
-        b, events = self.build()
-        b.set_code("1-code")
-        self.assertEqual(events, [("c.set_code", "1-code")])
-        events[:] = []
-
-        b.got_code("1-code")
-        self.assertEqual(events, [("w.got_code", "1-code")])
-        events[:] = []
-
-        b.happy()  # phase=version
-
-        b.got_message("unknown-phase", b"spooky")
-        self.assertEqual(events, [])
-
-        self.flushLoggedErrors(errors._UnknownPhaseError)
-
-    def test_set_code_bad_format(self):
-        b, events = self.build()
-        with self.assertRaises(errors.KeyFormatError):
-            b.set_code("1 code")
-        # wormhole should still be usable
-        b.set_code("1-code")
-        self.assertEqual(events, [("c.set_code", "1-code")])
-
-    def test_set_code_twice(self):
-        b, events = self.build()
-        b.set_code("1-code")
-        with self.assertRaises(errors.OnlyOneCodeError):
-            b.set_code("1-code")
-
-    def test_input_code(self):
-        b, events = self.build()
-        b._C.retval = "helper"
-        helper = b.input_code()
-        self.assertEqual(events, [("c.input_code", )])
-        self.assertEqual(helper, "helper")
-        with self.assertRaises(errors.OnlyOneCodeError):
-            b.input_code()
-
-    def test_allocate_code(self):
-        b, events = self.build()
-        wl = object()
-        with mock.patch("wormhole._boss.PGPWordList", return_value=wl):
-            b.allocate_code(3)
-        self.assertEqual(events, [("c.allocate_code", 3, wl)])
-        with self.assertRaises(errors.OnlyOneCodeError):
-            b.allocate_code(3)
+def test_allocate_code():
+    b, events = build_boss()
+    wl = object()
+    with mock.patch("wormhole._boss.PGPWordList", return_value=wl):
+        b.allocate_code(3)
+    assert events == [("c.allocate_code", 3, wl)]
+    with pytest.raises(errors.OnlyOneCodeError):
+        b.allocate_code(3)
 
 
-class Rendezvous(unittest.TestCase):
-    def build(self):
-        events = []
-        reactor = object()
-        journal = ImmediateJournal()
-        tor_manager = None
-        client_version = ("python", __version__)
-        rc = _rendezvous.RendezvousConnector(
-            "ws://host:4000/v1", "appid", "side", reactor, journal,
-            tor_manager, timing.DebugTiming(), client_version)
-        b = Dummy("b", events, IBoss, "error")
-        n = Dummy("n", events, INameplate, "connected", "lost")
-        m = Dummy("m", events, IMailbox, "connected", "lost")
-        a = Dummy("a", events, IAllocator, "connected", "lost")
-        x = Dummy("l", events, ILister, "connected", "lost")
-        t = Dummy("t", events, ITerminator)
-        rc.wire(b, n, m, a, x, t)
-        return rc, events
+def build_rendezvous():
+    events = []
+    reactor = object()
+    journal = ImmediateJournal()
+    tor_manager = None
+    client_version = ("python", __version__)
+    rc = _rendezvous.RendezvousConnector(
+        "ws://host:4000/v1", "appid", "side", reactor, journal,
+        tor_manager, timing.DebugTiming(), client_version)
+    b = Dummy("b", events, IBoss, "error")
+    n = Dummy("n", events, INameplate, "connected", "lost")
+    m = Dummy("m", events, IMailbox, "connected", "lost")
+    a = Dummy("a", events, IAllocator, "connected", "lost")
+    x = Dummy("l", events, ILister, "connected", "lost")
+    t = Dummy("t", events, ITerminator)
+    rc.wire(b, n, m, a, x, t)
+    return rc, events
 
-    def test_basic(self):
-        rc, events = self.build()
-        del rc, events
 
-    def test_websocket_failure(self):
-        # if the TCP connection succeeds, but the subsequent WebSocket
-        # negotiation fails, then we'll see an onClose without first seeing
-        # onOpen
-        rc, events = self.build()
-        rc.ws_close(False, 1006, "connection was closed uncleanly")
-        # this should cause the ClientService to be shut down, and an error
-        # delivered to the Boss
-        self.assertEqual(len(events), 1, events)
-        self.assertEqual(events[0][0], "b.error")
-        self.assertIsInstance(events[0][1], errors.ServerConnectionError)
-        self.assertEqual(str(events[0][1]), "connection was closed uncleanly")
+def test_rendezvous_basic():
+    rc, events = build_rendezvous()
+    del rc, events
 
-    def test_websocket_lost(self):
-        # if the TCP connection succeeds, and negotiation completes, then the
-        # connection is lost, several machines should be notified
-        rc, events = self.build()
+def test_websocket_failure():
+    # if the TCP connection succeeds, but the subsequent WebSocket
+    # negotiation fails, then we'll see an onClose without first seeing
+    # onOpen
+    rc, events = build_rendezvous()
+    rc.ws_close(False, 1006, "connection was closed uncleanly")
+    # this should cause the ClientService to be shut down, and an error
+    # delivered to the Boss
+    assert len(events) == 1, events
+    assert events[0][0] == "b.error"
+    assert isinstance(events[0][1], errors.ServerConnectionError)
+    assert str(events[0][1]) == "connection was closed uncleanly"
 
-        ws = mock.Mock()
+def test_websocket_lost():
+    # if the TCP connection succeeds, and negotiation completes, then the
+    # connection is lost, several machines should be notified
+    rc, events = build_rendezvous()
 
-        def notrandom(length):
-            return b"\x00" * length
+    ws = mock.Mock()
 
-        with mock.patch("os.urandom", notrandom):
-            rc.ws_open(ws)
-        self.assertEqual(events, [
-            ("n.connected", ),
-            ("m.connected", ),
-            ("l.connected", ),
-            ("a.connected", ),
-        ])
-        events[:] = []
+    def notrandom(length):
+        return b"\x00" * length
 
-        def sent_messages(ws):
-            for c in ws.mock_calls:
-                self.assertEqual(c[0], "sendMessage", ws.mock_calls)
-                self.assertEqual(c[1][1], False, ws.mock_calls)
-                yield bytes_to_dict(c[1][0])
+    with mock.patch("os.urandom", notrandom):
+        rc.ws_open(ws)
+    assert events == [
+        ("n.connected", ),
+        ("m.connected", ),
+        ("l.connected", ),
+        ("a.connected", ),
+    ]
+    events[:] = []
 
-        self.assertEqual(
-            list(sent_messages(ws)), [
-                dict(
-                    appid="appid",
-                    side="side",
-                    client_version=["python", __version__],
-                    id="0000",
-                    type="bind"),
-            ])
+    def sent_messages(ws):
+        for c in ws.mock_calls:
+            assert c[0] == "sendMessage", ws.mock_calls
+            assert c[1][1] == False, ws.mock_calls
+            yield bytes_to_dict(c[1][0])
 
-        rc.ws_close(True, None, None)
-        self.assertEqual(events, [
-            ("n.lost", ),
-            ("m.lost", ),
-            ("l.lost", ),
-            ("a.lost", ),
-        ])
+    assert list(sent_messages(ws)) == [
+            dict(
+                appid="appid",
+                side="side",
+                client_version=["python", __version__],
+                id="0000",
+                type="bind"),
+        ]
 
-    def test_endpoints(self):
-        # parse different URLs and check the tls status of each
-        reactor = object()
-        journal = ImmediateJournal()
-        tor_manager = None
-        client_version = ("python", __version__)
-        rc = _rendezvous.RendezvousConnector(
-            "ws://host:4000/v1", "appid", "side", reactor, journal,
-            tor_manager, timing.DebugTiming(), client_version)
+    rc.ws_close(True, None, None)
+    assert events == [
+        ("n.lost", ),
+        ("m.lost", ),
+        ("l.lost", ),
+        ("a.lost", ),
+    ]
 
-        new_ep = object()
-        with mock.patch("twisted.internet.endpoints.HostnameEndpoint",
-                        return_value=new_ep) as he:
-            ep = rc._make_endpoint("ws://host:4000/v1")
-        self.assertEqual(he.mock_calls, [mock.call(reactor, "host", 4000)])
-        self.assertIs(ep, new_ep)
+def test_endpoints():
+    # parse different URLs and check the tls status of each
+    reactor = object()
+    journal = ImmediateJournal()
+    tor_manager = None
+    client_version = ("python", __version__)
+    rc = _rendezvous.RendezvousConnector(
+        "ws://host:4000/v1", "appid", "side", reactor, journal,
+        tor_manager, timing.DebugTiming(), client_version)
 
-        new_ep = object()
-        with mock.patch("twisted.internet.endpoints.HostnameEndpoint",
-                        return_value=new_ep) as he:
-            ep = rc._make_endpoint("ws://host/v1")
-        self.assertEqual(he.mock_calls, [mock.call(reactor, "host", 80)])
-        self.assertIs(ep, new_ep)
-
-        new_ep = object()
-        with mock.patch("twisted.internet.endpoints.clientFromString",
-                        return_value=new_ep) as cfs:
-            ep = rc._make_endpoint("wss://host:4000/v1")
-        self.assertEqual(cfs.mock_calls, [mock.call(reactor, "tls:host:4000")])
-        self.assertIs(ep, new_ep)
-
-        new_ep = object()
-        with mock.patch("twisted.internet.endpoints.clientFromString",
-                        return_value=new_ep) as cfs:
-            ep = rc._make_endpoint("wss://host/v1")
-        self.assertEqual(cfs.mock_calls, [mock.call(reactor, "tls:host:443")])
-        self.assertIs(ep, new_ep)
-
-        tor_manager = mock.Mock()
-        directlyProvides(tor_manager, ITorManager)
-        rc = _rendezvous.RendezvousConnector(
-            "ws://host:4000/v1", "appid", "side", reactor, journal,
-            tor_manager, timing.DebugTiming(), client_version)
-
-        tor_manager.mock_calls[:] = []
+    new_ep = object()
+    with mock.patch("twisted.internet.endpoints.HostnameEndpoint",
+                    return_value=new_ep) as he:
         ep = rc._make_endpoint("ws://host:4000/v1")
-        self.assertEqual(tor_manager.mock_calls,
-                         [mock.call.stream_via("host", 4000, tls=False)])
+    assert he.mock_calls == [mock.call(reactor, "host", 4000)]
+    assert ep is new_ep
 
-        tor_manager.mock_calls[:] = []
+    new_ep = object()
+    with mock.patch("twisted.internet.endpoints.HostnameEndpoint",
+                    return_value=new_ep) as he:
         ep = rc._make_endpoint("ws://host/v1")
-        self.assertEqual(tor_manager.mock_calls,
-                         [mock.call.stream_via("host", 80, tls=False)])
+    assert he.mock_calls == [mock.call(reactor, "host", 80)]
+    assert ep is new_ep
 
-        tor_manager.mock_calls[:] = []
+    new_ep = object()
+    with mock.patch("twisted.internet.endpoints.clientFromString",
+                    return_value=new_ep) as cfs:
         ep = rc._make_endpoint("wss://host:4000/v1")
-        self.assertEqual(tor_manager.mock_calls,
-                         [mock.call.stream_via("host", 4000, tls=True)])
+    assert cfs.mock_calls == [mock.call(reactor, "tls:host:4000")]
+    assert ep is new_ep
 
-        tor_manager.mock_calls[:] = []
+    new_ep = object()
+    with mock.patch("twisted.internet.endpoints.clientFromString",
+                    return_value=new_ep) as cfs:
         ep = rc._make_endpoint("wss://host/v1")
-        self.assertEqual(tor_manager.mock_calls,
-                         [mock.call.stream_via("host", 443, tls=True)])
+    assert cfs.mock_calls == [mock.call(reactor, "tls:host:443")]
+    assert ep is new_ep
+
+    tor_manager = mock.Mock()
+    directlyProvides(tor_manager, ITorManager)
+    rc = _rendezvous.RendezvousConnector(
+        "ws://host:4000/v1", "appid", "side", reactor, journal,
+        tor_manager, timing.DebugTiming(), client_version)
+
+    tor_manager.mock_calls[:] = []
+    ep = rc._make_endpoint("ws://host:4000/v1")
+    assert tor_manager.mock_calls == \
+                     [mock.call.stream_via("host", 4000, tls=False)]
+
+    tor_manager.mock_calls[:] = []
+    ep = rc._make_endpoint("ws://host/v1")
+    assert tor_manager.mock_calls == \
+                     [mock.call.stream_via("host", 80, tls=False)]
+
+    tor_manager.mock_calls[:] = []
+    ep = rc._make_endpoint("wss://host:4000/v1")
+    assert tor_manager.mock_calls == \
+                     [mock.call.stream_via("host", 4000, tls=True)]
+
+    tor_manager.mock_calls[:] = []
+    ep = rc._make_endpoint("wss://host/v1")
+    assert tor_manager.mock_calls == \
+                     [mock.call.stream_via("host", 443, tls=True)]
 
 
 # TODO

--- a/src/wormhole/test/test_observer.py
+++ b/src/wormhole/test/test_observer.py
@@ -159,8 +159,8 @@ async def test_set():
     assert not d2.called
     s.discard(2)
     eq.flush_sync()
-    assert await d1 == None
-    assert await d2 == None
+    assert await d1 is None
+    assert await d2 is None
 
     s.add(3)
     s.discard(3)

--- a/src/wormhole/test/test_observer.py
+++ b/src/wormhole/test/test_observer.py
@@ -1,148 +1,166 @@
 from twisted.internet.task import Clock
 from twisted.python.failure import Failure
-from twisted.trial import unittest
+import pytest
+import pytest_twisted
 
 from ..eventual import EventualQueue
 from ..observer import OneShotObserver, SequenceObserver, EmptyableSet
 
 
-class OneShot(unittest.TestCase):
-    def test_fire(self):
-        c = Clock()
-        eq = EventualQueue(c)
-        o = OneShotObserver(eq)
-        res = object()
-        d1 = o.when_fired()
-        eq.flush_sync()
-        self.assertNoResult(d1)
-        o.fire(res)
-        eq.flush_sync()
-        self.assertIdentical(self.successResultOf(d1), res)
-        d2 = o.when_fired()
-        eq.flush_sync()
-        self.assertIdentical(self.successResultOf(d2), res)
-        o.fire_if_not_fired(object())
-        eq.flush_sync()
+@pytest_twisted.ensureDeferred()
+async def test_fire():
+    c = Clock()
+    eq = EventualQueue(c)
+    o = OneShotObserver(eq)
+    res = object()
+    d1 = o.when_fired()
+    eq.flush_sync()
+    assert not d1.called
+    o.fire(res)
+    eq.flush_sync()
+    await d1 is res
+    d2 = o.when_fired()
+    eq.flush_sync()
+    await d2 is res
+    o.fire_if_not_fired(object())
+    eq.flush_sync()
 
-    def test_fire_if_not_fired(self):
-        c = Clock()
-        eq = EventualQueue(c)
-        o = OneShotObserver(eq)
-        res1 = object()
-        res2 = object()
-        d1 = o.when_fired()
-        eq.flush_sync()
-        self.assertNoResult(d1)
-        o.fire_if_not_fired(res1)
-        o.fire_if_not_fired(res2)
-        eq.flush_sync()
-        self.assertIdentical(self.successResultOf(d1), res1)
-
-    def test_error_before_firing(self):
-        c = Clock()
-        eq = EventualQueue(c)
-        o = OneShotObserver(eq)
-        f = Failure(ValueError("oops"))
-        d1 = o.when_fired()
-        eq.flush_sync()
-        self.assertNoResult(d1)
-        o.error(f)
-        eq.flush_sync()
-        self.assertIdentical(self.failureResultOf(d1), f)
-        d2 = o.when_fired()
-        eq.flush_sync()
-        self.assertIdentical(self.failureResultOf(d2), f)
-
-    def test_error_after_firing(self):
-        c = Clock()
-        eq = EventualQueue(c)
-        o = OneShotObserver(eq)
-        res = object()
-        f = Failure(ValueError("oops"))
-
-        o.fire(res)
-        eq.flush_sync()
-        d1 = o.when_fired()
-        o.error(f)
-        d2 = o.when_fired()
-        eq.flush_sync()
-        self.assertIdentical(self.successResultOf(d1), res)
-        self.assertIdentical(self.failureResultOf(d2), f)
+@pytest_twisted.ensureDeferred()
+async def test_fire_if_not_fired():
+    c = Clock()
+    eq = EventualQueue(c)
+    o = OneShotObserver(eq)
+    res1 = object()
+    res2 = object()
+    d1 = o.when_fired()
+    eq.flush_sync()
+    assert not d1.called
+    o.fire_if_not_fired(res1)
+    o.fire_if_not_fired(res2)
+    eq.flush_sync()
+    await d1 is res1
 
 
-class Sequence(unittest.TestCase):
-    def test_fire(self):
-        c = Clock()
-        eq = EventualQueue(c)
-        o = SequenceObserver(eq)
-        d1 = o.when_next_event()
-        eq.flush_sync()
-        self.assertNoResult(d1)
-        d2 = o.when_next_event()
-        eq.flush_sync()
-        self.assertNoResult(d1)
-        self.assertNoResult(d2)
-
-        ev1 = object()
-        ev2 = object()
-        o.fire(ev1)
-        eq.flush_sync()
-        self.assertIdentical(self.successResultOf(d1), ev1)
-        self.assertNoResult(d2)
-
-        o.fire(ev2)
-        eq.flush_sync()
-        self.assertIdentical(self.successResultOf(d2), ev2)
-
-        ev3 = object()
-        ev4 = object()
-        o.fire(ev3)
-        o.fire(ev4)
-
-        d3 = o.when_next_event()
-        eq.flush_sync()
-        self.assertIdentical(self.successResultOf(d3), ev3)
-
-        d4 = o.when_next_event()
-        eq.flush_sync()
-        self.assertIdentical(self.successResultOf(d4), ev4)
-
-    def test_error(self):
-        c = Clock()
-        eq = EventualQueue(c)
-        o = SequenceObserver(eq)
-        d1 = o.when_next_event()
-        eq.flush_sync()
-        self.assertNoResult(d1)
-        f = Failure(ValueError("oops"))
-        o.fire(f)
-        eq.flush_sync()
-        self.assertIdentical(self.failureResultOf(d1), f)
-        d2 = o.when_next_event()
-        eq.flush_sync()
-        self.assertIdentical(self.failureResultOf(d2), f)
+@pytest_twisted.ensureDeferred()
+async def test_error_before_firing():
+    c = Clock()
+    eq = EventualQueue(c)
+    o = OneShotObserver(eq)
+    f = Failure(ValueError("oops"))
+    d1 = o.when_fired()
+    eq.flush_sync()
+    assert not d1.called
+    o.error(f)
+    eq.flush_sync()
+    with pytest.raises(Exception) as ar:
+        await d1
+    assert ar.value is f.value
+    d2 = o.when_fired()
+    eq.flush_sync()
+    with pytest.raises(Exception) as ar:
+        await d2
+    assert ar.value is f.value
 
 
-class Empty(unittest.TestCase):
-    def test_set(self):
-        eq = EventualQueue(Clock())
-        s = EmptyableSet(_eventual_queue=eq)
-        d1 = s.when_next_empty()
-        eq.flush_sync()
-        self.assertNoResult(d1)
-        s.add(1)
-        eq.flush_sync()
-        self.assertNoResult(d1)
-        s.add(2)
-        s.discard(1)
-        d2 = s.when_next_empty()
-        eq.flush_sync()
-        self.assertNoResult(d1)
-        self.assertNoResult(d2)
-        s.discard(2)
-        eq.flush_sync()
-        self.assertEqual(self.successResultOf(d1), None)
-        self.assertEqual(self.successResultOf(d2), None)
+@pytest_twisted.ensureDeferred()
+async def test_error_after_firing():
+    c = Clock()
+    eq = EventualQueue(c)
+    o = OneShotObserver(eq)
+    res = object()
+    f = Failure(ValueError("oops"))
 
-        s.add(3)
-        s.discard(3)
+    o.fire(res)
+    eq.flush_sync()
+    d1 = o.when_fired()
+    o.error(f)
+    d2 = o.when_fired()
+    eq.flush_sync()
+    await d1 is res
+    with pytest.raises(Exception) as ar:
+        await d2
+    assert ar.value is f.value
+
+
+@pytest_twisted.ensureDeferred()
+async def test_fire():
+    c = Clock()
+    eq = EventualQueue(c)
+    o = SequenceObserver(eq)
+    d1 = o.when_next_event()
+    eq.flush_sync()
+    assert not d1.called
+    d2 = o.when_next_event()
+    eq.flush_sync()
+    assert not d1.called
+    assert not d2.called
+
+    ev1 = object()
+    ev2 = object()
+    o.fire(ev1)
+    eq.flush_sync()
+    await d1 is ev1
+    assert not d2.called
+
+    o.fire(ev2)
+    eq.flush_sync()
+    await d2 is ev2
+
+    ev3 = object()
+    ev4 = object()
+    o.fire(ev3)
+    o.fire(ev4)
+
+    d3 = o.when_next_event()
+    eq.flush_sync()
+    await d3 is ev3
+
+    d4 = o.when_next_event()
+    eq.flush_sync()
+    await d4 is ev4
+
+
+@pytest_twisted.ensureDeferred()
+async def test_error():
+    c = Clock()
+    eq = EventualQueue(c)
+    o = SequenceObserver(eq)
+    d1 = o.when_next_event()
+    eq.flush_sync()
+    assert not d1.called
+    f = Failure(ValueError("oops"))
+    o.fire(f)
+    eq.flush_sync()
+    with pytest.raises(Exception) as ar:
+        await d1
+    assert ar.value is f.value
+    d2 = o.when_next_event()
+    eq.flush_sync()
+    with pytest.raises(Exception) as ar:
+        await d2
+    assert ar.value is f.value
+
+
+@pytest_twisted.ensureDeferred()
+async def test_set():
+    eq = EventualQueue(Clock())
+    s = EmptyableSet(_eventual_queue=eq)
+    d1 = s.when_next_empty()
+    eq.flush_sync()
+    assert not d1.called
+    s.add(1)
+    eq.flush_sync()
+    assert not d1.called
+    s.add(2)
+    s.discard(1)
+    d2 = s.when_next_empty()
+    eq.flush_sync()
+    assert not d1.called
+    assert not d2.called
+    s.discard(2)
+    eq.flush_sync()
+    assert await d1 == None
+    assert await d2 == None
+
+    s.add(3)
+    s.discard(3)

--- a/src/wormhole/test/test_observer.py
+++ b/src/wormhole/test/test_observer.py
@@ -83,7 +83,7 @@ async def test_error_after_firing():
 
 
 @pytest_twisted.ensureDeferred()
-async def test_fire():
+async def test_fire_multiple():
     c = Clock()
     eq = EventualQueue(c)
     o = SequenceObserver(eq)

--- a/src/wormhole/test/test_rlcompleter.py
+++ b/src/wormhole/test/test_rlcompleter.py
@@ -2,7 +2,6 @@ from itertools import count
 
 from twisted.internet import reactor
 from twisted.internet.threads import deferToThread
-from twisted.trial import unittest
 
 from unittest import mock
 

--- a/src/wormhole/test/test_rlcompleter.py
+++ b/src/wormhole/test/test_rlcompleter.py
@@ -11,136 +11,135 @@ from pytest_twisted import ensureDeferred
 from .._rlcompleter import (CodeInputter, _input_code_with_completion,
                             input_with_completion, warn_readline)
 from ..errors import AlreadyInputNameplateError, KeyFormatError
+import pytest
 
 APPID = "appid"
 
 
-class Input(unittest.TestCase):
-    @ensureDeferred
-    async def test_wrapper(self):
-        helper = object()
-        trueish = object()
-        with mock.patch(
-                "wormhole._rlcompleter._input_code_with_completion",
-                return_value=trueish) as m:
-            used_completion = await input_with_completion(
-                "prompt:", helper, reactor)
-        self.assertIs(used_completion, trueish)
-        self.assertEqual(m.mock_calls, [mock.call("prompt:", helper, reactor)])
-        # note: if this test fails, the warn_readline() message will probably
-        # get written to stderr
+@ensureDeferred
+async def test_wrapper():
+    helper = object()
+    trueish = object()
+    with mock.patch(
+            "wormhole._rlcompleter._input_code_with_completion",
+            return_value=trueish) as m:
+        used_completion = await input_with_completion(
+            "prompt:", helper, reactor)
+    assert used_completion is trueish
+    assert m.mock_calls == [mock.call("prompt:", helper, reactor)]
+    # note: if this test fails, the warn_readline() message will probably
+    # get written to stderr
 
 
-class Sync(unittest.TestCase):
-    # exercise _input_code_with_completion, which uses the blocking builtin
-    # "input()" function, hence _input_code_with_completion is usually in a
-    # thread with deferToThread
+# exercise _input_code_with_completion, which uses the blocking builtin
+# "input()" function, hence _input_code_with_completion is usually in a
+# thread with deferToThread
 
-    @mock.patch("wormhole._rlcompleter.CodeInputter")
-    @mock.patch("wormhole._rlcompleter.readline", __doc__="I am GNU readline")
-    @mock.patch("wormhole._rlcompleter.input", return_value="code")
-    def test_readline(self, input, readline, ci):
-        c = mock.Mock(name="inhibit parenting")
-        c.completer = object()
-        trueish = object()
-        c.used_completion = trueish
-        ci.configure_mock(return_value=c)
-        prompt = object()
-        input_helper = object()
-        reactor = object()
-        used = _input_code_with_completion(prompt, input_helper, reactor)
-        self.assertIs(used, trueish)
-        self.assertEqual(ci.mock_calls, [mock.call(input_helper, reactor)])
-        self.assertEqual(c.mock_calls, [mock.call.finish("code")])
-        self.assertEqual(input.mock_calls, [mock.call(prompt)])
-        self.assertEqual(readline.mock_calls, [
-            mock.call.parse_and_bind("tab: complete"),
-            mock.call.set_completer(c.completer),
-            mock.call.set_completer_delims(""),
-        ])
+@mock.patch("wormhole._rlcompleter.CodeInputter")
+@mock.patch("wormhole._rlcompleter.readline", __doc__="I am GNU readline")
+@mock.patch("wormhole._rlcompleter.input", return_value="code")
+def test_readline(input, readline, ci):
+    c = mock.Mock(name="inhibit parenting")
+    c.completer = object()
+    trueish = object()
+    c.used_completion = trueish
+    ci.configure_mock(return_value=c)
+    prompt = object()
+    input_helper = object()
+    reactor = object()
+    used = _input_code_with_completion(prompt, input_helper, reactor)
+    assert used is trueish
+    assert ci.mock_calls == [mock.call(input_helper, reactor)]
+    assert c.mock_calls == [mock.call.finish("code")]
+    assert input.mock_calls == [mock.call(prompt)]
+    assert readline.mock_calls == [
+        mock.call.parse_and_bind("tab: complete"),
+        mock.call.set_completer(c.completer),
+        mock.call.set_completer_delims(""),
+    ]
 
-    @mock.patch("wormhole._rlcompleter.CodeInputter")
-    @mock.patch("wormhole._rlcompleter.readline")
-    @mock.patch("wormhole._rlcompleter.input", return_value="code")
-    def test_readline_no_docstring(self, input, readline, ci):
-        del readline.__doc__  # when in doubt, it assumes GNU readline
-        c = mock.Mock(name="inhibit parenting")
-        c.completer = object()
-        trueish = object()
-        c.used_completion = trueish
-        ci.configure_mock(return_value=c)
-        prompt = object()
-        input_helper = object()
-        reactor = object()
-        used = _input_code_with_completion(prompt, input_helper, reactor)
-        self.assertIs(used, trueish)
-        self.assertEqual(ci.mock_calls, [mock.call(input_helper, reactor)])
-        self.assertEqual(c.mock_calls, [mock.call.finish("code")])
-        self.assertEqual(input.mock_calls, [mock.call(prompt)])
-        self.assertEqual(readline.mock_calls, [
-            mock.call.parse_and_bind("tab: complete"),
-            mock.call.set_completer(c.completer),
-            mock.call.set_completer_delims(""),
-        ])
+@mock.patch("wormhole._rlcompleter.CodeInputter")
+@mock.patch("wormhole._rlcompleter.readline")
+@mock.patch("wormhole._rlcompleter.input", return_value="code")
+def test_readline_no_docstring(input, readline, ci):
+    del readline.__doc__  # when in doubt, it assumes GNU readline
+    c = mock.Mock(name="inhibit parenting")
+    c.completer = object()
+    trueish = object()
+    c.used_completion = trueish
+    ci.configure_mock(return_value=c)
+    prompt = object()
+    input_helper = object()
+    reactor = object()
+    used = _input_code_with_completion(prompt, input_helper, reactor)
+    assert used is trueish
+    assert ci.mock_calls == [mock.call(input_helper, reactor)]
+    assert c.mock_calls == [mock.call.finish("code")]
+    assert input.mock_calls == [mock.call(prompt)]
+    assert readline.mock_calls == [
+        mock.call.parse_and_bind("tab: complete"),
+        mock.call.set_completer(c.completer),
+        mock.call.set_completer_delims(""),
+    ]
 
-    @mock.patch("wormhole._rlcompleter.CodeInputter")
-    @mock.patch("wormhole._rlcompleter.readline", __doc__="I am libedit")
-    @mock.patch("wormhole._rlcompleter.input", return_value="code")
-    def test_libedit(self, input, readline, ci):
-        c = mock.Mock(name="inhibit parenting")
-        c.completer = object()
-        trueish = object()
-        c.used_completion = trueish
-        ci.configure_mock(return_value=c)
-        prompt = object()
-        input_helper = object()
-        reactor = object()
-        used = _input_code_with_completion(prompt, input_helper, reactor)
-        self.assertIs(used, trueish)
-        self.assertEqual(ci.mock_calls, [mock.call(input_helper, reactor)])
-        self.assertEqual(c.mock_calls, [mock.call.finish("code")])
-        self.assertEqual(input.mock_calls, [mock.call(prompt)])
-        self.assertEqual(readline.mock_calls, [
-            mock.call.parse_and_bind("bind ^I rl_complete"),
-            mock.call.set_completer(c.completer),
-            mock.call.set_completer_delims(""),
-        ])
+@mock.patch("wormhole._rlcompleter.CodeInputter")
+@mock.patch("wormhole._rlcompleter.readline", __doc__="I am libedit")
+@mock.patch("wormhole._rlcompleter.input", return_value="code")
+def test_libedit(input, readline, ci):
+    c = mock.Mock(name="inhibit parenting")
+    c.completer = object()
+    trueish = object()
+    c.used_completion = trueish
+    ci.configure_mock(return_value=c)
+    prompt = object()
+    input_helper = object()
+    reactor = object()
+    used = _input_code_with_completion(prompt, input_helper, reactor)
+    assert used is trueish
+    assert ci.mock_calls == [mock.call(input_helper, reactor)]
+    assert c.mock_calls == [mock.call.finish("code")]
+    assert input.mock_calls == [mock.call(prompt)]
+    assert readline.mock_calls == [
+        mock.call.parse_and_bind("bind ^I rl_complete"),
+        mock.call.set_completer(c.completer),
+        mock.call.set_completer_delims(""),
+    ]
 
-    @mock.patch("wormhole._rlcompleter.CodeInputter")
-    @mock.patch("wormhole._rlcompleter.readline", None)
-    @mock.patch("wormhole._rlcompleter.input", return_value="code")
-    def test_no_readline(self, input, ci):
-        c = mock.Mock(name="inhibit parenting")
-        c.completer = object()
-        trueish = object()
-        c.used_completion = trueish
-        ci.configure_mock(return_value=c)
-        prompt = object()
-        input_helper = object()
-        reactor = object()
-        used = _input_code_with_completion(prompt, input_helper, reactor)
-        self.assertIs(used, trueish)
-        self.assertEqual(ci.mock_calls, [mock.call(input_helper, reactor)])
-        self.assertEqual(c.mock_calls, [mock.call.finish("code")])
-        self.assertEqual(input.mock_calls, [mock.call(prompt)])
+@mock.patch("wormhole._rlcompleter.CodeInputter")
+@mock.patch("wormhole._rlcompleter.readline", None)
+@mock.patch("wormhole._rlcompleter.input", return_value="code")
+def test_no_readline(input, ci):
+    c = mock.Mock(name="inhibit parenting")
+    c.completer = object()
+    trueish = object()
+    c.used_completion = trueish
+    ci.configure_mock(return_value=c)
+    prompt = object()
+    input_helper = object()
+    reactor = object()
+    used = _input_code_with_completion(prompt, input_helper, reactor)
+    assert used is trueish
+    assert ci.mock_calls == [mock.call(input_helper, reactor)]
+    assert c.mock_calls == [mock.call.finish("code")]
+    assert input.mock_calls == [mock.call(prompt)]
 
-    @mock.patch("wormhole._rlcompleter.CodeInputter")
-    @mock.patch("wormhole._rlcompleter.readline", None)
-    @mock.patch("wormhole._rlcompleter.input", return_value=b"code")
-    def test_bytes(self, input, ci):
-        c = mock.Mock(name="inhibit parenting")
-        c.completer = object()
-        trueish = object()
-        c.used_completion = trueish
-        ci.configure_mock(return_value=c)
-        prompt = object()
-        input_helper = object()
-        reactor = object()
-        used = _input_code_with_completion(prompt, input_helper, reactor)
-        self.assertIs(used, trueish)
-        self.assertEqual(ci.mock_calls, [mock.call(input_helper, reactor)])
-        self.assertEqual(c.mock_calls, [mock.call.finish(u"code")])
-        self.assertEqual(input.mock_calls, [mock.call(prompt)])
+@mock.patch("wormhole._rlcompleter.CodeInputter")
+@mock.patch("wormhole._rlcompleter.readline", None)
+@mock.patch("wormhole._rlcompleter.input", return_value=b"code")
+def test_bytes(input, ci):
+    c = mock.Mock(name="inhibit parenting")
+    c.completer = object()
+    trueish = object()
+    c.used_completion = trueish
+    ci.configure_mock(return_value=c)
+    prompt = object()
+    input_helper = object()
+    reactor = object()
+    used = _input_code_with_completion(prompt, input_helper, reactor)
+    assert used is trueish
+    assert ci.mock_calls == [mock.call(input_helper, reactor)]
+    assert c.mock_calls == [mock.call.finish(u"code")]
+    assert input.mock_calls == [mock.call(prompt)]
 
 
 def get_completions(c, prefix):
@@ -156,228 +155,223 @@ def fake_blockingCallFromThread(f, *a, **kw):
     return f(*a, **kw)
 
 
-class Completion(unittest.TestCase):
-    def test_simple(self):
-        # no actual completion
-        helper = mock.Mock()
-        c = CodeInputter(helper, "reactor")
-        c.bcft = fake_blockingCallFromThread
-        c.finish("1-code-ghost")
-        self.assertFalse(c.used_completion)
-        self.assertEqual(helper.mock_calls, [
-            mock.call.choose_nameplate("1"),
-            mock.call.choose_words("code-ghost")
-        ])
+def test_simple():
+    # no actual completion
+    helper = mock.Mock()
+    c = CodeInputter(helper, "reactor")
+    c.bcft = fake_blockingCallFromThread
+    c.finish("1-code-ghost")
+    assert not c.used_completion
+    assert helper.mock_calls == [
+        mock.call.choose_nameplate("1"),
+        mock.call.choose_words("code-ghost")
+    ]
 
-    @mock.patch(
-        "wormhole._rlcompleter.readline",
-        get_completion_type=mock.Mock(return_value=0))
-    def test_call(self, readline):
-        # check that it calls _commit_and_build_completions correctly
-        helper = mock.Mock()
-        c = CodeInputter(helper, "reactor")
-        c.bcft = fake_blockingCallFromThread
+@mock.patch(
+    "wormhole._rlcompleter.readline",
+    get_completion_type=mock.Mock(return_value=0))
+def test_call(readline):
+    # check that it calls _commit_and_build_completions correctly
+    helper = mock.Mock()
+    c = CodeInputter(helper, "reactor")
+    c.bcft = fake_blockingCallFromThread
 
-        # pretend nameplates: 1, 12, 34
+    # pretend nameplates: 1, 12, 34
 
-        # first call will be with "1"
-        cabc = mock.Mock(return_value=["1", "12"])
-        c._commit_and_build_completions = cabc
+    # first call will be with "1"
+    cabc = mock.Mock(return_value=["1", "12"])
+    c._commit_and_build_completions = cabc
 
-        self.assertEqual(get_completions(c, "1"), ["1", "12"])
-        self.assertEqual(cabc.mock_calls, [mock.call("1")])
+    assert get_completions(c, "1") == ["1", "12"]
+    assert cabc.mock_calls == [mock.call("1")]
 
-        # then "12"
-        cabc.reset_mock()
-        cabc.configure_mock(return_value=["12"])
-        self.assertEqual(get_completions(c, "12"), ["12"])
-        self.assertEqual(cabc.mock_calls, [mock.call("12")])
+    # then "12"
+    cabc.reset_mock()
+    cabc.configure_mock(return_value=["12"])
+    assert get_completions(c, "12") == ["12"]
+    assert cabc.mock_calls == [mock.call("12")]
 
-        # now we have three "a" words: "and", "ark", "aaah!zombies!!"
-        cabc.reset_mock()
-        cabc.configure_mock(return_value=["aargh", "ark", "aaah!zombies!!"])
-        self.assertEqual(
-            get_completions(c, "12-a"), ["aargh", "ark", "aaah!zombies!!"])
-        self.assertEqual(cabc.mock_calls, [mock.call("12-a")])
+    # now we have three "a" words: "and", "ark", "aaah!zombies!!"
+    cabc.reset_mock()
+    cabc.configure_mock(return_value=["aargh", "ark", "aaah!zombies!!"])
+    assert get_completions(c, "12-a") == ["aargh", "ark", "aaah!zombies!!"]
+    assert cabc.mock_calls == [mock.call("12-a")]
 
-        cabc.reset_mock()
-        cabc.configure_mock(return_value=["aargh", "aaah!zombies!!"])
-        self.assertEqual(
-            get_completions(c, "12-aa"), ["aargh", "aaah!zombies!!"])
-        self.assertEqual(cabc.mock_calls, [mock.call("12-aa")])
+    cabc.reset_mock()
+    cabc.configure_mock(return_value=["aargh", "aaah!zombies!!"])
+    assert get_completions(c, "12-aa") == ["aargh", "aaah!zombies!!"]
+    assert cabc.mock_calls == [mock.call("12-aa")]
 
-        cabc.reset_mock()
-        cabc.configure_mock(return_value=["aaah!zombies!!"])
-        self.assertEqual(get_completions(c, "12-aaa"), ["aaah!zombies!!"])
-        self.assertEqual(cabc.mock_calls, [mock.call("12-aaa")])
+    cabc.reset_mock()
+    cabc.configure_mock(return_value=["aaah!zombies!!"])
+    assert get_completions(c, "12-aaa") == ["aaah!zombies!!"]
+    assert cabc.mock_calls == [mock.call("12-aaa")]
 
-        c.finish("1-code")
-        self.assert_(c.used_completion)
+    c.finish("1-code")
+    assert c.used_completion
 
-    def test_wrap_error(self):
-        helper = mock.Mock()
-        c = CodeInputter(helper, "reactor")
-        c._wrapped_completer = mock.Mock(side_effect=ValueError("oops"))
-        with mock.patch("wormhole._rlcompleter.traceback") as traceback:
-            with mock.patch("wormhole._rlcompleter.print") as mock_print:
-                with self.assertRaises(ValueError) as e:
-                    c.completer("text", 0)
-        self.assertEqual(traceback.mock_calls, [mock.call.print_exc()])
-        self.assertEqual(mock_print.mock_calls,
-                         [mock.call("completer exception: oops")])
-        self.assertEqual(str(e.exception), "oops")
+def test_wrap_error():
+    helper = mock.Mock()
+    c = CodeInputter(helper, "reactor")
+    c._wrapped_completer = mock.Mock(side_effect=ValueError("oops"))
+    with mock.patch("wormhole._rlcompleter.traceback") as traceback:
+        with mock.patch("wormhole._rlcompleter.print") as mock_print:
+            with pytest.raises(ValueError) as e:
+                c.completer("text", 0)
+    assert traceback.mock_calls == [mock.call.print_exc()]
+    assert mock_print.mock_calls == \
+                     [mock.call("completer exception: oops")]
+    assert str(e.value) == "oops"
 
-    @ensureDeferred
-    async def test_build_completions(self):
-        rn = mock.Mock()
-        # InputHelper.get_nameplate_completions returns just the suffixes
-        gnc = mock.Mock()  # get_nameplate_completions
-        cn = mock.Mock()  # choose_nameplate
-        gwc = mock.Mock()  # get_word_completions
-        cw = mock.Mock()  # choose_words
-        helper = mock.Mock(
-            refresh_nameplates=rn,
-            get_nameplate_completions=gnc,
-            choose_nameplate=cn,
-            get_word_completions=gwc,
-            choose_words=cw,
-        )
-        # this needs a real reactor, for blockingCallFromThread
-        c = CodeInputter(helper, reactor)
-        cabc = c._commit_and_build_completions
+@ensureDeferred
+async def test_build_completions():
+    rn = mock.Mock()
+    # InputHelper.get_nameplate_completions returns just the suffixes
+    gnc = mock.Mock()  # get_nameplate_completions
+    cn = mock.Mock()  # choose_nameplate
+    gwc = mock.Mock()  # get_word_completions
+    cw = mock.Mock()  # choose_words
+    helper = mock.Mock(
+        refresh_nameplates=rn,
+        get_nameplate_completions=gnc,
+        choose_nameplate=cn,
+        get_word_completions=gwc,
+        choose_words=cw,
+    )
+    # this needs a real reactor, for blockingCallFromThread
+    c = CodeInputter(helper, reactor)
+    cabc = c._commit_and_build_completions
 
-        # in this test, we pretend that nameplates 1,12,34 are active.
+    # in this test, we pretend that nameplates 1,12,34 are active.
 
-        # 43 TAB -> nothing (and refresh_nameplates)
-        gnc.configure_mock(return_value=[])
-        matches = await deferToThread(cabc, "43")
-        self.assertEqual(matches, [])
-        self.assertEqual(rn.mock_calls, [mock.call()])
-        self.assertEqual(gnc.mock_calls, [mock.call("43")])
-        self.assertEqual(cn.mock_calls, [])
-        rn.reset_mock()
-        gnc.reset_mock()
+    # 43 TAB -> nothing (and refresh_nameplates)
+    gnc.configure_mock(return_value=[])
+    matches = await deferToThread(cabc, "43")
+    assert matches == []
+    assert rn.mock_calls == [mock.call()]
+    assert gnc.mock_calls == [mock.call("43")]
+    assert cn.mock_calls == []
+    rn.reset_mock()
+    gnc.reset_mock()
 
-        # 1 TAB -> 1-, 12- (and refresh_nameplates)
-        gnc.configure_mock(return_value=["1-", "12-"])
-        matches = await deferToThread(cabc, "1")
-        self.assertEqual(matches, ["1-", "12-"])
-        self.assertEqual(rn.mock_calls, [mock.call()])
-        self.assertEqual(gnc.mock_calls, [mock.call("1")])
-        self.assertEqual(cn.mock_calls, [])
-        rn.reset_mock()
-        gnc.reset_mock()
+    # 1 TAB -> 1-, 12- (and refresh_nameplates)
+    gnc.configure_mock(return_value=["1-", "12-"])
+    matches = await deferToThread(cabc, "1")
+    assert matches == ["1-", "12-"]
+    assert rn.mock_calls == [mock.call()]
+    assert gnc.mock_calls == [mock.call("1")]
+    assert cn.mock_calls == []
+    rn.reset_mock()
+    gnc.reset_mock()
 
-        # 12 TAB -> 12- (and refresh_nameplates)
-        # I wouldn't mind if it didn't refresh the nameplates here, but meh
-        gnc.configure_mock(return_value=["12-"])
-        matches = await deferToThread(cabc, "12")
-        self.assertEqual(matches, ["12-"])
-        self.assertEqual(rn.mock_calls, [mock.call()])
-        self.assertEqual(gnc.mock_calls, [mock.call("12")])
-        self.assertEqual(cn.mock_calls, [])
-        rn.reset_mock()
-        gnc.reset_mock()
+    # 12 TAB -> 12- (and refresh_nameplates)
+    # I wouldn't mind if it didn't refresh the nameplates here, but meh
+    gnc.configure_mock(return_value=["12-"])
+    matches = await deferToThread(cabc, "12")
+    assert matches == ["12-"]
+    assert rn.mock_calls == [mock.call()]
+    assert gnc.mock_calls == [mock.call("12")]
+    assert cn.mock_calls == []
+    rn.reset_mock()
+    gnc.reset_mock()
 
-        # 12- TAB -> 12- {all words} (claim, no refresh)
-        gnc.configure_mock(return_value=["12-"])
-        gwc.configure_mock(return_value=["and-", "ark-", "aaah!zombies!!-"])
-        matches = await deferToThread(cabc, "12-")
-        self.assertEqual(matches, ["12-aaah!zombies!!-", "12-and-", "12-ark-"])
-        self.assertEqual(rn.mock_calls, [])
-        self.assertEqual(gnc.mock_calls, [])
-        self.assertEqual(cn.mock_calls, [mock.call("12")])
-        self.assertEqual(gwc.mock_calls, [mock.call("")])
-        cn.reset_mock()
-        gwc.reset_mock()
+    # 12- TAB -> 12- {all words} (claim, no refresh)
+    gnc.configure_mock(return_value=["12-"])
+    gwc.configure_mock(return_value=["and-", "ark-", "aaah!zombies!!-"])
+    matches = await deferToThread(cabc, "12-")
+    assert matches == ["12-aaah!zombies!!-", "12-and-", "12-ark-"]
+    assert rn.mock_calls == []
+    assert gnc.mock_calls == []
+    assert cn.mock_calls == [mock.call("12")]
+    assert gwc.mock_calls == [mock.call("")]
+    cn.reset_mock()
+    gwc.reset_mock()
 
-        # TODO: another path with "3 TAB" then "34-an TAB", so the claim
-        # happens in the second call (and it waits for the wordlist)
+    # TODO: another path with "3 TAB" then "34-an TAB", so the claim
+    # happens in the second call (and it waits for the wordlist)
 
-        # 12-a TAB -> 12-and- 12-ark- 12-aaah!zombies!!-
-        gnc.configure_mock(side_effect=ValueError)
-        gwc.configure_mock(return_value=["and-", "ark-", "aaah!zombies!!-"])
-        matches = await deferToThread(cabc, "12-a")
-        # matches are always sorted
-        self.assertEqual(matches, ["12-aaah!zombies!!-", "12-and-", "12-ark-"])
-        self.assertEqual(rn.mock_calls, [])
-        self.assertEqual(gnc.mock_calls, [])
-        self.assertEqual(cn.mock_calls, [])
-        self.assertEqual(gwc.mock_calls, [mock.call("a")])
-        gwc.reset_mock()
+    # 12-a TAB -> 12-and- 12-ark- 12-aaah!zombies!!-
+    gnc.configure_mock(side_effect=ValueError)
+    gwc.configure_mock(return_value=["and-", "ark-", "aaah!zombies!!-"])
+    matches = await deferToThread(cabc, "12-a")
+    # matches are always sorted
+    assert matches == ["12-aaah!zombies!!-", "12-and-", "12-ark-"]
+    assert rn.mock_calls == []
+    assert gnc.mock_calls == []
+    assert cn.mock_calls == []
+    assert gwc.mock_calls == [mock.call("a")]
+    gwc.reset_mock()
 
-        # 12-and-b TAB -> 12-and-bat 12-and-bet 12-and-but
-        gnc.configure_mock(side_effect=ValueError)
-        # wordlist knows the code length, so doesn't add hyphens to these
-        gwc.configure_mock(return_value=["and-bat", "and-bet", "and-but"])
-        matches = await deferToThread(cabc, "12-and-b")
-        self.assertEqual(matches, ["12-and-bat", "12-and-bet", "12-and-but"])
-        self.assertEqual(rn.mock_calls, [])
-        self.assertEqual(gnc.mock_calls, [])
-        self.assertEqual(cn.mock_calls, [])
-        self.assertEqual(gwc.mock_calls, [mock.call("and-b")])
-        gwc.reset_mock()
+    # 12-and-b TAB -> 12-and-bat 12-and-bet 12-and-but
+    gnc.configure_mock(side_effect=ValueError)
+    # wordlist knows the code length, so doesn't add hyphens to these
+    gwc.configure_mock(return_value=["and-bat", "and-bet", "and-but"])
+    matches = await deferToThread(cabc, "12-and-b")
+    assert matches == ["12-and-bat", "12-and-bet", "12-and-but"]
+    assert rn.mock_calls == []
+    assert gnc.mock_calls == []
+    assert cn.mock_calls == []
+    assert gwc.mock_calls == [mock.call("and-b")]
+    gwc.reset_mock()
 
-        await deferToThread(c.finish, "12-and-bat")
-        self.assertEqual(cw.mock_calls, [mock.call("and-bat")])
+    await deferToThread(c.finish, "12-and-bat")
+    assert cw.mock_calls == [mock.call("and-bat")]
 
-    def test_incomplete_code(self):
-        helper = mock.Mock()
-        c = CodeInputter(helper, "reactor")
-        c.bcft = fake_blockingCallFromThread
-        with self.assertRaises(KeyFormatError) as e:
-            c.finish("1")
-        self.assertEqual(str(e.exception), "incomplete wormhole code")
+def test_incomplete_code():
+    helper = mock.Mock()
+    c = CodeInputter(helper, "reactor")
+    c.bcft = fake_blockingCallFromThread
+    with pytest.raises(KeyFormatError) as e:
+        c.finish("1")
+    assert str(e.value) == "incomplete wormhole code"
 
-    @ensureDeferred
-    async def test_rollback_nameplate_during_completion(self):
-        helper = mock.Mock()
-        gwc = helper.get_word_completions = mock.Mock()
-        gwc.configure_mock(return_value=["code", "court"])
-        c = CodeInputter(helper, reactor)
-        cabc = c._commit_and_build_completions
-        matches = await deferToThread(cabc, "1-co")  # this commits us to 1-
-        self.assertEqual(helper.mock_calls, [
-            mock.call.choose_nameplate("1"),
-            mock.call.when_wordlist_is_available(),
-            mock.call.get_word_completions("co")
-        ])
-        self.assertEqual(matches, ["1-code", "1-court"])
-        helper.reset_mock()
-        with self.assertRaises(AlreadyInputNameplateError) as e:
-            await deferToThread(cabc, "2-co")
-        self.assertEqual(
-            str(e.exception), "nameplate (1-) already entered, cannot go back")
-        self.assertEqual(helper.mock_calls, [])
+@ensureDeferred
+async def test_rollback_nameplate_during_completion():
+    helper = mock.Mock()
+    gwc = helper.get_word_completions = mock.Mock()
+    gwc.configure_mock(return_value=["code", "court"])
+    c = CodeInputter(helper, reactor)
+    cabc = c._commit_and_build_completions
+    matches = await deferToThread(cabc, "1-co")  # this commits us to 1-
+    assert helper.mock_calls == [
+        mock.call.choose_nameplate("1"),
+        mock.call.when_wordlist_is_available(),
+        mock.call.get_word_completions("co")
+    ]
+    assert matches == ["1-code", "1-court"]
+    helper.reset_mock()
+    with pytest.raises(AlreadyInputNameplateError) as e:
+        await deferToThread(cabc, "2-co")
+    assert str(e.value) == "nameplate (1-) already entered, cannot go back"
+    assert helper.mock_calls == []
 
-    @ensureDeferred
-    async def test_rollback_nameplate_during_finish(self):
-        helper = mock.Mock()
-        gwc = helper.get_word_completions = mock.Mock()
-        gwc.configure_mock(return_value=["code", "court"])
-        c = CodeInputter(helper, reactor)
-        cabc = c._commit_and_build_completions
-        matches = await deferToThread(cabc, "1-co")  # this commits us to 1-
-        self.assertEqual(helper.mock_calls, [
-            mock.call.choose_nameplate("1"),
-            mock.call.when_wordlist_is_available(),
-            mock.call.get_word_completions("co")
-        ])
-        self.assertEqual(matches, ["1-code", "1-court"])
-        helper.reset_mock()
-        with self.assertRaises(AlreadyInputNameplateError) as e:
-            await deferToThread(c.finish, "2-code")
-        self.assertEqual(
-            str(e.exception), "nameplate (1-) already entered, cannot go back")
-        self.assertEqual(helper.mock_calls, [])
+@ensureDeferred
+async def test_rollback_nameplate_during_finish():
+    helper = mock.Mock()
+    gwc = helper.get_word_completions = mock.Mock()
+    gwc.configure_mock(return_value=["code", "court"])
+    c = CodeInputter(helper, reactor)
+    cabc = c._commit_and_build_completions
+    matches = await deferToThread(cabc, "1-co")  # this commits us to 1-
+    assert helper.mock_calls == [
+        mock.call.choose_nameplate("1"),
+        mock.call.when_wordlist_is_available(),
+        mock.call.get_word_completions("co")
+    ]
+    assert matches == ["1-code", "1-court"]
+    helper.reset_mock()
+    with pytest.raises(AlreadyInputNameplateError) as e:
+        await deferToThread(c.finish, "2-code")
+    assert str(e.value) == "nameplate (1-) already entered, cannot go back"
+    assert helper.mock_calls == []
 
-    @mock.patch("wormhole._rlcompleter.stderr")
-    def test_warn_readline(self, stderr):
-        # there is no good way to test that this function gets used at the
-        # right time, since it involves a reactor and a "system event
-        # trigger", but let's at least make sure it's invocable
-        warn_readline()
-        expected = "\nCommand interrupted: please press Return to quit"
-        self.assertEqual(stderr.mock_calls,
-                         [mock.call.write(expected),
-                          mock.call.write("\n")])
+@mock.patch("wormhole._rlcompleter.stderr")
+def test_warn_readline(stderr):
+    # there is no good way to test that this function gets used at the
+    # right time, since it involves a reactor and a "system event
+    # trigger", but let's at least make sure it's invocable
+    warn_readline()
+    expected = "\nCommand interrupted: please press Return to quit"
+    assert stderr.mock_calls == \
+                     [mock.call.write(expected),
+                      mock.call.write("\n")]

--- a/src/wormhole/test/test_ssh.py
+++ b/src/wormhole/test/test_ssh.py
@@ -1,83 +1,79 @@
 import io
 import os
 
-from twisted.trial import unittest
-
 from unittest import mock
 
 from ..cli import cmd_ssh
+import pytest
 
 OTHERS = ["config", "config~", "known_hosts", "known_hosts~"]
 
 
-class FindPubkey(unittest.TestCase):
-    def test_find_one(self):
-        files = OTHERS + ["id_rsa.pub", "id_rsa"]
-        pubkey_data = u"ssh-rsa AAAAkeystuff email@host\n"
-        pubkey_file = io.StringIO(pubkey_data)
-        with mock.patch("wormhole.cli.cmd_ssh.exists", return_value=True):
-            with mock.patch("os.listdir", return_value=files) as ld:
+def test_find_one():
+    files = OTHERS + ["id_rsa.pub", "id_rsa"]
+    pubkey_data = u"ssh-rsa AAAAkeystuff email@host\n"
+    pubkey_file = io.StringIO(pubkey_data)
+    with mock.patch("wormhole.cli.cmd_ssh.exists", return_value=True):
+        with mock.patch("os.listdir", return_value=files) as ld:
+            with mock.patch(
+                    "wormhole.cli.cmd_ssh.open", return_value=pubkey_file):
+                res = cmd_ssh.find_public_key()
+    assert ld.mock_calls == \
+                     [mock.call(os.path.expanduser("~/.ssh/"))]
+    assert len(res) == 3, res
+    kind, keyid, pubkey = res
+    assert kind == "ssh-rsa"
+    assert keyid == "email@host"
+    assert pubkey == pubkey_data
+
+def test_find_none():
+    files = OTHERS  # no pubkey
+    with mock.patch("wormhole.cli.cmd_ssh.exists", return_value=True):
+        with mock.patch("os.listdir", return_value=files):
+            with pytest.raises(cmd_ssh.PubkeyError) as f:
+                cmd_ssh.find_public_key()
+    dot_ssh = os.path.expanduser("~/.ssh/")
+    assert str(f.value) == "No public keys in '{}'".format(dot_ssh)
+
+def test_bad_hint():
+    with mock.patch("wormhole.cli.cmd_ssh.exists", return_value=False):
+        with pytest.raises(cmd_ssh.PubkeyError) as f:
+            cmd_ssh.find_public_key(hint="bogus/path")
+    assert str(f.value) == "Can't find 'bogus/path'"
+
+def test_find_multiple():
+    files = OTHERS + ["id_rsa.pub", "id_rsa", "id_dsa.pub", "id_dsa"]
+    pubkey_data = u"ssh-rsa AAAAkeystuff email@host\n"
+    pubkey_file = io.StringIO(pubkey_data)
+    with mock.patch("wormhole.cli.cmd_ssh.exists", return_value=True):
+        with mock.patch("os.listdir", return_value=files):
+            responses = iter(["frog", "NaN", "-1", "0"])
+            with mock.patch(
+                    "click.prompt", side_effect=lambda p: next(responses)):
                 with mock.patch(
-                        "wormhole.cli.cmd_ssh.open", return_value=pubkey_file):
+                        "wormhole.cli.cmd_ssh.open",
+                        return_value=pubkey_file):
                     res = cmd_ssh.find_public_key()
-        self.assertEqual(ld.mock_calls,
-                         [mock.call(os.path.expanduser("~/.ssh/"))])
-        self.assertEqual(len(res), 3, res)
-        kind, keyid, pubkey = res
-        self.assertEqual(kind, "ssh-rsa")
-        self.assertEqual(keyid, "email@host")
-        self.assertEqual(pubkey, pubkey_data)
+    assert len(res) == 3, res
+    kind, keyid, pubkey = res
+    assert kind == "ssh-rsa"
+    assert keyid == "email@host"
+    assert pubkey == pubkey_data
 
-    def test_find_none(self):
-        files = OTHERS  # no pubkey
-        with mock.patch("wormhole.cli.cmd_ssh.exists", return_value=True):
-            with mock.patch("os.listdir", return_value=files):
-                e = self.assertRaises(cmd_ssh.PubkeyError,
-                                      cmd_ssh.find_public_key)
-        dot_ssh = os.path.expanduser("~/.ssh/")
-        self.assertEqual(str(e), "No public keys in '{}'".format(dot_ssh))
+def test_comment_with_spaces():
+    files = OTHERS + ["id_ed25519.pub", "id_ed25519"]
+    pubkey_data = u"ssh-ed25519 AAAAkeystuff comment with spaces"
+    pubkey_file = io.StringIO(pubkey_data)
 
-    def test_bad_hint(self):
-        with mock.patch("wormhole.cli.cmd_ssh.exists", return_value=False):
-            e = self.assertRaises(
-                cmd_ssh.PubkeyError,
-                cmd_ssh.find_public_key,
-                hint="bogus/path")
-        self.assertEqual(str(e), "Can't find 'bogus/path'")
-
-    def test_find_multiple(self):
-        files = OTHERS + ["id_rsa.pub", "id_rsa", "id_dsa.pub", "id_dsa"]
-        pubkey_data = u"ssh-rsa AAAAkeystuff email@host\n"
-        pubkey_file = io.StringIO(pubkey_data)
-        with mock.patch("wormhole.cli.cmd_ssh.exists", return_value=True):
-            with mock.patch("os.listdir", return_value=files):
-                responses = iter(["frog", "NaN", "-1", "0"])
-                with mock.patch(
-                        "click.prompt", side_effect=lambda p: next(responses)):
-                    with mock.patch(
-                            "wormhole.cli.cmd_ssh.open",
-                            return_value=pubkey_file):
-                        res = cmd_ssh.find_public_key()
-        self.assertEqual(len(res), 3, res)
-        kind, keyid, pubkey = res
-        self.assertEqual(kind, "ssh-rsa")
-        self.assertEqual(keyid, "email@host")
-        self.assertEqual(pubkey, pubkey_data)
-
-    def test_comment_with_spaces(self):
-        files = OTHERS + ["id_ed25519.pub", "id_ed25519"]
-        pubkey_data = u"ssh-ed25519 AAAAkeystuff comment with spaces"
-        pubkey_file = io.StringIO(pubkey_data)
-
-        with mock.patch("wormhole.cli.cmd_ssh.exists", return_value=True):
-            with mock.patch("os.listdir", return_value=files) as ld:
-                with mock.patch(
-                        "wormhole.cli.cmd_ssh.open", return_value=pubkey_file):
-                    res = cmd_ssh.find_public_key()
-        self.assertEqual(ld.mock_calls,
-                         [mock.call(os.path.expanduser("~/.ssh/"))])
-        self.assertEqual(len(res), 3, res)
-        kind, keyid, pubkey = res
-        self.assertEqual(kind, "ssh-ed25519")
-        self.assertEqual(keyid, "comment with spaces")
-        self.assertEqual(pubkey, pubkey_data)
+    with mock.patch("wormhole.cli.cmd_ssh.exists", return_value=True):
+        with mock.patch("os.listdir", return_value=files) as ld:
+            with mock.patch(
+                    "wormhole.cli.cmd_ssh.open", return_value=pubkey_file):
+                res = cmd_ssh.find_public_key()
+    assert ld.mock_calls == \
+                     [mock.call(os.path.expanduser("~/.ssh/"))]
+    assert len(res) == 3, res
+    kind, keyid, pubkey = res
+    assert kind == "ssh-ed25519"
+    assert keyid == "comment with spaces"
+    assert pubkey == pubkey_data

--- a/src/wormhole/test/test_tor_manager.py
+++ b/src/wormhole/test/test_tor_manager.py
@@ -2,9 +2,10 @@ import io
 
 from twisted.internet import defer
 from twisted.internet.error import ConnectError
-from twisted.trial import unittest
 
 from unittest import mock
+import pytest
+import pytest_twisted
 
 from .._interfaces import ITorManager
 from ..errors import NoTorError
@@ -15,153 +16,161 @@ class X():
     pass
 
 
-class Tor(unittest.TestCase):
-    def test_no_txtorcon(self):
-        with mock.patch("wormhole.tor_manager.txtorcon", None):
-            self.failureResultOf(get_tor(None), NoTorError)
+@pytest_twisted.ensureDeferred
+async def test_no_txtorcon():
+    with mock.patch("wormhole.tor_manager.txtorcon", None):
+        with pytest.raises(NoTorError):
+            await get_tor(None)
 
-    def test_bad_args(self):
-        f = self.failureResultOf(
-            get_tor(None, launch_tor="not boolean"), TypeError)
-        self.assertEqual(str(f.value), "launch_tor= must be boolean")
 
-        f = self.failureResultOf(
-            get_tor(None, tor_control_port=1234), TypeError)
-        self.assertEqual(str(f.value), "tor_control_port= must be str or None")
-        f = self.failureResultOf(
-            get_tor(
-                None, launch_tor=True, tor_control_port="tcp:127.0.0.1:1234"),
-            ValueError)
-        self.assertEqual(
-            str(f.value),
-            "cannot combine --launch-tor and --tor-control-port=")
+@pytest_twisted.ensureDeferred
+async def test_bad_args():
+    with pytest.raises(TypeError) as f:
+        await get_tor(None, launch_tor="not boolean")
+    assert str(f.value) == "launch_tor= must be boolean"
 
-    def test_launch(self):
-        reactor = object()
-        my_tor = X()  # object() didn't like providedBy()
-        launch_d = defer.Deferred()
-        stderr = io.StringIO()
+    with pytest.raises(TypeError) as f:
+        await get_tor(None, tor_control_port=1234)
+    assert str(f.value) == "tor_control_port= must be str or None"
+
+    with pytest.raises(ValueError) as f:
+        await get_tor(None, launch_tor=True, tor_control_port="tcp:127.0.0.1:1234")
+    assert str(f.value) == "cannot combine --launch-tor and --tor-control-port="
+
+
+@pytest_twisted.ensureDeferred
+async def test_launch():
+    reactor = object()
+    my_tor = X()  # object() didn't like providedBy()
+    launch_d = defer.Deferred()
+    stderr = io.StringIO()
+    with mock.patch(
+            "wormhole.tor_manager.txtorcon.launch",
+            side_effect=launch_d) as launch:
+        d = get_tor(reactor, launch_tor=True, stderr=stderr)
+        assert not d.called
+        assert launch.mock_calls == [mock.call(reactor)]
+        launch_d.callback(my_tor)
+        tor = await d
+        assert tor is my_tor
+        assert ITorManager.providedBy(tor)
+        assert stderr.getvalue() == \
+            " launching a new Tor process, this may take a while..\n"
+
+
+@pytest_twisted.ensureDeferred
+async def test_connect():
+    reactor = object()
+    my_tor = X()  # object() didn't like providedBy()
+    connect_d = defer.Deferred()
+    stderr = io.StringIO()
+    with mock.patch(
+            "wormhole.tor_manager.txtorcon.connect",
+            side_effect=connect_d) as connect:
         with mock.patch(
-                "wormhole.tor_manager.txtorcon.launch",
-                side_effect=launch_d) as launch:
-            d = get_tor(reactor, launch_tor=True, stderr=stderr)
-            self.assertNoResult(d)
-            self.assertEqual(launch.mock_calls, [mock.call(reactor)])
-            launch_d.callback(my_tor)
-            tor = self.successResultOf(d)
-            self.assertIs(tor, my_tor)
-            self.assert_(ITorManager.providedBy(tor))
-            self.assertEqual(
-                stderr.getvalue(),
-                " launching a new Tor process, this may take a while..\n")
+                "wormhole.tor_manager.clientFromString",
+                side_effect=["foo"]) as sfs:
+            d = get_tor(reactor, stderr=stderr)
+    assert sfs.mock_calls == []
+    assert not d.called
+    assert connect.mock_calls == [mock.call(reactor)]
+    connect_d.callback(my_tor)
+    tor = await d
+    assert tor is my_tor
+    assert ITorManager.providedBy(tor)
+    assert stderr.getvalue() == \
+                     " using Tor via default control port\n"
 
-    def test_connect(self):
-        reactor = object()
-        my_tor = X()  # object() didn't like providedBy()
-        connect_d = defer.Deferred()
-        stderr = io.StringIO()
+
+@pytest_twisted.ensureDeferred
+async def test_connect_fails():
+    reactor = object()
+    connect_d = defer.Deferred()
+    stderr = io.StringIO()
+    with mock.patch(
+            "wormhole.tor_manager.txtorcon.connect",
+            side_effect=connect_d) as connect:
         with mock.patch(
-                "wormhole.tor_manager.txtorcon.connect",
-                side_effect=connect_d) as connect:
-            with mock.patch(
-                    "wormhole.tor_manager.clientFromString",
-                    side_effect=["foo"]) as sfs:
-                d = get_tor(reactor, stderr=stderr)
-        self.assertEqual(sfs.mock_calls, [])
-        self.assertNoResult(d)
-        self.assertEqual(connect.mock_calls, [mock.call(reactor)])
-        connect_d.callback(my_tor)
-        tor = self.successResultOf(d)
-        self.assertIs(tor, my_tor)
-        self.assert_(ITorManager.providedBy(tor))
-        self.assertEqual(stderr.getvalue(),
-                         " using Tor via default control port\n")
+                "wormhole.tor_manager.clientFromString",
+                side_effect=["foo"]) as sfs:
+            d = get_tor(reactor, stderr=stderr)
+    assert sfs.mock_calls == []
+    assert not d.called
+    assert connect.mock_calls == [mock.call(reactor)]
 
-    def test_connect_fails(self):
-        reactor = object()
-        connect_d = defer.Deferred()
-        stderr = io.StringIO()
+    connect_d.errback(ConnectError())
+    tor = await d
+    assert isinstance(tor, SocksOnlyTor)
+    assert ITorManager.providedBy(tor)
+    assert tor._reactor == reactor
+    assert stderr.getvalue() == \
+        " unable to find default Tor control port, using SOCKS\n"
+
+
+@pytest_twisted.ensureDeferred
+async def test_connect_custom_control_port():
+    reactor = object()
+    my_tor = X()  # object() didn't like providedBy()
+    tcp = "PORT"
+    ep = object()
+    connect_d = defer.Deferred()
+    stderr = io.StringIO()
+    with mock.patch(
+            "wormhole.tor_manager.txtorcon.connect",
+            side_effect=connect_d) as connect:
         with mock.patch(
-                "wormhole.tor_manager.txtorcon.connect",
-                side_effect=connect_d) as connect:
-            with mock.patch(
-                    "wormhole.tor_manager.clientFromString",
-                    side_effect=["foo"]) as sfs:
-                d = get_tor(reactor, stderr=stderr)
-        self.assertEqual(sfs.mock_calls, [])
-        self.assertNoResult(d)
-        self.assertEqual(connect.mock_calls, [mock.call(reactor)])
+                "wormhole.tor_manager.clientFromString",
+                side_effect=[ep]) as sfs:
+            d = get_tor(reactor, tor_control_port=tcp, stderr=stderr)
+    assert sfs.mock_calls == [mock.call(reactor, tcp)]
+    assert not d.called
+    assert connect.mock_calls == [mock.call(reactor, ep)]
+    connect_d.callback(my_tor)
+    tor = await d
+    assert tor is my_tor
+    assert ITorManager.providedBy(tor)
+    assert stderr.getvalue() == \
+                     " using Tor via control port at PORT\n"
 
-        connect_d.errback(ConnectError())
-        tor = self.successResultOf(d)
-        self.assertIsInstance(tor, SocksOnlyTor)
-        self.assert_(ITorManager.providedBy(tor))
-        self.assertEqual(tor._reactor, reactor)
-        self.assertEqual(
-            stderr.getvalue(),
-            " unable to find default Tor control port, using SOCKS\n")
 
-    def test_connect_custom_control_port(self):
-        reactor = object()
-        my_tor = X()  # object() didn't like providedBy()
-        tcp = "PORT"
-        ep = object()
-        connect_d = defer.Deferred()
-        stderr = io.StringIO()
+@pytest_twisted.ensureDeferred
+async def test_connect_custom_control_port_fails():
+    reactor = object()
+    tcp = "port"
+    ep = object()
+    connect_d = defer.Deferred()
+    stderr = io.StringIO()
+    with mock.patch(
+            "wormhole.tor_manager.txtorcon.connect",
+            side_effect=connect_d) as connect:
         with mock.patch(
-                "wormhole.tor_manager.txtorcon.connect",
-                side_effect=connect_d) as connect:
-            with mock.patch(
-                    "wormhole.tor_manager.clientFromString",
-                    side_effect=[ep]) as sfs:
-                d = get_tor(reactor, tor_control_port=tcp, stderr=stderr)
-        self.assertEqual(sfs.mock_calls, [mock.call(reactor, tcp)])
-        self.assertNoResult(d)
-        self.assertEqual(connect.mock_calls, [mock.call(reactor, ep)])
-        connect_d.callback(my_tor)
-        tor = self.successResultOf(d)
-        self.assertIs(tor, my_tor)
-        self.assert_(ITorManager.providedBy(tor))
-        self.assertEqual(stderr.getvalue(),
-                         " using Tor via control port at PORT\n")
+                "wormhole.tor_manager.clientFromString",
+                side_effect=[ep]) as sfs:
+            d = get_tor(reactor, tor_control_port=tcp, stderr=stderr)
+    assert sfs.mock_calls == [mock.call(reactor, tcp)]
+    assert not d.called
+    assert connect.mock_calls == [mock.call(reactor, ep)]
 
-    def test_connect_custom_control_port_fails(self):
-        reactor = object()
-        tcp = "port"
-        ep = object()
-        connect_d = defer.Deferred()
-        stderr = io.StringIO()
-        with mock.patch(
-                "wormhole.tor_manager.txtorcon.connect",
-                side_effect=connect_d) as connect:
-            with mock.patch(
-                    "wormhole.tor_manager.clientFromString",
-                    side_effect=[ep]) as sfs:
-                d = get_tor(reactor, tor_control_port=tcp, stderr=stderr)
-        self.assertEqual(sfs.mock_calls, [mock.call(reactor, tcp)])
-        self.assertNoResult(d)
-        self.assertEqual(connect.mock_calls, [mock.call(reactor, ep)])
-
-        connect_d.errback(ConnectError())
-        self.failureResultOf(d, ConnectError)
-        self.assertEqual(stderr.getvalue(), "")
+    connect_d.errback(ConnectError())
+    with pytest.raises(ConnectError):
+        await d
+    assert stderr.getvalue() == ""
 
 
-class SocksOnly(unittest.TestCase):
-    def test_tor(self):
-        reactor = object()
-        sot = SocksOnlyTor(reactor)
-        fake_ep = object()
-        with mock.patch(
-                "wormhole.tor_manager.txtorcon.TorClientEndpoint",
-                return_value=fake_ep) as tce:
-            ep = sot.stream_via("host", "port")
-        self.assertIs(ep, fake_ep)
-        self.assertEqual(tce.mock_calls, [
-            mock.call(
-                "host",
-                "port",
-                socks_endpoint=None,
-                tls=False,
-                reactor=reactor)
-        ])
+def test_tor():
+    reactor = object()
+    sot = SocksOnlyTor(reactor)
+    fake_ep = object()
+    with mock.patch(
+            "wormhole.tor_manager.txtorcon.TorClientEndpoint",
+            return_value=fake_ep) as tce:
+        ep = sot.stream_via("host", "port")
+    assert ep is fake_ep
+    assert tce.mock_calls == [
+        mock.call(
+            "host",
+            "port",
+            socks_endpoint=None,
+            tls=False,
+            reactor=reactor)
+    ]

--- a/src/wormhole/test/test_transit.py
+++ b/src/wormhole/test/test_transit.py
@@ -15,7 +15,6 @@ from .. import transit
 from .._hints import DirectTCPV1Hint
 from ..errors import InternalError
 from ..util import HKDF
-from .common import ServerBase
 import pytest
 
 

--- a/src/wormhole/test/test_transit.py
+++ b/src/wormhole/test/test_transit.py
@@ -446,7 +446,7 @@ async def test_success():
     p = f.buildProtocol(addr)
     assert isinstance(p, MockConnection)
     assert p.owner == "owner"
-    assert p.relay_handshake == None
+    assert p.relay_handshake is None
     assert p._start_negotiation_called == False
     # meh .start
 
@@ -1143,7 +1143,7 @@ def test_producer():
     assert c.transport.producerState == "producing"
 
     c.disconnectConsumer()
-    assert consumer.producer == None
+    assert consumer.producer is None
     c.connectConsumer(consumer)
 
     c.stopProducing()
@@ -1274,7 +1274,7 @@ def test_consumer():
     assert records == [b"r1."]
 
     c.unregisterProducer()
-    assert c.transport.producer == None
+    assert c.transport.producer is None
 
 
 def test_basic():

--- a/src/wormhole/test/test_transit.py
+++ b/src/wormhole/test/test_transit.py
@@ -6,7 +6,6 @@ from nacl.secret import SecretBox
 from twisted.internet import address, defer, endpoints, error, protocol, task
 from twisted.internet.defer import gatherResults
 from twisted.test import proto_helpers
-from twisted.trial import unittest
 
 from unittest import mock
 from wormhole_transit_relay import transit_server
@@ -17,298 +16,330 @@ from .._hints import DirectTCPV1Hint
 from ..errors import InternalError
 from ..util import HKDF
 from .common import ServerBase
+import pytest
 
 
-class Highlander(unittest.TestCase):
-    def test_one_winner(self):
-        cancelled = set()
-        contenders = [
-            defer.Deferred(lambda d, i=i: cancelled.add(i)) for i in range(5)
-        ]
-        d = transit.there_can_be_only_one(contenders)
-        self.assertNoResult(d)
-        contenders[0].errback(ValueError())
-        self.assertNoResult(d)
-        contenders[1].errback(TypeError())
-        self.assertNoResult(d)
-        contenders[2].callback("yay")
-        self.assertEqual(self.successResultOf(d), "yay")
-        self.assertEqual(cancelled, set([3, 4]))
-
-    def test_there_might_also_be_none(self):
-        cancelled = set()
-        contenders = [
-            defer.Deferred(lambda d, i=i: cancelled.add(i)) for i in range(4)
-        ]
-        d = transit.there_can_be_only_one(contenders)
-        self.assertNoResult(d)
-        contenders[0].errback(ValueError())
-        self.assertNoResult(d)
-        contenders[1].errback(TypeError())
-        self.assertNoResult(d)
-        contenders[2].errback(TypeError())
-        self.assertNoResult(d)
-        contenders[3].errback(NameError())
-        self.failureResultOf(d, ValueError)  # first failure is recorded
-        self.assertEqual(cancelled, set())
-
-    def test_cancel_early(self):
-        cancelled = set()
-        contenders = [
-            defer.Deferred(lambda d, i=i: cancelled.add(i)) for i in range(4)
-        ]
-        d = transit.there_can_be_only_one(contenders)
-        self.assertNoResult(d)
-        self.assertEqual(cancelled, set())
-        d.cancel()
-        self.failureResultOf(d, defer.CancelledError)
-        self.assertEqual(cancelled, set(range(4)))
-
-    def test_cancel_after_one_failure(self):
-        cancelled = set()
-        contenders = [
-            defer.Deferred(lambda d, i=i: cancelled.add(i)) for i in range(4)
-        ]
-        d = transit.there_can_be_only_one(contenders)
-        self.assertNoResult(d)
-        self.assertEqual(cancelled, set())
-        contenders[0].errback(ValueError())
-        d.cancel()
-        self.failureResultOf(d, ValueError)
-        self.assertEqual(cancelled, set([1, 2, 3]))
+@ensureDeferred
+async def test_one_winner():
+    cancelled = set()
+    contenders = [
+        defer.Deferred(lambda d, i=i: cancelled.add(i)) for i in range(5)
+    ]
+    d = transit.there_can_be_only_one(contenders)
+    assert not d.called
+    contenders[0].errback(ValueError())
+    assert not d.called
+    contenders[1].errback(TypeError())
+    assert not d.called
+    contenders[2].callback("yay")
+    assert await d == "yay"
+    assert cancelled == set([3, 4])
 
 
-class Forever(unittest.TestCase):
-    def _forever_setup(self):
-        clock = task.Clock()
-        c = transit.Common("", reactor=clock)
-        cancelled = []
-        d0 = defer.Deferred(cancelled.append)
-        d = c._not_forever(1.0, d0)
-        return c, clock, d0, d, cancelled
-
-    def test_not_forever_fires(self):
-        c, clock, d0, d, cancelled = self._forever_setup()
-        self.assertNoResult(d)
-        self.assertEqual(cancelled, [])
-        d.callback(1)
-        self.assertEqual(self.successResultOf(d), 1)
-        self.assertEqual(cancelled, [])
-        self.assertNot(clock.getDelayedCalls())
-
-    def test_not_forever_errs(self):
-        c, clock, d0, d, cancelled = self._forever_setup()
-        self.assertNoResult(d)
-        self.assertEqual(cancelled, [])
-        d.errback(ValueError())
-        self.assertEqual(cancelled, [])
-        self.failureResultOf(d, ValueError)
-        self.assertNot(clock.getDelayedCalls())
-
-    def test_not_forever_cancel_early(self):
-        c, clock, d0, d, cancelled = self._forever_setup()
-        self.assertNoResult(d)
-        self.assertEqual(cancelled, [])
-        d.cancel()
-        self.assertEqual(cancelled, [d0])
-        self.failureResultOf(d, defer.CancelledError)
-        self.assertNot(clock.getDelayedCalls())
-
-    def test_not_forever_timeout(self):
-        c, clock, d0, d, cancelled = self._forever_setup()
-        self.assertNoResult(d)
-        self.assertEqual(cancelled, [])
-        clock.advance(2.0)
-        self.assertEqual(cancelled, [d0])
-        self.failureResultOf(d, defer.CancelledError)
-        self.assertNot(clock.getDelayedCalls())
+@ensureDeferred
+async def test_there_might_also_be_none():
+    cancelled = set()
+    contenders = [
+        defer.Deferred(lambda d, i=i: cancelled.add(i)) for i in range(4)
+    ]
+    d = transit.there_can_be_only_one(contenders)
+    assert not d.called
+    contenders[0].errback(ValueError())
+    assert not d.called
+    contenders[1].errback(TypeError())
+    assert not d.called
+    contenders[2].errback(TypeError())
+    assert not d.called
+    contenders[3].errback(NameError())
+    with pytest.raises(ValueError):
+        await d  # first failure is recorded
+    assert cancelled == set()
 
 
-class Misc(unittest.TestCase):
-    def test_allocate_port(self):
+@ensureDeferred
+async def test_cancel_early():
+    cancelled = set()
+    contenders = [
+        defer.Deferred(lambda d, i=i: cancelled.add(i)) for i in range(4)
+    ]
+    d = transit.there_can_be_only_one(contenders)
+    assert not d.called
+    assert cancelled == set()
+    d.cancel()
+    with pytest.raises(defer.CancelledError):
+        await d
+    assert cancelled == set(range(4))
+
+
+@ensureDeferred
+async def test_cancel_after_one_failure():
+    cancelled = set()
+    contenders = [
+        defer.Deferred(lambda d, i=i: cancelled.add(i)) for i in range(4)
+    ]
+    d = transit.there_can_be_only_one(contenders)
+    assert not d.called
+    assert cancelled == set()
+    contenders[0].errback(ValueError())
+    d.cancel()
+    with pytest.raises(ValueError):
+        await d
+    assert cancelled == set([1, 2, 3])
+
+
+@pytest.fixture()
+def forever():
+    clock = task.Clock()
+    c = transit.Common("", reactor=clock)
+    cancelled = []
+    d0 = defer.Deferred(cancelled.append)
+    d = c._not_forever(1.0, d0)
+    yield c, clock, d0, d, cancelled
+
+
+@ensureDeferred
+async def test_not_forever_fires(forever):
+    c, clock, d0, d, cancelled = forever
+    assert not d.called
+    assert cancelled == []
+    d.callback(1)
+    answer = await d
+    assert answer == 1
+    assert cancelled == []
+    assert not clock.getDelayedCalls()
+
+
+@ensureDeferred
+async def test_not_forever_errs(forever):
+    c, clock, d0, d, cancelled = forever
+    assert not d.called
+    assert cancelled == []
+    d.errback(ValueError())
+    assert cancelled == []
+    with pytest.raises(ValueError):
+        await d
+    assert not clock.getDelayedCalls()
+
+
+@ensureDeferred
+async def test_not_forever_cancel_early(forever):
+    c, clock, d0, d, cancelled = forever
+    assert not d.called
+    assert cancelled == []
+    d.cancel()
+    assert cancelled == [d0]
+    with pytest.raises(defer.CancelledError):
+        await d
+    assert not clock.getDelayedCalls()
+
+
+@ensureDeferred
+async def test_not_forever_timeout(forever):
+    c, clock, d0, d, cancelled = forever
+    assert not d.called
+    assert cancelled == []
+    clock.advance(2.0)
+    assert cancelled == [d0]
+    with pytest.raises(defer.CancelledError):
+        await d
+    assert not clock.getDelayedCalls()
+
+
+def test_allocate_port():
+    portno = transit.allocate_tcp_port()
+    assert isinstance(portno, int)
+
+
+def test_allocate_port_no_reuseaddr():
+    mock_sys = mock.Mock()
+    mock_sys.platform = "cygwin"
+    with mock.patch("wormhole.transit.sys", mock_sys):
         portno = transit.allocate_tcp_port()
-        self.assertIsInstance(portno, int)
-
-    def test_allocate_port_no_reuseaddr(self):
-        mock_sys = mock.Mock()
-        mock_sys.platform = "cygwin"
-        with mock.patch("wormhole.transit.sys", mock_sys):
-            portno = transit.allocate_tcp_port()
-        self.assertIsInstance(portno, int)
+    assert isinstance(portno, int)
 
 
 LOOPADDR = "127.0.0.1"
 OTHERADDR = "1.2.3.4"
 
 
-class Basic(unittest.TestCase):
-    @ensureDeferred
-    async def test_relay_hints(self):
-        URL = "tcp:host:1234"
-        c = transit.Common(URL, no_listen=True)
+@ensureDeferred
+async def test_relay_hints():
+    URL = "tcp:host:1234"
+    c = transit.Common(URL, no_listen=True)
+    hints = await c.get_connection_hints()
+    assert hints == [{
+        "type":
+        "relay-v1",
+        "hints": [{
+            "type": "direct-tcp-v1",
+            "hostname": "host",
+            "port": 1234,
+            "priority": 0.0
+        }],
+    }]
+    with pytest.raises(InternalError):
+        transit.Common(123)
+
+
+@ensureDeferred
+async def test_no_relay_hints():
+    c = transit.Common(None, no_listen=True)
+    hints = await c.get_connection_hints()
+    assert hints == []
+
+
+def test_ignore_bad_hints():
+    c = transit.Common("")
+    c.add_connection_hints([{"type": "unknown"}])
+    c.add_connection_hints([{
+        "type": "relay-v1",
+        "hints": [{
+            "type": "unknown"
+        }]
+    }])
+    assert c._their_direct_hints == []
+    assert c._our_relay_hints == set()
+
+
+@ensureDeferred
+async def test_ignore_localhost_hint_orig():
+    # this actually starts the listener
+    c = transit.TransitSender("")
+    hints = await c.get_connection_hints()
+    c._stop_listening()
+    # If there are non-localhost hints, then localhost hints should be
+    # removed. But if the only hint is localhost, it should stay.
+    if len(hints) == 1:
+        if hints[0]["hostname"] == "127.0.0.1":
+            return
+    for hint in hints:
+        assert not (hint["hostname"] == "127.0.0.1")
+
+
+@ensureDeferred
+async def test_ignore_localhost_hint():
+    # this actually starts the listener
+    c = transit.TransitSender("")
+    with mock.patch(
+            "wormhole.ipaddrs.find_addresses",
+            return_value=[LOOPADDR, OTHERADDR]):
         hints = await c.get_connection_hints()
-        self.assertEqual(hints, [{
-            "type":
-            "relay-v1",
-            "hints": [{
-                "type": "direct-tcp-v1",
-                "hostname": "host",
-                "port": 1234,
-                "priority": 0.0
-            }],
-        }])
-        self.assertRaises(InternalError, transit.Common, 123)
+    c._stop_listening()
+    # If there are non-localhost hints, then localhost hints should be
+    # removed.
+    assert len(hints) == 1
+    assert hints[0]["hostname"] == "1.2.3.4"
 
-    @ensureDeferred
-    async def test_no_relay_hints(self):
-        c = transit.Common(None, no_listen=True)
+
+@ensureDeferred
+async def test_keep_only_localhost_hint():
+    # this actually starts the listener
+    c = transit.TransitSender("")
+    with mock.patch(
+            "wormhole.ipaddrs.find_addresses", return_value=[LOOPADDR]):
         hints = await c.get_connection_hints()
-        self.assertEqual(hints, [])
-
-    def test_ignore_bad_hints(self):
-        c = transit.Common("")
-        c.add_connection_hints([{"type": "unknown"}])
-        c.add_connection_hints([{
-            "type": "relay-v1",
-            "hints": [{
-                "type": "unknown"
-            }]
-        }])
-        self.assertEqual(c._their_direct_hints, [])
-        self.assertEqual(c._our_relay_hints, set())
-
-    def test_ignore_localhost_hint_orig(self):
-        # this actually starts the listener
-        c = transit.TransitSender("")
-        hints = self.successResultOf(c.get_connection_hints())
-        c._stop_listening()
-        # If there are non-localhost hints, then localhost hints should be
-        # removed. But if the only hint is localhost, it should stay.
-        if len(hints) == 1:
-            if hints[0]["hostname"] == "127.0.0.1":
-                return
-        for hint in hints:
-            self.assertFalse(hint["hostname"] == "127.0.0.1")
-
-    def test_ignore_localhost_hint(self):
-        # this actually starts the listener
-        c = transit.TransitSender("")
-        with mock.patch(
-                "wormhole.ipaddrs.find_addresses",
-                return_value=[LOOPADDR, OTHERADDR]):
-            hints = self.successResultOf(c.get_connection_hints())
-        c._stop_listening()
-        # If there are non-localhost hints, then localhost hints should be
-        # removed.
-        self.assertEqual(len(hints), 1)
-        self.assertEqual(hints[0]["hostname"], "1.2.3.4")
-
-    def test_keep_only_localhost_hint(self):
-        # this actually starts the listener
-        c = transit.TransitSender("")
-        with mock.patch(
-                "wormhole.ipaddrs.find_addresses", return_value=[LOOPADDR]):
-            hints = self.successResultOf(c.get_connection_hints())
-        c._stop_listening()
-        # If the only hint is localhost, it should stay.
-        self.assertEqual(len(hints), 1)
-        self.assertEqual(hints[0]["hostname"], "127.0.0.1")
-
-    def test_abilities(self):
-        c = transit.Common(None, no_listen=True)
-        abilities = c.get_connection_abilities()
-        self.assertEqual(abilities, [
-            {
-                "type": "direct-tcp-v1"
-            },
-            {
-                "type": "relay-v1"
-            },
-        ])
-
-    def test_transit_key_wait(self):
-        KEY = b"123"
-        c = transit.Common("")
-        d = c._get_transit_key()
-        self.assertNoResult(d)
-        c.set_transit_key(KEY)
-        self.assertEqual(self.successResultOf(d), KEY)
-
-    def test_transit_key_already_set(self):
-        KEY = b"123"
-        c = transit.Common("")
-        c.set_transit_key(KEY)
-        d = c._get_transit_key()
-        self.assertEqual(self.successResultOf(d), KEY)
-
-    def test_transit_keys(self):
-        KEY = b"123"
-        s = transit.TransitSender("")
-        s.set_transit_key(KEY)
-        r = transit.TransitReceiver("")
-        r.set_transit_key(KEY)
-
-        self.assertEqual(s._send_this(), (
-            b"transit sender "
-            b"559bdeae4b49fa6a23378d2b68f4c7e69378615d4af049c371c6a26e82391089"
-            b" ready\n\n"))
-        self.assertEqual(s._send_this(), r._expect_this())
-
-        self.assertEqual(r._send_this(), (
-            b"transit receiver "
-            b"ed447528194bac4c00d0c854b12a97ce51413d89aa74d6304475f516fdc23a1b"
-            b" ready\n\n"))
-        self.assertEqual(r._send_this(), s._expect_this())
-
-        self.assertEqual(
-            hexlify(s._sender_record_key()),
-            b"5a2fba3a9e524ab2e2823ff53b05f946896f6e4ce4e282ffd8e3ac0e5e9e0cda"
-        )
-        self.assertEqual(
-            hexlify(s._sender_record_key()), hexlify(r._receiver_record_key()))
-
-        self.assertEqual(
-            hexlify(r._sender_record_key()),
-            b"eedb143117249f45b39da324decf6bd9aae33b7ccd58487436de611a3c6b871d"
-        )
-        self.assertEqual(
-            hexlify(r._sender_record_key()), hexlify(s._receiver_record_key()))
-
-    def test_connection_ready(self):
-        s = transit.TransitSender("")
-        self.assertEqual(s.connection_ready("p1"), "go")
-        self.assertEqual(s._winner, "p1")
-        self.assertEqual(s.connection_ready("p2"), "nevermind")
-        self.assertEqual(s._winner, "p1")
-
-        r = transit.TransitReceiver("")
-        self.assertEqual(r.connection_ready("p1"), "wait-for-decision")
-        self.assertEqual(r.connection_ready("p2"), "wait-for-decision")
+    c._stop_listening()
+    # If the only hint is localhost, it should stay.
+    assert len(hints) == 1
+    assert hints[0]["hostname"] == "127.0.0.1"
 
 
-class Listener(unittest.TestCase):
-    def test_listener(self):
-        c = transit.Common("")
-        hints, ep = c._build_listener()
-        self.assertIsInstance(hints, (list, set))
-        if hints:
-            self.assertIsInstance(hints[0], DirectTCPV1Hint)
-        self.assertIsInstance(ep, endpoints.TCP4ServerEndpoint)
+def test_abilities():
+    c = transit.Common(None, no_listen=True)
+    abilities = c.get_connection_abilities()
+    assert abilities == [
+        {
+            "type": "direct-tcp-v1"
+        },
+        {
+            "type": "relay-v1"
+        },
+    ]
 
-    def test_get_direct_hints(self):
-        # this actually starts the listener
-        c = transit.TransitSender("")
 
-        d = c.get_connection_hints()
-        hints = self.successResultOf(d)
+@ensureDeferred
+async def test_transit_key_wait():
+    KEY = b"123"
+    c = transit.Common("")
+    d = c._get_transit_key()
+    assert not d.called
+    c.set_transit_key(KEY)
+    assert await d == KEY
 
-        # the hints are supposed to be cached, so calling this twice won't
-        # start a second listener
-        self.assert_(c._listener)
-        d2 = c.get_connection_hints()
-        self.assertEqual(self.successResultOf(d2), hints)
 
-        c._stop_listening()
+@ensureDeferred
+async def test_transit_key_already_set():
+    KEY = b"123"
+    c = transit.Common("")
+    c.set_transit_key(KEY)
+    d = c._get_transit_key()
+    assert await d == KEY
+
+
+async def test_transit_keys():
+    KEY = b"123"
+    s = transit.TransitSender("")
+    s.set_transit_key(KEY)
+    r = transit.TransitReceiver("")
+    r.set_transit_key(KEY)
+
+    assert s._send_this() == (
+        b"transit sender "
+        b"559bdeae4b49fa6a23378d2b68f4c7e69378615d4af049c371c6a26e82391089"
+        b" ready\n\n")
+    assert s._send_this() == r._expect_this()
+
+    assert r._send_this() == (
+        b"transit receiver "
+        b"ed447528194bac4c00d0c854b12a97ce51413d89aa74d6304475f516fdc23a1b"
+        b" ready\n\n")
+    assert r._send_this() == s._expect_this()
+
+    assert hexlify(s._sender_record_key()) == \
+        b"5a2fba3a9e524ab2e2823ff53b05f946896f6e4ce4e282ffd8e3ac0e5e9e0cda"
+    assert hexlify(s._sender_record_key()) == hexlify(r._receiver_record_key())
+
+    assert hexlify(r._sender_record_key()) == \
+        b"eedb143117249f45b39da324decf6bd9aae33b7ccd58487436de611a3c6b871d"
+    assert hexlify(r._sender_record_key()) == hexlify(s._receiver_record_key())
+
+
+def test_connection_ready():
+    s = transit.TransitSender("")
+    assert s.connection_ready("p1") == "go"
+    assert s._winner == "p1"
+    assert s.connection_ready("p2") == "nevermind"
+    assert s._winner == "p1"
+
+    r = transit.TransitReceiver("")
+    assert r.connection_ready("p1") == "wait-for-decision"
+    assert r.connection_ready("p2") == "wait-for-decision"
+
+
+def test_listener():
+    c = transit.Common("")
+    hints, ep = c._build_listener()
+    assert isinstance(hints, (list, set))
+    if hints:
+        assert isinstance(hints[0], DirectTCPV1Hint)
+    assert isinstance(ep, endpoints.TCP4ServerEndpoint)
+
+
+
+@ensureDeferred
+async def test_get_direct_hints():
+    # this actually starts the listener
+    c = transit.TransitSender("")
+
+    hints = await c.get_connection_hints()
+
+    # the hints are supposed to be cached, so calling this twice won't
+    # start a second listener
+    assert c._listener
+    d2 = c.get_connection_hints()
+    assert await d2 == hints
+
+    c._stop_listening()
 
 
 class DummyProtocol(protocol.Protocol):
@@ -393,124 +424,127 @@ class MockConnection:
         return self._d
 
 
-class InboundConnectionFactory(unittest.TestCase):
-    def test_describe(self):
-        f = transit.InboundConnectionFactory(None)
-        addrH = address.HostnameAddress("example.com", 1234)
-        self.assertEqual(f._describePeer(addrH), "<-example.com:1234")
-        addr4 = address.IPv4Address("TCP", "1.2.3.4", 1234)
-        self.assertEqual(f._describePeer(addr4), "<-1.2.3.4:1234")
-        addr6 = address.IPv6Address("TCP", "::1", 1234)
-        self.assertEqual(f._describePeer(addr6), "<-::1:1234")
-        addrU = address.UNIXAddress("/dev/unlikely")
-        self.assertEqual(
-            f._describePeer(addrU), "<-UNIXAddress('/dev/unlikely')")
-
-    def test_success(self):
-        f = transit.InboundConnectionFactory("owner")
-        f.protocol = MockConnection
-        d = f.whenDone()
-        self.assertNoResult(d)
-
-        addr = address.HostnameAddress("example.com", 1234)
-        p = f.buildProtocol(addr)
-        self.assertIsInstance(p, MockConnection)
-        self.assertEqual(p.owner, "owner")
-        self.assertEqual(p.relay_handshake, None)
-        self.assertEqual(p._start_negotiation_called, False)
-        # meh .start
-
-        # this is normally called from Connection.connectionMade
-        f.connectionWasMade(p)
-        self.assertEqual(p._start_negotiation_called, True)
-        self.assertNoResult(d)
-        self.assertEqual(p._description, "<-example.com:1234")
-
-        p._d.callback(p)
-        self.assertEqual(self.successResultOf(d), p)
-
-    def test_one_fail_one_success(self):
-        f = transit.InboundConnectionFactory("owner")
-        f.protocol = MockConnection
-        d = f.whenDone()
-        self.assertNoResult(d)
-
-        addr1 = address.HostnameAddress("example.com", 1234)
-        addr2 = address.HostnameAddress("example.com", 5678)
-        p1 = f.buildProtocol(addr1)
-        p2 = f.buildProtocol(addr2)
-
-        f.connectionWasMade(p1)
-        f.connectionWasMade(p2)
-        self.assertNoResult(d)
-
-        p1._d.errback(transit.BadHandshake("nope"))
-        self.assertNoResult(d)
-        p2._d.callback(p2)
-        self.assertEqual(self.successResultOf(d), p2)
-
-    def test_first_success_wins(self):
-        f = transit.InboundConnectionFactory("owner")
-        f.protocol = MockConnection
-        d = f.whenDone()
-        self.assertNoResult(d)
-
-        addr1 = address.HostnameAddress("example.com", 1234)
-        addr2 = address.HostnameAddress("example.com", 5678)
-        p1 = f.buildProtocol(addr1)
-        p2 = f.buildProtocol(addr2)
-
-        f.connectionWasMade(p1)
-        f.connectionWasMade(p2)
-        self.assertNoResult(d)
-
-        p1._d.callback(p1)
-        self.assertEqual(self.successResultOf(d), p1)
-        self.assertEqual(p1._cancelled, False)
-        self.assertEqual(p2._cancelled, True)
-
-    def test_cancel(self):
-        f = transit.InboundConnectionFactory("owner")
-        f.protocol = MockConnection
-        d = f.whenDone()
-        self.assertNoResult(d)
-
-        addr1 = address.HostnameAddress("example.com", 1234)
-        addr2 = address.HostnameAddress("example.com", 5678)
-        p1 = f.buildProtocol(addr1)
-        p2 = f.buildProtocol(addr2)
-
-        f.connectionWasMade(p1)
-        f.connectionWasMade(p2)
-        self.assertNoResult(d)
-
-        d.cancel()
-
-        self.failureResultOf(d, defer.CancelledError)
-        self.assertEqual(p1._cancelled, True)
-        self.assertEqual(p2._cancelled, True)
+def test_describe():
+    f = transit.InboundConnectionFactory(None)
+    addrH = address.HostnameAddress("example.com", 1234)
+    assert f._describePeer(addrH) == "<-example.com:1234"
+    addr4 = address.IPv4Address("TCP", "1.2.3.4", 1234)
+    assert f._describePeer(addr4) == "<-1.2.3.4:1234"
+    addr6 = address.IPv6Address("TCP", "::1", 1234)
+    assert f._describePeer(addr6) == "<-::1:1234"
+    addrU = address.UNIXAddress("/dev/unlikely")
+    assert f._describePeer(addrU) == "<-UNIXAddress('/dev/unlikely')"
 
 
-# XXX check descriptions
+@ensureDeferred
+async def test_success():
+    f = transit.InboundConnectionFactory("owner")
+    f.protocol = MockConnection
+    d = f.whenDone()
+    assert not d.called
+
+    addr = address.HostnameAddress("example.com", 1234)
+    p = f.buildProtocol(addr)
+    assert isinstance(p, MockConnection)
+    assert p.owner == "owner"
+    assert p.relay_handshake == None
+    assert p._start_negotiation_called == False
+    # meh .start
+
+    # this is normally called from Connection.connectionMade
+    f.connectionWasMade(p)
+    assert p._start_negotiation_called == True
+    assert not d.called
+    assert p._description == "<-example.com:1234"
+
+    p._d.callback(p)
+    assert await d == p
 
 
-class OutboundConnectionFactory(unittest.TestCase):
-    def test_success(self):
-        f = transit.OutboundConnectionFactory("owner", "relay_handshake",
-                                              "description")
-        f.protocol = MockConnection
+@ensureDeferred
+async def test_one_fail_one_success():
+    f = transit.InboundConnectionFactory("owner")
+    f.protocol = MockConnection
+    d = f.whenDone()
+    assert not d.called
 
-        addr = address.HostnameAddress("example.com", 1234)
-        p = f.buildProtocol(addr)
-        self.assertIsInstance(p, MockConnection)
-        self.assertEqual(p.owner, "owner")
-        self.assertEqual(p.relay_handshake, "relay_handshake")
-        self.assertEqual(p._start_negotiation_called, False)
-        # meh .start
+    addr1 = address.HostnameAddress("example.com", 1234)
+    addr2 = address.HostnameAddress("example.com", 5678)
+    p1 = f.buildProtocol(addr1)
+    p2 = f.buildProtocol(addr2)
 
-        # this is normally called from Connection.connectionMade
-        f.connectionWasMade(p)  # no-op for outbound
-        self.assertEqual(p._start_negotiation_called, False)
+    f.connectionWasMade(p1)
+    f.connectionWasMade(p2)
+    assert not d.called
+
+    p1._d.errback(transit.BadHandshake("nope"))
+    assert not d.called
+    p2._d.callback(p2)
+    assert await d == p2
+
+
+@ensureDeferred
+async def test_first_success_wins():
+    f = transit.InboundConnectionFactory("owner")
+    f.protocol = MockConnection
+    d = f.whenDone()
+    assert not d.called
+
+    addr1 = address.HostnameAddress("example.com", 1234)
+    addr2 = address.HostnameAddress("example.com", 5678)
+    p1 = f.buildProtocol(addr1)
+    p2 = f.buildProtocol(addr2)
+
+    f.connectionWasMade(p1)
+    f.connectionWasMade(p2)
+    assert not d.called
+
+    p1._d.callback(p1)
+    assert await d == p1
+    assert p1._cancelled == False
+    assert p2._cancelled == True
+
+
+@ensureDeferred
+async def test_cancel():
+    f = transit.InboundConnectionFactory("owner")
+    f.protocol = MockConnection
+    d = f.whenDone()
+    assert not d.called
+
+    addr1 = address.HostnameAddress("example.com", 1234)
+    addr2 = address.HostnameAddress("example.com", 5678)
+    p1 = f.buildProtocol(addr1)
+    p2 = f.buildProtocol(addr2)
+
+    f.connectionWasMade(p1)
+    f.connectionWasMade(p2)
+    assert not d.called
+
+    d.cancel()
+
+    with pytest.raises(defer.CancelledError):
+        await d
+    assert p1._cancelled == True
+    assert p2._cancelled == True
+
+
+def test_success():
+    f = transit.OutboundConnectionFactory("owner", "relay_handshake",
+                                          "description")
+    f.protocol = MockConnection
+
+    addr = address.HostnameAddress("example.com", 1234)
+    p = f.buildProtocol(addr)
+    assert isinstance(p, MockConnection)
+    assert p.owner == "owner"
+    assert p.relay_handshake == "relay_handshake"
+    assert p._start_negotiation_called == False
+    # meh .start
+
+    # this is normally called from Connection.connectionMade
+    f.connectionWasMade(p)  # no-op for outbound
+    assert p._start_negotiation_called == False
 
 
 class MockOwner:
@@ -542,683 +576,738 @@ class MockFactory:
         self._p = p
 
 
-class Connection(unittest.TestCase):
-    # exercise the Connection protocol class
+def test_check_and_remove():
+    c = transit.Connection(None, None, None, "description")
+    c.buf = b""
+    EXP = b"expectation"
+    assert not c._check_and_remove(EXP)
+    assert c.buf == b""
 
-    def test_check_and_remove(self):
-        c = transit.Connection(None, None, None, "description")
-        c.buf = b""
-        EXP = b"expectation"
-        self.assertFalse(c._check_and_remove(EXP))
-        self.assertEqual(c.buf, b"")
+    c.buf = b"unexpected"
+    with pytest.raises(transit.BadHandshake) as f:
+        c._check_and_remove(EXP)
+    assert str(f.value) == "got %r want %r" % (b'unexpected', b'expectation')
+    assert c.buf == b"unexpected"
 
-        c.buf = b"unexpected"
-        e = self.assertRaises(transit.BadHandshake, c._check_and_remove, EXP)
-        self.assertEqual(
-            str(e), "got %r want %r" % (b'unexpected', b'expectation'))
-        self.assertEqual(c.buf, b"unexpected")
+    c.buf = b"expect"
+    assert not c._check_and_remove(EXP)
+    assert c.buf == b"expect"
 
-        c.buf = b"expect"
-        self.assertFalse(c._check_and_remove(EXP))
-        self.assertEqual(c.buf, b"expect")
+    c.buf = b"expectation"
+    assert c._check_and_remove(EXP)
+    assert c.buf == b""
 
-        c.buf = b"expectation"
-        self.assertTrue(c._check_and_remove(EXP))
-        self.assertEqual(c.buf, b"")
+    c.buf = b"expectation exceeded"
+    assert c._check_and_remove(EXP)
+    assert c.buf == b" exceeded"
 
-        c.buf = b"expectation exceeded"
-        self.assertTrue(c._check_and_remove(EXP))
-        self.assertEqual(c.buf, b" exceeded")
 
-    def test_describe(self):
-        c = transit.Connection(None, None, None, "description")
-        self.assertEqual(c.describe(), "description")
+def test_describe():
+    c = transit.Connection(None, None, None, "description")
+    assert c.describe() == "description"
 
-    def test_sender_accepting(self):
-        relay_handshake = None
-        owner = MockOwner()
-        factory = MockFactory()
-        addr = address.HostnameAddress("example.com", 1234)
-        c = transit.Connection(owner, relay_handshake, None, "description")
-        self.assertEqual(c.state, "too-early")
-        t = c.transport = FakeTransport(c, addr)
-        c.factory = factory
-        c.connectionMade()
-        self.assertEqual(factory._connectionWasMade_called, True)
-        self.assertEqual(factory._p, c)
 
-        owner._state = "go"
-        d = c.startNegotiation()
-        self.assertEqual(c.state, "handshake")
-        self.assertEqual(t.read_buf(), b"send_this")
-        self.assertNoResult(d)
+@ensureDeferred
+async def test_sender_accepting():
+    relay_handshake = None
+    owner = MockOwner()
+    factory = MockFactory()
+    addr = address.HostnameAddress("example.com", 1234)
+    c = transit.Connection(owner, relay_handshake, None, "description")
+    assert c.state == "too-early"
+    t = c.transport = FakeTransport(c, addr)
+    c.factory = factory
+    c.connectionMade()
+    assert factory._connectionWasMade_called == True
+    assert factory._p == c
 
-        c.dataReceived(b"expect_this")
-        self.assertEqual(t.read_buf(), b"go\n")
-        self.assertEqual(t._connected, True)
-        self.assertEqual(c.state, "records")
-        self.assertEqual(self.successResultOf(d), c)
+    owner._state = "go"
+    d = c.startNegotiation()
+    assert c.state == "handshake"
+    assert t.read_buf() == b"send_this"
+    assert not d.called
 
-        c.close()
-        self.assertEqual(t._connected, False)
+    c.dataReceived(b"expect_this")
+    assert t.read_buf() == b"go\n"
+    assert t._connected == True
+    assert c.state == "records"
+    assert await d == c
 
-    def test_sender_rejecting(self):
-        relay_handshake = None
-        owner = MockOwner()
-        factory = MockFactory()
-        addr = address.HostnameAddress("example.com", 1234)
-        c = transit.Connection(owner, relay_handshake, None, "description")
-        self.assertEqual(c.state, "too-early")
-        t = c.transport = FakeTransport(c, addr)
-        c.factory = factory
-        c.connectionMade()
-        self.assertEqual(factory._connectionWasMade_called, True)
-        self.assertEqual(factory._p, c)
+    c.close()
+    assert t._connected == False
 
-        owner._state = "nevermind"
-        d = c.startNegotiation()
-        self.assertEqual(c.state, "handshake")
-        self.assertEqual(t.read_buf(), b"send_this")
-        self.assertNoResult(d)
 
-        c.dataReceived(b"expect_this")
-        self.assertEqual(t.read_buf(), b"nevermind\n")
-        self.assertEqual(t._connected, False)
-        self.assertEqual(c.state, "hung up")
-        f = self.failureResultOf(d, transit.BadHandshake)
-        self.assertEqual(str(f.value), "abandoned")
+@ensureDeferred
+async def test_sender_rejecting():
+    relay_handshake = None
+    owner = MockOwner()
+    factory = MockFactory()
+    addr = address.HostnameAddress("example.com", 1234)
+    c = transit.Connection(owner, relay_handshake, None, "description")
+    assert c.state == "too-early"
+    t = c.transport = FakeTransport(c, addr)
+    c.factory = factory
+    c.connectionMade()
+    assert factory._connectionWasMade_called == True
+    assert factory._p == c
 
-    def test_handshake_other_error(self):
-        owner = MockOwner()
-        factory = MockFactory()
-        addr = address.HostnameAddress("example.com", 1234)
-        c = transit.Connection(owner, None, None, "description")
-        self.assertEqual(c.state, "too-early")
-        t = c.transport = FakeTransport(c, addr)
-        c.factory = factory
-        c.connectionMade()
-        self.assertEqual(factory._connectionWasMade_called, True)
-        self.assertEqual(factory._p, c)
+    owner._state = "nevermind"
+    d = c.startNegotiation()
+    assert c.state == "handshake"
+    assert t.read_buf() == b"send_this"
+    assert not d.called
 
-        d = c.startNegotiation()
-        self.assertEqual(c.state, "handshake")
-        self.assertEqual(t.read_buf(), b"send_this")
-        self.assertNoResult(d)
-        c.state = RandomError("boom2")
-        self.assertRaises(RandomError, c.dataReceived, b"surprise!")
-        self.assertEqual(t._connected, False)
-        self.assertEqual(c.state, "hung up")
-        self.failureResultOf(d, RandomError)
+    c.dataReceived(b"expect_this")
+    assert t.read_buf() == b"nevermind\n"
+    assert t._connected == False
+    assert c.state == "hung up"
+    with pytest.raises(transit.BadHandshake) as f:
+        await d
+    assert str(f.value) == "abandoned"
 
-    def test_handshake_bad_state(self):
-        owner = MockOwner()
-        factory = MockFactory()
-        addr = address.HostnameAddress("example.com", 1234)
-        c = transit.Connection(owner, None, None, "description")
-        self.assertEqual(c.state, "too-early")
-        t = c.transport = FakeTransport(c, addr)
-        c.factory = factory
-        c.connectionMade()
-        self.assertEqual(factory._connectionWasMade_called, True)
-        self.assertEqual(factory._p, c)
 
-        d = c.startNegotiation()
-        self.assertEqual(c.state, "handshake")
-        self.assertEqual(t.read_buf(), b"send_this")
-        self.assertNoResult(d)
-        c.state = "unknown-bogus-state"
-        self.assertRaises(ValueError, c.dataReceived, b"surprise!")
-        self.assertEqual(t._connected, False)
-        self.assertEqual(c.state, "hung up")
-        self.failureResultOf(d, ValueError)
+@ensureDeferred
+async def test_handshake_other_error():
+    owner = MockOwner()
+    factory = MockFactory()
+    addr = address.HostnameAddress("example.com", 1234)
+    c = transit.Connection(owner, None, None, "description")
+    assert c.state == "too-early"
+    t = c.transport = FakeTransport(c, addr)
+    c.factory = factory
+    c.connectionMade()
+    assert factory._connectionWasMade_called == True
+    assert factory._p == c
 
-    def test_relay_handshake(self):
-        relay_handshake = b"relay handshake"
-        owner = MockOwner()
-        factory = MockFactory()
-        addr = address.HostnameAddress("example.com", 1234)
-        c = transit.Connection(owner, relay_handshake, None, "description")
-        self.assertEqual(c.state, "too-early")
-        t = c.transport = FakeTransport(c, addr)
-        c.factory = factory
-        c.connectionMade()
-        self.assertEqual(factory._connectionWasMade_called, True)
-        self.assertEqual(factory._p, c)
-        self.assertEqual(t.read_buf(), b"")  # quiet until startNegotiation
+    d = c.startNegotiation()
+    assert c.state == "handshake"
+    assert t.read_buf() == b"send_this"
+    assert not d.called
+    c.state = RandomError("boom2")
+    with pytest.raises(RandomError):
+        c.dataReceived(b"surprise!")
+    assert t._connected == False
+    assert c.state == "hung up"
+    with pytest.raises(RandomError):
+        await d
 
-        owner._state = "go"
-        d = c.startNegotiation()
-        self.assertEqual(t.read_buf(), relay_handshake)
-        self.assertEqual(c.state, "relay")  # waiting for OK from relay
 
-        c.dataReceived(b"ok\n")
-        self.assertEqual(t.read_buf(), b"send_this")
-        self.assertEqual(c.state, "handshake")
+@ensureDeferred
+async def test_handshake_bad_state():
+    owner = MockOwner()
+    factory = MockFactory()
+    addr = address.HostnameAddress("example.com", 1234)
+    c = transit.Connection(owner, None, None, "description")
+    assert c.state == "too-early"
+    t = c.transport = FakeTransport(c, addr)
+    c.factory = factory
+    c.connectionMade()
+    assert factory._connectionWasMade_called == True
+    assert factory._p == c
 
-        self.assertNoResult(d)
+    d = c.startNegotiation()
+    assert c.state == "handshake"
+    assert t.read_buf() == b"send_this"
+    assert not d.called
+    c.state = "unknown-bogus-state"
+    with pytest.raises(ValueError):
+        c.dataReceived(b"surprise!")
+    assert t._connected == False
+    assert c.state == "hung up"
+    with pytest.raises(ValueError):
+        await d
 
-        c.dataReceived(b"expect_this")
-        self.assertEqual(c.state, "records")
-        self.assertEqual(self.successResultOf(d), c)
 
-        self.assertEqual(t.read_buf(), b"go\n")
+@ensureDeferred
+async def test_relay_handshake():
+    relay_handshake = b"relay handshake"
+    owner = MockOwner()
+    factory = MockFactory()
+    addr = address.HostnameAddress("example.com", 1234)
+    c = transit.Connection(owner, relay_handshake, None, "description")
+    assert c.state == "too-early"
+    t = c.transport = FakeTransport(c, addr)
+    c.factory = factory
+    c.connectionMade()
+    assert factory._connectionWasMade_called == True
+    assert factory._p == c
+    assert t.read_buf() == b""  # quiet until startNegotiation
 
-    def test_relay_handshake_bad(self):
-        relay_handshake = b"relay handshake"
-        owner = MockOwner()
-        factory = MockFactory()
-        addr = address.HostnameAddress("example.com", 1234)
-        c = transit.Connection(owner, relay_handshake, None, "description")
-        self.assertEqual(c.state, "too-early")
-        t = c.transport = FakeTransport(c, addr)
-        c.factory = factory
-        c.connectionMade()
-        self.assertEqual(factory._connectionWasMade_called, True)
-        self.assertEqual(factory._p, c)
-        self.assertEqual(t.read_buf(), b"")  # quiet until startNegotiation
+    owner._state = "go"
+    d = c.startNegotiation()
+    assert t.read_buf() == relay_handshake
+    assert c.state == "relay"  # waiting for OK from relay
 
-        owner._state = "go"
-        d = c.startNegotiation()
-        self.assertEqual(t.read_buf(), relay_handshake)
-        self.assertEqual(c.state, "relay")  # waiting for OK from relay
+    c.dataReceived(b"ok\n")
+    assert t.read_buf() == b"send_this"
+    assert c.state == "handshake"
 
-        c.dataReceived(b"not ok\n")
-        self.assertEqual(t._connected, False)
-        self.assertEqual(c.state, "hung up")
+    assert not d.called
 
-        f = self.failureResultOf(d, transit.BadHandshake)
-        self.assertEqual(
-            str(f.value), "got %r want %r" % (b"not ok\n", b"ok\n"))
+    c.dataReceived(b"expect_this")
+    assert c.state == "records"
+    assert await d == c
 
-    def test_receiver_accepted(self):
-        # we're on the receiving side, so we wait for the sender to decide
-        owner = MockOwner()
-        factory = MockFactory()
-        addr = address.HostnameAddress("example.com", 1234)
-        c = transit.Connection(owner, None, None, "description")
-        self.assertEqual(c.state, "too-early")
-        t = c.transport = FakeTransport(c, addr)
-        c.factory = factory
-        c.connectionMade()
-        self.assertEqual(factory._connectionWasMade_called, True)
-        self.assertEqual(factory._p, c)
+    assert t.read_buf() == b"go\n"
 
-        owner._state = "wait-for-decision"
-        d = c.startNegotiation()
-        self.assertEqual(c.state, "handshake")
-        self.assertEqual(t.read_buf(), b"send_this")
-        self.assertNoResult(d)
 
-        c.dataReceived(b"expect_this")
-        self.assertEqual(c.state, "wait-for-decision")
-        self.assertNoResult(d)
+@ensureDeferred
+async def test_relay_handshake_bad():
+    relay_handshake = b"relay handshake"
+    owner = MockOwner()
+    factory = MockFactory()
+    addr = address.HostnameAddress("example.com", 1234)
+    c = transit.Connection(owner, relay_handshake, None, "description")
+    assert c.state == "too-early"
+    t = c.transport = FakeTransport(c, addr)
+    c.factory = factory
+    c.connectionMade()
+    assert factory._connectionWasMade_called == True
+    assert factory._p == c
+    assert t.read_buf() == b""  # quiet until startNegotiation
 
-        c.dataReceived(b"go\n")
-        self.assertEqual(c.state, "records")
-        self.assertEqual(self.successResultOf(d), c)
+    owner._state = "go"
+    d = c.startNegotiation()
+    assert t.read_buf() == relay_handshake
+    assert c.state == "relay"  # waiting for OK from relay
 
-    def test_receiver_rejected_politely(self):
-        # we're on the receiving side, so we wait for the sender to decide
-        owner = MockOwner()
-        factory = MockFactory()
-        addr = address.HostnameAddress("example.com", 1234)
-        c = transit.Connection(owner, None, None, "description")
-        self.assertEqual(c.state, "too-early")
-        t = c.transport = FakeTransport(c, addr)
-        c.factory = factory
-        c.connectionMade()
-        self.assertEqual(factory._connectionWasMade_called, True)
-        self.assertEqual(factory._p, c)
+    c.dataReceived(b"not ok\n")
+    assert t._connected == False
+    assert c.state == "hung up"
 
-        owner._state = "wait-for-decision"
-        d = c.startNegotiation()
-        self.assertEqual(c.state, "handshake")
-        self.assertEqual(t.read_buf(), b"send_this")
-        self.assertNoResult(d)
+    with pytest.raises(transit.BadHandshake) as f:
+        await d
+    assert str(f.value) == "got %r want %r" % (b"not ok\n", b"ok\n")
 
-        c.dataReceived(b"expect_this")
-        self.assertEqual(c.state, "wait-for-decision")
-        self.assertNoResult(d)
 
-        c.dataReceived(b"nevermind\n")  # polite rejection
-        self.assertEqual(t._connected, False)
-        self.assertEqual(c.state, "hung up")
-        f = self.failureResultOf(d, transit.BadHandshake)
-        self.assertEqual(
-            str(f.value), "got %r want %r" % (b"nevermind\n", b"go\n"))
+@ensureDeferred
+async def test_receiver_accepted():
+    # we're on the receiving side, so we wait for the sender to decide
+    owner = MockOwner()
+    factory = MockFactory()
+    addr = address.HostnameAddress("example.com", 1234)
+    c = transit.Connection(owner, None, None, "description")
+    assert c.state == "too-early"
+    t = c.transport = FakeTransport(c, addr)
+    c.factory = factory
+    c.connectionMade()
+    assert factory._connectionWasMade_called == True
+    assert factory._p == c
 
-    def test_receiver_rejected_rudely(self):
-        # we're on the receiving side, so we wait for the sender to decide
-        owner = MockOwner()
-        factory = MockFactory()
-        addr = address.HostnameAddress("example.com", 1234)
-        c = transit.Connection(owner, None, None, "description")
-        self.assertEqual(c.state, "too-early")
-        t = c.transport = FakeTransport(c, addr)
-        c.factory = factory
-        c.connectionMade()
-        self.assertEqual(factory._connectionWasMade_called, True)
-        self.assertEqual(factory._p, c)
+    owner._state = "wait-for-decision"
+    d = c.startNegotiation()
+    assert c.state == "handshake"
+    assert t.read_buf() == b"send_this"
+    assert not d.called
 
-        owner._state = "wait-for-decision"
-        d = c.startNegotiation()
-        self.assertEqual(c.state, "handshake")
-        self.assertEqual(t.read_buf(), b"send_this")
-        self.assertNoResult(d)
+    c.dataReceived(b"expect_this")
+    assert c.state == "wait-for-decision"
+    assert not d.called
 
-        c.dataReceived(b"expect_this")
-        self.assertEqual(c.state, "wait-for-decision")
-        self.assertNoResult(d)
+    c.dataReceived(b"go\n")
+    assert c.state == "records"
+    assert await d == c
 
-        t.loseConnection()
-        self.assertEqual(t._connected, False)
-        f = self.failureResultOf(d, transit.BadHandshake)
-        self.assertEqual(str(f.value), "connection lost")
 
-    def test_cancel(self):
-        owner = MockOwner()
-        factory = MockFactory()
-        addr = address.HostnameAddress("example.com", 1234)
-        c = transit.Connection(owner, None, None, "description")
-        self.assertEqual(c.state, "too-early")
-        t = c.transport = FakeTransport(c, addr)
-        c.factory = factory
-        c.connectionMade()
+@ensureDeferred
+async def test_receiver_rejected_politely():
+    # we're on the receiving side, so we wait for the sender to decide
+    owner = MockOwner()
+    factory = MockFactory()
+    addr = address.HostnameAddress("example.com", 1234)
+    c = transit.Connection(owner, None, None, "description")
+    assert c.state == "too-early"
+    t = c.transport = FakeTransport(c, addr)
+    c.factory = factory
+    c.connectionMade()
+    assert factory._connectionWasMade_called == True
+    assert factory._p == c
 
-        d = c.startNegotiation()
-        # while we're waiting for negotiation, we get cancelled
-        d.cancel()
+    owner._state = "wait-for-decision"
+    d = c.startNegotiation()
+    assert c.state == "handshake"
+    assert t.read_buf() == b"send_this"
+    assert not d.called
 
-        self.assertEqual(t._connected, False)
-        self.assertEqual(c.state, "hung up")
-        self.failureResultOf(d, defer.CancelledError)
+    c.dataReceived(b"expect_this")
+    assert c.state == "wait-for-decision"
+    assert not d.called
 
-    def test_timeout(self):
-        clock = task.Clock()
-        owner = MockOwner()
-        factory = MockFactory()
-        addr = address.HostnameAddress("example.com", 1234)
-        c = transit.Connection(owner, None, None, "description")
+    c.dataReceived(b"nevermind\n")  # polite rejection
+    assert t._connected == False
+    assert c.state == "hung up"
+    with pytest.raises(transit.BadHandshake) as f:
+        await d
+    assert str(f.value) == "got %r want %r" % (b"nevermind\n", b"go\n")
 
-        def _callLater(period, func):
-            clock.callLater(period, func)
 
-        c.callLater = _callLater
-        self.assertEqual(c.state, "too-early")
-        t = c.transport = FakeTransport(c, addr)
-        c.factory = factory
-        c.connectionMade()
-        # the timer should now be running
-        d = c.startNegotiation()
-        # while we're waiting for negotiation, the timer expires
-        clock.advance(transit.TIMEOUT + 1.0)
+@ensureDeferred
+async def test_receiver_rejected_rudely():
+    # we're on the receiving side, so we wait for the sender to decide
+    owner = MockOwner()
+    factory = MockFactory()
+    addr = address.HostnameAddress("example.com", 1234)
+    c = transit.Connection(owner, None, None, "description")
+    assert c.state == "too-early"
+    t = c.transport = FakeTransport(c, addr)
+    c.factory = factory
+    c.connectionMade()
+    assert factory._connectionWasMade_called == True
+    assert factory._p == c
 
-        self.assertEqual(t._connected, False)
-        f = self.failureResultOf(d, transit.BadHandshake)
-        self.assertEqual(str(f.value), "timeout")
+    owner._state = "wait-for-decision"
+    d = c.startNegotiation()
+    assert c.state == "handshake"
+    assert t.read_buf() == b"send_this"
+    assert not d.called
 
-    def make_connection(self):
-        owner = MockOwner()
-        factory = MockFactory()
-        addr = address.HostnameAddress("example.com", 1234)
-        c = transit.Connection(owner, None, None, "description")
-        t = c.transport = FakeTransport(c, addr)
-        c.factory = factory
-        c.connectionMade()
+    c.dataReceived(b"expect_this")
+    assert c.state == "wait-for-decision"
+    assert not d.called
 
-        owner._state = "go"
-        d = c.startNegotiation()
-        c.dataReceived(b"expect_this")
-        self.assertEqual(self.successResultOf(d), c)
-        t.read_buf()  # flush input buffer, prepare for encrypted records
+    t.loseConnection()
+    assert t._connected == False
+    with pytest.raises(transit.BadHandshake) as f:
+        await d
+    assert str(f.value) == "connection lost"
 
-        return t, c, owner
 
-    def test_records_not_binary(self):
-        t, c, owner = self.make_connection()
+@ensureDeferred
+async def test_cancel():
+    owner = MockOwner()
+    factory = MockFactory()
+    addr = address.HostnameAddress("example.com", 1234)
+    c = transit.Connection(owner, None, None, "description")
+    assert c.state == "too-early"
+    t = c.transport = FakeTransport(c, addr)
+    c.factory = factory
+    c.connectionMade()
 
-        RECORD1 = u"not binary"
-        with self.assertRaises(InternalError):
-            c.send_record(RECORD1)
+    d = c.startNegotiation()
+    # while we're waiting for negotiation, we get cancelled
+    d.cancel()
 
-    def test_records_good(self):
-        # now make sure that outbound records are encrypted properly
-        t, c, owner = self.make_connection()
+    assert t._connected == False
+    assert c.state == "hung up"
+    with pytest.raises(defer.CancelledError):
+        await d
 
-        RECORD1 = b"record"
+
+@ensureDeferred
+async def test_timeout():
+    clock = task.Clock()
+    owner = MockOwner()
+    factory = MockFactory()
+    addr = address.HostnameAddress("example.com", 1234)
+    c = transit.Connection(owner, None, None, "description")
+
+    def _callLater(period, func):
+        clock.callLater(period, func)
+
+    c.callLater = _callLater
+    assert c.state == "too-early"
+    t = c.transport = FakeTransport(c, addr)
+    c.factory = factory
+    c.connectionMade()
+    # the timer should now be running
+    d = c.startNegotiation()
+    # while we're waiting for negotiation, the timer expires
+    clock.advance(transit.TIMEOUT + 1.0)
+
+    assert t._connected == False
+    with pytest.raises(transit.BadHandshake) as f:
+        await d
+    assert str(f.value) == "timeout"
+
+
+async def make_connection():
+    owner = MockOwner()
+    factory = MockFactory()
+    addr = address.HostnameAddress("example.com", 1234)
+    c = transit.Connection(owner, None, None, "description")
+    t = c.transport = FakeTransport(c, addr)
+    c.factory = factory
+    c.connectionMade()
+
+    owner._state = "go"
+    d = c.startNegotiation()
+    c.dataReceived(b"expect_this")
+    assert await d == c
+    t.read_buf()  # flush input buffer, prepare for encrypted records
+
+    return t, c, owner
+
+
+@ensureDeferred
+async def test_records_not_binary():
+    t, c, owner = await make_connection()
+
+    RECORD1 = u"not binary"
+    with pytest.raises(InternalError):
         c.send_record(RECORD1)
-        buf = t.read_buf()
-        expected = ("%08x" % (24 + len(RECORD1) + 16)).encode("ascii")
-        self.assertEqual(hexlify(buf[:4]), expected)
-        encrypted = buf[4:]
-        receive_box = SecretBox(owner._sender_record_key())
-        nonce_buf = encrypted[:SecretBox.NONCE_SIZE]  # assume it's prepended
-        nonce = int(hexlify(nonce_buf), 16)
-        self.assertEqual(nonce, 0)  # first message gets nonce 0
-        decrypted = receive_box.decrypt(encrypted)
-        self.assertEqual(decrypted, RECORD1)
 
-        # second message gets nonce 1
-        RECORD2 = b"record2"
-        c.send_record(RECORD2)
-        buf = t.read_buf()
-        expected = ("%08x" % (24 + len(RECORD2) + 16)).encode("ascii")
-        self.assertEqual(hexlify(buf[:4]), expected)
-        encrypted = buf[4:]
-        receive_box = SecretBox(owner._sender_record_key())
-        nonce_buf = encrypted[:SecretBox.NONCE_SIZE]  # assume it's prepended
-        nonce = int(hexlify(nonce_buf), 16)
-        self.assertEqual(nonce, 1)
-        decrypted = receive_box.decrypt(encrypted)
-        self.assertEqual(decrypted, RECORD2)
 
-        # and that we can receive records properly
-        inbound_records = []
-        c.recordReceived = inbound_records.append
-        send_box = SecretBox(owner._receiver_record_key())
+@ensureDeferred
+async def test_records_good():
+    # now make sure that outbound records are encrypted properly
+    t, c, owner = await make_connection()
 
-        RECORD3 = b"record3"
-        nonce_buf = unhexlify("%048x" % 0)  # first nonce must be 0
-        encrypted = send_box.encrypt(RECORD3, nonce_buf)
-        length = unhexlify("%08x" % len(encrypted))  # always 4 bytes long
-        c.dataReceived(length[:2])
-        c.dataReceived(length[2:])
-        c.dataReceived(encrypted[:-2])
-        self.assertEqual(inbound_records, [])
+    RECORD1 = b"record"
+    c.send_record(RECORD1)
+    buf = t.read_buf()
+    expected = ("%08x" % (24 + len(RECORD1) + 16)).encode("ascii")
+    assert hexlify(buf[:4]) == expected
+    encrypted = buf[4:]
+    receive_box = SecretBox(owner._sender_record_key())
+    nonce_buf = encrypted[:SecretBox.NONCE_SIZE]  # assume it's prepended
+    nonce = int(hexlify(nonce_buf), 16)
+    assert nonce == 0  # first message gets nonce 0
+    decrypted = receive_box.decrypt(encrypted)
+    assert decrypted == RECORD1
+
+    # second message gets nonce 1
+    RECORD2 = b"record2"
+    c.send_record(RECORD2)
+    buf = t.read_buf()
+    expected = ("%08x" % (24 + len(RECORD2) + 16)).encode("ascii")
+    assert hexlify(buf[:4]) == expected
+    encrypted = buf[4:]
+    receive_box = SecretBox(owner._sender_record_key())
+    nonce_buf = encrypted[:SecretBox.NONCE_SIZE]  # assume it's prepended
+    nonce = int(hexlify(nonce_buf), 16)
+    assert nonce == 1
+    decrypted = receive_box.decrypt(encrypted)
+    assert decrypted == RECORD2
+
+    # and that we can receive records properly
+    inbound_records = []
+    c.recordReceived = inbound_records.append
+    send_box = SecretBox(owner._receiver_record_key())
+
+    RECORD3 = b"record3"
+    nonce_buf = unhexlify("%048x" % 0)  # first nonce must be 0
+    encrypted = send_box.encrypt(RECORD3, nonce_buf)
+    length = unhexlify("%08x" % len(encrypted))  # always 4 bytes long
+    c.dataReceived(length[:2])
+    c.dataReceived(length[2:])
+    c.dataReceived(encrypted[:-2])
+    assert inbound_records == []
+    c.dataReceived(encrypted[-2:])
+    assert inbound_records == [RECORD3]
+
+    RECORD4 = b"record4"
+    nonce_buf = unhexlify("%048x" % 1)  # nonces increment
+    encrypted = send_box.encrypt(RECORD4, nonce_buf)
+    length = unhexlify("%08x" % len(encrypted))  # always 4 bytes long
+    c.dataReceived(length[:2])
+    c.dataReceived(length[2:])
+    c.dataReceived(encrypted[:-2])
+    assert inbound_records == [RECORD3]
+    c.dataReceived(encrypted[-2:])
+    assert inbound_records == [RECORD3, RECORD4]
+
+    # receiving two records at the same time: deliver both
+    inbound_records[:] = []
+    RECORD5 = b"record5"
+    nonce_buf = unhexlify("%048x" % 2)  # nonces increment
+    encrypted = send_box.encrypt(RECORD5, nonce_buf)
+    length = unhexlify("%08x" % len(encrypted))  # always 4 bytes long
+    r5 = length + encrypted
+    RECORD6 = b"record6"
+    nonce_buf = unhexlify("%048x" % 3)  # nonces increment
+    encrypted = send_box.encrypt(RECORD6, nonce_buf)
+    length = unhexlify("%08x" % len(encrypted))  # always 4 bytes long
+    r6 = length + encrypted
+    c.dataReceived(r5 + r6)
+    assert inbound_records == [RECORD5, RECORD6]
+
+
+def corrupt(orig):
+    last_byte = orig[-1:]
+    num = int(hexlify(last_byte).decode("ascii"), 16)
+    corrupt_num = 256 - num
+    as_byte = unhexlify("%02x" % corrupt_num)
+    return orig[:-1] + as_byte
+
+
+@ensureDeferred
+async def test_records_corrupt():
+    # corrupt records should be rejected
+    t, c, owner = await make_connection()
+
+    inbound_records = []
+    c.recordReceived = inbound_records.append
+
+    RECORD = b"record"
+    send_box = SecretBox(owner._receiver_record_key())
+    nonce_buf = unhexlify("%048x" % 0)  # first nonce must be 0
+    encrypted = corrupt(send_box.encrypt(RECORD, nonce_buf))
+    length = unhexlify("%08x" % len(encrypted))  # always 4 bytes long
+    c.dataReceived(length)
+    c.dataReceived(encrypted[:-2])
+    assert inbound_records == []
+    with pytest.raises(CryptoError):
         c.dataReceived(encrypted[-2:])
-        self.assertEqual(inbound_records, [RECORD3])
+    assert inbound_records == []
+    # and the connection should have been dropped
+    assert t._connected == False
 
-        RECORD4 = b"record4"
-        nonce_buf = unhexlify("%048x" % 1)  # nonces increment
-        encrypted = send_box.encrypt(RECORD4, nonce_buf)
-        length = unhexlify("%08x" % len(encrypted))  # always 4 bytes long
-        c.dataReceived(length[:2])
-        c.dataReceived(length[2:])
-        c.dataReceived(encrypted[:-2])
-        self.assertEqual(inbound_records, [RECORD3])
+
+@ensureDeferred
+async def test_out_of_order_nonce():
+    # an inbound out-of-order nonce should be rejected
+    t, c, owner = await make_connection()
+
+    inbound_records = []
+    c.recordReceived = inbound_records.append
+
+    RECORD = b"record"
+    send_box = SecretBox(owner._receiver_record_key())
+    nonce_buf = unhexlify("%048x" % 1)  # first nonce must be 0
+    encrypted = send_box.encrypt(RECORD, nonce_buf)
+    length = unhexlify("%08x" % len(encrypted))  # always 4 bytes long
+    c.dataReceived(length)
+    c.dataReceived(encrypted[:-2])
+    assert inbound_records == []
+    with pytest.raises(transit.BadNonce):
         c.dataReceived(encrypted[-2:])
-        self.assertEqual(inbound_records, [RECORD3, RECORD4])
+    assert inbound_records == []
+    # and the connection should have been dropped
+    assert t._connected == False
 
-        # receiving two records at the same time: deliver both
-        inbound_records[:] = []
-        RECORD5 = b"record5"
-        nonce_buf = unhexlify("%048x" % 2)  # nonces increment
-        encrypted = send_box.encrypt(RECORD5, nonce_buf)
-        length = unhexlify("%08x" % len(encrypted))  # always 4 bytes long
-        r5 = length + encrypted
-        RECORD6 = b"record6"
-        nonce_buf = unhexlify("%048x" % 3)  # nonces increment
-        encrypted = send_box.encrypt(RECORD6, nonce_buf)
-        length = unhexlify("%08x" % len(encrypted))  # always 4 bytes long
-        r6 = length + encrypted
-        c.dataReceived(r5 + r6)
-        self.assertEqual(inbound_records, [RECORD5, RECORD6])
 
-    def corrupt(self, orig):
-        last_byte = orig[-1:]
-        num = int(hexlify(last_byte).decode("ascii"), 16)
-        corrupt_num = 256 - num
-        as_byte = unhexlify("%02x" % corrupt_num)
-        return orig[:-1] + as_byte
+# TODO: check that .connectionLost/loseConnection signatures are
+# consistent: zero args, or one arg?
 
-    def test_records_corrupt(self):
-        # corrupt records should be rejected
-        t, c, owner = self.make_connection()
+# XXX: if we don't set the transit key before connecting, what
+# happens? We currently get a type-check assertion from HKDF because
+# the key is None.
 
-        inbound_records = []
-        c.recordReceived = inbound_records.append
 
-        RECORD = b"record"
-        send_box = SecretBox(owner._receiver_record_key())
-        nonce_buf = unhexlify("%048x" % 0)  # first nonce must be 0
-        encrypted = self.corrupt(send_box.encrypt(RECORD, nonce_buf))
-        length = unhexlify("%08x" % len(encrypted))  # always 4 bytes long
-        c.dataReceived(length)
-        c.dataReceived(encrypted[:-2])
-        self.assertEqual(inbound_records, [])
-        self.assertRaises(CryptoError, c.dataReceived, encrypted[-2:])
-        self.assertEqual(inbound_records, [])
-        # and the connection should have been dropped
-        self.assertEqual(t._connected, False)
+@ensureDeferred
+async def test_receive_queue():
+    c = transit.Connection(None, None, None, "description")
+    c.transport = FakeTransport(c, None)
+    c.transport.signalConnectionLost = False
+    c.recordReceived(b"0")
+    c.recordReceived(b"1")
+    c.recordReceived(b"2")
+    d0 = c.receive_record()
+    assert await d0 == b"0"
+    d1 = c.receive_record()
+    d2 = c.receive_record()
+    # they must fire in order of receipt, not order of addCallback
+    assert await d2 == b"2"
+    assert await d1 == b"1"
 
-    def test_out_of_order_nonce(self):
-        # an inbound out-of-order nonce should be rejected
-        t, c, owner = self.make_connection()
+    d3 = c.receive_record()
+    d4 = c.receive_record()
+    assert not d3.called
+    assert not d4.called
 
-        inbound_records = []
-        c.recordReceived = inbound_records.append
+    c.recordReceived(b"3")
+    assert await d3 == b"3"
+    assert not d4.called
 
-        RECORD = b"record"
-        send_box = SecretBox(owner._receiver_record_key())
-        nonce_buf = unhexlify("%048x" % 1)  # first nonce must be 0
-        encrypted = send_box.encrypt(RECORD, nonce_buf)
-        length = unhexlify("%08x" % len(encrypted))  # always 4 bytes long
-        c.dataReceived(length)
-        c.dataReceived(encrypted[:-2])
-        self.assertEqual(inbound_records, [])
-        self.assertRaises(transit.BadNonce, c.dataReceived, encrypted[-2:])
-        self.assertEqual(inbound_records, [])
-        # and the connection should have been dropped
-        self.assertEqual(t._connected, False)
+    c.recordReceived(b"4")
+    assert await d4 == b"4"
 
-        # TODO: check that .connectionLost/loseConnection signatures are
-        # consistent: zero args, or one arg?
+    d5 = c.receive_record()
+    c.close()
+    with pytest.raises(error.ConnectionClosed):
+        await d5
 
-        # XXX: if we don't set the transit key before connecting, what
-        # happens? We currently get a type-check assertion from HKDF because
-        # the key is None.
 
-    def test_receive_queue(self):
-        c = transit.Connection(None, None, None, "description")
-        c.transport = FakeTransport(c, None)
-        c.transport.signalConnectionLost = False
-        c.recordReceived(b"0")
-        c.recordReceived(b"1")
-        c.recordReceived(b"2")
-        d0 = c.receive_record()
-        self.assertEqual(self.successResultOf(d0), b"0")
-        d1 = c.receive_record()
-        d2 = c.receive_record()
-        # they must fire in order of receipt, not order of addCallback
-        self.assertEqual(self.successResultOf(d2), b"2")
-        self.assertEqual(self.successResultOf(d1), b"1")
+def test_producer():
+    # a Transit object (receiving data from the remote peer) produces
+    # data and writes it into a local Consumer
+    c = transit.Connection(None, None, None, "description")
+    c.transport = proto_helpers.StringTransport()
+    c.recordReceived(b"r1.")
+    c.recordReceived(b"r2.")
 
-        d3 = c.receive_record()
-        d4 = c.receive_record()
-        self.assertNoResult(d3)
-        self.assertNoResult(d4)
+    consumer = proto_helpers.StringTransport()
+    rv = c.connectConsumer(consumer)
+    assert rv is None
+    assert c._consumer is consumer
+    assert consumer.value() == b"r1.r2."
 
-        c.recordReceived(b"3")
-        self.assertEqual(self.successResultOf(d3), b"3")
-        self.assertNoResult(d4)
-
-        c.recordReceived(b"4")
-        self.assertEqual(self.successResultOf(d4), b"4")
-
-        d5 = c.receive_record()
-        c.close()
-        self.failureResultOf(d5, error.ConnectionClosed)
-
-    def test_producer(self):
-        # a Transit object (receiving data from the remote peer) produces
-        # data and writes it into a local Consumer
-        c = transit.Connection(None, None, None, "description")
-        c.transport = proto_helpers.StringTransport()
-        c.recordReceived(b"r1.")
-        c.recordReceived(b"r2.")
-
-        consumer = proto_helpers.StringTransport()
-        rv = c.connectConsumer(consumer)
-        self.assertIs(rv, None)
-        self.assertIs(c._consumer, consumer)
-        self.assertEqual(consumer.value(), b"r1.r2.")
-
-        self.assertRaises(RuntimeError, c.connectConsumer, consumer)
-
-        c.recordReceived(b"r3.")
-        self.assertEqual(consumer.value(), b"r1.r2.r3.")
-
-        c.pauseProducing()
-        self.assertEqual(c.transport.producerState, "paused")
-        c.resumeProducing()
-        self.assertEqual(c.transport.producerState, "producing")
-
-        c.disconnectConsumer()
-        self.assertEqual(consumer.producer, None)
+    with pytest.raises(RuntimeError):
         c.connectConsumer(consumer)
 
-        c.stopProducing()
-        self.assertEqual(c.transport.producerState, "stopped")
+    c.recordReceived(b"r3.")
+    assert consumer.value() == b"r1.r2.r3."
 
-    def test_connectConsumer(self):
-        # connectConsumer() takes an optional number of bytes to expect, and
-        # fires a Deferred when that many have been written
-        c = transit.Connection(None, None, None, "description")
-        c._negotiation_d.addErrback(lambda err: None)  # eat it
-        c.transport = proto_helpers.StringTransport()
-        c.recordReceived(b"r1.")
+    c.pauseProducing()
+    assert c.transport.producerState == "paused"
+    c.resumeProducing()
+    assert c.transport.producerState == "producing"
 
-        consumer = proto_helpers.StringTransport()
-        d = c.connectConsumer(consumer, expected=10)
-        self.assertEqual(consumer.value(), b"r1.")
-        self.assertNoResult(d)
+    c.disconnectConsumer()
+    assert consumer.producer == None
+    c.connectConsumer(consumer)
 
-        c.recordReceived(b"r2.")
-        self.assertEqual(consumer.value(), b"r1.r2.")
-        self.assertNoResult(d)
-
-        c.recordReceived(b"r3.")
-        self.assertEqual(consumer.value(), b"r1.r2.r3.")
-        self.assertNoResult(d)
-
-        c.recordReceived(b"!")
-        self.assertEqual(consumer.value(), b"r1.r2.r3.!")
-        self.assertEqual(self.successResultOf(d), 10)
-
-        # that should automatically disconnect the consumer, and subsequent
-        # records should get queued, not delivered
-        self.assertIs(c._consumer, None)
-        c.recordReceived(b"overflow")
-        self.assertEqual(consumer.value(), b"r1.r2.r3.!")
-
-        # now test that the Deferred errbacks when the connection is lost
-        d = c.connectConsumer(consumer, expected=10)
-
-        c.connectionLost()
-        self.failureResultOf(d, error.ConnectionClosed)
-
-    def test_connectConsumer_empty(self):
-        # if connectConsumer() expects 0 bytes (e.g. someone is "sending" a
-        # zero-length file), make sure it gets woken up right away, so it can
-        # disconnect itself, even though no bytes will actually arrive
-        c = transit.Connection(None, None, None, "description")
-        c._negotiation_d.addErrback(lambda err: None)  # eat it
-        c.transport = proto_helpers.StringTransport()
-
-        consumer = proto_helpers.StringTransport()
-        d = c.connectConsumer(consumer, expected=0)
-        self.assertEqual(self.successResultOf(d), 0)
-        self.assertEqual(consumer.value(), b"")
-        self.assertIs(c._consumer, None)
-
-    def test_writeToFile(self):
-        c = transit.Connection(None, None, None, "description")
-        c._negotiation_d.addErrback(lambda err: None)  # eat it
-        c.transport = proto_helpers.StringTransport()
-        c.recordReceived(b"r1.")
-
-        f = io.BytesIO()
-        progress = []
-        d = c.writeToFile(f, 10, progress.append)
-        self.assertEqual(f.getvalue(), b"r1.")
-        self.assertEqual(progress, [3])
-        self.assertNoResult(d)
-
-        c.recordReceived(b"r2.")
-        self.assertEqual(f.getvalue(), b"r1.r2.")
-        self.assertEqual(progress, [3, 3])
-        self.assertNoResult(d)
-
-        c.recordReceived(b"r3.")
-        self.assertEqual(f.getvalue(), b"r1.r2.r3.")
-        self.assertEqual(progress, [3, 3, 3])
-        self.assertNoResult(d)
-
-        c.recordReceived(b"!")
-        self.assertEqual(f.getvalue(), b"r1.r2.r3.!")
-        self.assertEqual(progress, [3, 3, 3, 1])
-        self.assertEqual(self.successResultOf(d), 10)
-
-        # that should automatically disconnect the consumer, and subsequent
-        # records should get queued, not delivered
-        self.assertIs(c._consumer, None)
-        c.recordReceived(b"overflow.")
-        self.assertEqual(f.getvalue(), b"r1.r2.r3.!")
-        self.assertEqual(progress, [3, 3, 3, 1])
-
-        # test what happens when enough data is queued ahead of time
-        c.recordReceived(b"second.")  # now "overflow.second."
-        c.recordReceived(b"third.")  # now "overflow.second.third."
-        f = io.BytesIO()
-        d = c.writeToFile(f, 10)
-        self.assertEqual(f.getvalue(), b"overflow.second.")  # whole records
-        self.assertEqual(self.successResultOf(d), 16)
-        self.assertEqual(list(c._inbound_records), [b"third."])
-
-        # now test that the Deferred errbacks when the connection is lost
-        d = c.writeToFile(f, 10)
-
-        c.connectionLost()
-        self.failureResultOf(d, error.ConnectionClosed)
-
-    def test_consumer(self):
-        # a local producer sends data to a consuming Transit object
-        c = transit.Connection(None, None, None, "description")
-        c.transport = proto_helpers.StringTransport()
-        records = []
-        c.send_record = records.append
-
-        producer = proto_helpers.StringTransport()
-        c.registerProducer(producer, True)
-        self.assertIs(c.transport.producer, producer)
-
-        c.write(b"r1.")
-        self.assertEqual(records, [b"r1."])
-
-        c.unregisterProducer()
-        self.assertEqual(c.transport.producer, None)
+    c.stopProducing()
+    assert c.transport.producerState == "stopped"
 
 
-class FileConsumer(unittest.TestCase):
-    def test_basic(self):
-        f = io.BytesIO()
-        progress = []
-        fc = transit.FileConsumer(f, progress.append)
-        self.assertEqual(progress, [])
-        self.assertEqual(f.getvalue(), b"")
-        fc.write(b"." * 99)
-        self.assertEqual(progress, [99])
-        self.assertEqual(f.getvalue(), b"." * 99)
-        fc.write(b"!")
-        self.assertEqual(progress, [99, 1])
-        self.assertEqual(f.getvalue(), b"." * 99 + b"!")
+@ensureDeferred
+async def test_connectConsumer():
+    # connectConsumer() takes an optional number of bytes to expect, and
+    # fires a Deferred when that many have been written
+    c = transit.Connection(None, None, None, "description")
+    c._negotiation_d.addErrback(lambda err: None)  # eat it
+    c.transport = proto_helpers.StringTransport()
+    c.recordReceived(b"r1.")
 
-    def test_hasher(self):
-        hashee = []
-        f = io.BytesIO()
-        progress = []
-        fc = transit.FileConsumer(f, progress.append, hasher=hashee.append)
-        self.assertEqual(progress, [])
-        self.assertEqual(f.getvalue(), b"")
-        self.assertEqual(hashee, [])
-        fc.write(b"." * 99)
-        self.assertEqual(progress, [99])
-        self.assertEqual(f.getvalue(), b"." * 99)
-        self.assertEqual(hashee, [b"." * 99])
-        fc.write(b"!")
-        self.assertEqual(progress, [99, 1])
-        self.assertEqual(f.getvalue(), b"." * 99 + b"!")
-        self.assertEqual(hashee, [b"." * 99, b"!"])
+    consumer = proto_helpers.StringTransport()
+    d = c.connectConsumer(consumer, expected=10)
+    assert consumer.value() == b"r1."
+    assert not d.called
+
+    c.recordReceived(b"r2.")
+    assert consumer.value() == b"r1.r2."
+    assert not d.called
+
+    c.recordReceived(b"r3.")
+    assert consumer.value() == b"r1.r2.r3."
+    assert not d.called
+
+    c.recordReceived(b"!")
+    assert consumer.value() == b"r1.r2.r3.!"
+    assert await d == 10
+
+    # that should automatically disconnect the consumer, and subsequent
+    # records should get queued, not delivered
+    assert c._consumer is None
+    c.recordReceived(b"overflow")
+    assert consumer.value() == b"r1.r2.r3.!"
+
+    # now test that the Deferred errbacks when the connection is lost
+    d = c.connectConsumer(consumer, expected=10)
+
+    c.connectionLost()
+    with pytest.raises(error.ConnectionClosed):
+        await d
+
+
+@ensureDeferred
+async def test_connectConsumer_empty():
+    # if connectConsumer() expects 0 bytes (e.g. someone is "sending" a
+    # zero-length file), make sure it gets woken up right away, so it can
+    # disconnect itself, even though no bytes will actually arrive
+    c = transit.Connection(None, None, None, "description")
+    c._negotiation_d.addErrback(lambda err: None)  # eat it
+    c.transport = proto_helpers.StringTransport()
+
+    consumer = proto_helpers.StringTransport()
+    d = c.connectConsumer(consumer, expected=0)
+    assert await d == 0
+    assert consumer.value() == b""
+    assert c._consumer is None
+
+
+@ensureDeferred
+async def test_writeToFile():
+    c = transit.Connection(None, None, None, "description")
+    c._negotiation_d.addErrback(lambda err: None)  # eat it
+    c.transport = proto_helpers.StringTransport()
+    c.recordReceived(b"r1.")
+
+    f = io.BytesIO()
+    progress = []
+    d = c.writeToFile(f, 10, progress.append)
+    assert f.getvalue() == b"r1."
+    assert progress == [3]
+    assert not d.called
+
+    c.recordReceived(b"r2.")
+    assert f.getvalue() == b"r1.r2."
+    assert progress == [3, 3]
+    assert not d.called
+
+    c.recordReceived(b"r3.")
+    assert f.getvalue() == b"r1.r2.r3."
+    assert progress == [3, 3, 3]
+    assert not d.called
+
+    c.recordReceived(b"!")
+    assert f.getvalue() == b"r1.r2.r3.!"
+    assert progress == [3, 3, 3, 1]
+    assert await d == 10
+
+    # that should automatically disconnect the consumer, and subsequent
+    # records should get queued, not delivered
+    assert c._consumer is None
+    c.recordReceived(b"overflow.")
+    assert f.getvalue() == b"r1.r2.r3.!"
+    assert progress == [3, 3, 3, 1]
+
+    # test what happens when enough data is queued ahead of time
+    c.recordReceived(b"second.")  # now "overflow.second."
+    c.recordReceived(b"third.")  # now "overflow.second.third."
+    f = io.BytesIO()
+    d = c.writeToFile(f, 10)
+    assert f.getvalue() == b"overflow.second."  # whole records
+    assert await d == 16
+    assert list(c._inbound_records) == [b"third."]
+
+    # now test that the Deferred errbacks when the connection is lost
+    d = c.writeToFile(f, 10)
+
+    c.connectionLost()
+    with pytest.raises(error.ConnectionClosed):
+        await d
+
+
+def test_consumer():
+    # a local producer sends data to a consuming Transit object
+    c = transit.Connection(None, None, None, "description")
+    c.transport = proto_helpers.StringTransport()
+    records = []
+    c.send_record = records.append
+
+    producer = proto_helpers.StringTransport()
+    c.registerProducer(producer, True)
+    assert c.transport.producer is producer
+
+    c.write(b"r1.")
+    assert records == [b"r1."]
+
+    c.unregisterProducer()
+    assert c.transport.producer == None
+
+
+def test_basic():
+    f = io.BytesIO()
+    progress = []
+    fc = transit.FileConsumer(f, progress.append)
+    assert progress == []
+    assert f.getvalue() == b""
+    fc.write(b"." * 99)
+    assert progress == [99]
+    assert f.getvalue() == b"." * 99
+    fc.write(b"!")
+    assert progress == [99, 1]
+    assert f.getvalue() == b"." * 99 + b"!"
+
+
+def test_hasher():
+    hashee = []
+    f = io.BytesIO()
+    progress = []
+    fc = transit.FileConsumer(f, progress.append, hasher=hashee.append)
+    assert progress == []
+    assert f.getvalue() == b""
+    assert hashee == []
+    fc.write(b"." * 99)
+    assert progress == [99]
+    assert f.getvalue() == b"." * 99
+    assert hashee == [b"." * 99]
+    fc.write(b"!")
+    assert progress == [99, 1]
+    assert f.getvalue() == b"." * 99 + b"!"
+    assert hashee == [b"." * 99, b"!"]
 
 
 DIRECT_HINT_JSON = {
@@ -1259,8 +1348,8 @@ UNAVAILABLE_RELAY_HINT_JSON = {
 }
 
 
-class Transit(unittest.TestCase):
-    def setUp(self):
+class FakeConnector:
+    def __init__(self):
         self._connectors = []
         self._waiters = []
         self._descriptions = []
@@ -1272,319 +1361,337 @@ class Transit(unittest.TestCase):
         self._descriptions.append(description)
         return d
 
-    @ensureDeferred
-    async def test_success_direct(self):
-        reactor = mock.Mock()
-        s = transit.TransitSender("", reactor=reactor)
-        s.set_transit_key(b"key")
-        hints = await s.get_connection_hints()  # start the listener
-        del hints
-        s.add_connection_hints([
-            DIRECT_HINT_JSON, UNRECOGNIZED_DIRECT_HINT_JSON,
-            UNRECOGNIZED_HINT_JSON
-        ])
 
-        s._start_connector = self._start_connector
+@ensureDeferred
+async def test_success_direct():
+    reactor = mock.Mock()
+    fc = FakeConnector()
+    s = transit.TransitSender("", reactor=reactor)
+    s.set_transit_key(b"key")
+    hints = await s.get_connection_hints()  # start the listener
+    del hints
+    s.add_connection_hints([
+        DIRECT_HINT_JSON, UNRECOGNIZED_DIRECT_HINT_JSON,
+        UNRECOGNIZED_HINT_JSON
+    ])
+
+    s._start_connector = fc._start_connector
+    d = s.connect()
+    assert not d.called
+    assert len(fc._waiters) == 1
+    assert isinstance(fc._waiters[0], defer.Deferred)
+
+    fc._waiters[0].callback("winner")
+    assert await d == "winner"
+    assert fc._descriptions == ["->tcp:direct:1234"]
+
+
+@ensureDeferred
+async def test_success_direct_tor():
+    clock = task.Clock()
+    fc = FakeConnector()
+    s = transit.TransitSender("", tor=mock.Mock(), reactor=clock)
+    s.set_transit_key(b"key")
+    hints = await s.get_connection_hints()  # start the listener
+    del hints
+    s.add_connection_hints([DIRECT_HINT_JSON])
+
+    s._start_connector = fc._start_connector
+    d = s.connect()
+    assert not d.called
+    assert len(fc._waiters) == 1
+    assert isinstance(fc._waiters[0], defer.Deferred)
+
+    fc._waiters[0].callback("winner")
+    assert await d == "winner"
+    assert fc._descriptions == ["tor->tcp:direct:1234"]
+
+
+@ensureDeferred
+async def test_success_direct_tor_relay():
+    clock = task.Clock()
+    fc = FakeConnector()
+    s = transit.TransitSender("", tor=mock.Mock(), reactor=clock)
+    s.set_transit_key(b"key")
+    hints = await s.get_connection_hints()  # start the listener
+    del hints
+    s.add_connection_hints([RELAY_HINT_JSON])
+
+    s._start_connector = fc._start_connector
+    d = s.connect()
+    # move the clock forward any amount, since relay connections are
+    # triggered starting at T+0.0
+    clock.advance(1.0)
+    assert not d.called
+    assert len(fc._waiters) == 1
+    assert isinstance(fc._waiters[0], defer.Deferred)
+
+    fc._waiters[0].callback("winner")
+    assert await d == "winner"
+    assert fc._descriptions == ["tor->relay:tcp:relay:1234"]
+
+
+def _endpoint_from_hint_obj(hint, _tor, _reactor):
+    if isinstance(hint, DirectTCPV1Hint):
+        if hint.hostname == "unavailable":
+            return None
+        return hint.hostname
+    return None
+
+
+@ensureDeferred
+async def test_wait_for_relay():
+    clock = task.Clock()
+    fc = FakeConnector()
+    s = transit.TransitSender("", reactor=clock, no_listen=True)
+    s.set_transit_key(b"key")
+    hints = await s.get_connection_hints()
+    del hints
+    s.add_connection_hints(
+        [DIRECT_HINT_JSON, UNRECOGNIZED_HINT_JSON, RELAY_HINT_JSON])
+    s._start_connector = fc._start_connector
+
+    with mock.patch("wormhole.transit.endpoint_from_hint_obj",
+                    _endpoint_from_hint_obj):
         d = s.connect()
-        self.assertNoResult(d)
-        self.assertEqual(len(self._waiters), 1)
-        self.assertIsInstance(self._waiters[0], defer.Deferred)
+        assert not d.called
+        # the direct connectors are tried right away, but the relay
+        # connectors are stalled for a few seconds
+        assert fc._connectors == ["direct"]
 
-        self._waiters[0].callback("winner")
-        self.assertEqual(self.successResultOf(d), "winner")
-        self.assertEqual(self._descriptions, ["->tcp:direct:1234"])
+        clock.advance(s.RELAY_DELAY + 1.0)
+        assert fc._connectors == ["direct", "relay"]
 
-    @ensureDeferred
-    async def test_success_direct_tor(self):
-        clock = task.Clock()
-        s = transit.TransitSender("", tor=mock.Mock(), reactor=clock)
-        s.set_transit_key(b"key")
-        hints = await s.get_connection_hints()  # start the listener
-        del hints
-        s.add_connection_hints([DIRECT_HINT_JSON])
+        fc._waiters[0].callback("winner")
+        assert await d == "winner"
 
-        s._start_connector = self._start_connector
-        d = s.connect()
-        self.assertNoResult(d)
-        self.assertEqual(len(self._waiters), 1)
-        self.assertIsInstance(self._waiters[0], defer.Deferred)
 
-        self._waiters[0].callback("winner")
-        self.assertEqual(self.successResultOf(d), "winner")
-        self.assertEqual(self._descriptions, ["tor->tcp:direct:1234"])
-
-    @ensureDeferred
-    async def test_success_direct_tor_relay(self):
-        clock = task.Clock()
-        s = transit.TransitSender("", tor=mock.Mock(), reactor=clock)
-        s.set_transit_key(b"key")
-        hints = await s.get_connection_hints()  # start the listener
-        del hints
-        s.add_connection_hints([RELAY_HINT_JSON])
-
-        s._start_connector = self._start_connector
-        d = s.connect()
-        # move the clock forward any amount, since relay connections are
-        # triggered starting at T+0.0
-        clock.advance(1.0)
-        self.assertNoResult(d)
-        self.assertEqual(len(self._waiters), 1)
-        self.assertIsInstance(self._waiters[0], defer.Deferred)
-
-        self._waiters[0].callback("winner")
-        self.assertEqual(self.successResultOf(d), "winner")
-        self.assertEqual(self._descriptions, ["tor->relay:tcp:relay:1234"])
-
-    def _endpoint_from_hint_obj(self, hint, _tor, _reactor):
-        if isinstance(hint, DirectTCPV1Hint):
-            if hint.hostname == "unavailable":
-                return None
-            return hint.hostname
-        return None
-
-    @ensureDeferred
-    async def test_wait_for_relay(self):
-        clock = task.Clock()
-        s = transit.TransitSender("", reactor=clock, no_listen=True)
-        s.set_transit_key(b"key")
-        hints = await s.get_connection_hints()
-        del hints
-        s.add_connection_hints(
-            [DIRECT_HINT_JSON, UNRECOGNIZED_HINT_JSON, RELAY_HINT_JSON])
-        s._start_connector = self._start_connector
-
-        with mock.patch("wormhole.transit.endpoint_from_hint_obj",
-                        self._endpoint_from_hint_obj):
-            d = s.connect()
-            self.assertNoResult(d)
-            # the direct connectors are tried right away, but the relay
-            # connectors are stalled for a few seconds
-            self.assertEqual(self._connectors, ["direct"])
-
-            clock.advance(s.RELAY_DELAY + 1.0)
-            self.assertEqual(self._connectors, ["direct", "relay"])
-
-            self._waiters[0].callback("winner")
-            self.assertEqual(self.successResultOf(d), "winner")
-
-    @ensureDeferred
-    async def test_priorities(self):
-        clock = task.Clock()
-        s = transit.TransitSender("", reactor=clock, no_listen=True)
-        s.set_transit_key(b"key")
-        hints = await s.get_connection_hints()
-        del hints
-        s.add_connection_hints([
-            {
-                "type":
-                "relay-v1",
-                "hints": [{
-                    "type": "direct-tcp-v1",
-                    "hostname": "relay",
-                    "port": 1234
-                }]
-            },
-            {
+@ensureDeferred
+async def test_priorities():
+    clock = task.Clock()
+    fc = FakeConnector()
+    s = transit.TransitSender("", reactor=clock, no_listen=True)
+    s.set_transit_key(b"key")
+    hints = await s.get_connection_hints()
+    del hints
+    s.add_connection_hints([
+        {
+            "type":
+            "relay-v1",
+            "hints": [{
                 "type": "direct-tcp-v1",
-                "hostname": "direct",
+                "hostname": "relay",
                 "port": 1234
-            },
-            {
-                "type":
-                "relay-v1",
-                "hints": [{
-                    "type": "direct-tcp-v1",
-                    "priority": 2.0,
-                    "hostname": "relay2",
-                    "port": 1234
-                }, {
-                    "type": "direct-tcp-v1",
-                    "priority": 3.0,
-                    "hostname": "relay3",
-                    "port": 1234
-                }]
-            },
-            {
-                "type":
-                "relay-v1",
-                "hints": [{
-                    "type": "direct-tcp-v1",
-                    "priority": 2.0,
-                    "hostname": "relay4",
-                    "port": 1234
-                }]
-            },
-        ])
-        s._start_connector = self._start_connector
+            }]
+        },
+        {
+            "type": "direct-tcp-v1",
+            "hostname": "direct",
+            "port": 1234
+        },
+        {
+            "type":
+            "relay-v1",
+            "hints": [{
+                "type": "direct-tcp-v1",
+                "priority": 2.0,
+                "hostname": "relay2",
+                "port": 1234
+            }, {
+                "type": "direct-tcp-v1",
+                "priority": 3.0,
+                "hostname": "relay3",
+                "port": 1234
+            }]
+        },
+        {
+            "type":
+            "relay-v1",
+            "hints": [{
+                "type": "direct-tcp-v1",
+                "priority": 2.0,
+                "hostname": "relay4",
+                "port": 1234
+            }]
+        },
+    ])
+    s._start_connector = fc._start_connector
 
-        with mock.patch("wormhole.transit.endpoint_from_hint_obj",
-                        self._endpoint_from_hint_obj):
-            d = s.connect()
-            self.assertNoResult(d)
-            # direct connector should be used first, then the priority=3.0 relay,
-            # then the two 2.0 relays, then the (default) 0.0 relay
+    with mock.patch("wormhole.transit.endpoint_from_hint_obj",
+                    _endpoint_from_hint_obj):
+        d = s.connect()
+        assert not d.called
+        # direct connector should be used first, then the priority=3.0 relay,
+        # then the two 2.0 relays, then the (default) 0.0 relay
 
-            self.assertEqual(self._connectors, ["direct"])
+        assert fc._connectors == ["direct"]
 
-            clock.advance(s.RELAY_DELAY + 1.0)
-            self.assertEqual(self._connectors, ["direct", "relay3"])
+        clock.advance(s.RELAY_DELAY + 1.0)
+        assert fc._connectors == ["direct", "relay3"]
 
-            clock.advance(s.RELAY_DELAY)
-            self.assertIn(self._connectors,
-                          (["direct", "relay3", "relay2", "relay4"],
-                           ["direct", "relay3", "relay4", "relay2"]))
+        clock.advance(s.RELAY_DELAY)
+        assert fc._connectors in \
+                      (["direct", "relay3", "relay2", "relay4"],
+                       ["direct", "relay3", "relay4", "relay2"])
 
-            clock.advance(s.RELAY_DELAY)
-            self.assertIn(self._connectors,
-                          (["direct", "relay3", "relay2", "relay4", "relay"],
-                           ["direct", "relay3", "relay4", "relay2", "relay"]))
+        clock.advance(s.RELAY_DELAY)
+        assert fc._connectors in \
+                      (["direct", "relay3", "relay2", "relay4", "relay"],
+                       ["direct", "relay3", "relay4", "relay2", "relay"])
 
-            self._waiters[0].callback("winner")
-            self.assertEqual(self.successResultOf(d), "winner")
-
-    @ensureDeferred
-    async def test_no_direct_hints(self):
-        clock = task.Clock()
-        s = transit.TransitSender("", reactor=clock, no_listen=True)
-        s.set_transit_key(b"key")
-        hints = await s.get_connection_hints()  # start the listener
-        del hints
-        # include hints that can't be turned into an endpoint at runtime
-        s.add_connection_hints([
-            UNRECOGNIZED_HINT_JSON, UNAVAILABLE_HINT_JSON, RELAY_HINT2_JSON,
-            UNAVAILABLE_RELAY_HINT_JSON
-        ])
-        s._start_connector = self._start_connector
-
-        with mock.patch("wormhole.transit.endpoint_from_hint_obj",
-                        self._endpoint_from_hint_obj):
-            d = s.connect()
-            self.assertNoResult(d)
-            # since there are no usable direct hints, the relay connector will
-            # only be stalled for 0 seconds
-            self.assertEqual(self._connectors, [])
-
-            clock.advance(0)
-            self.assertEqual(self._connectors, ["relay"])
-
-            self._waiters[0].callback("winner")
-            self.assertEqual(self.successResultOf(d), "winner")
-
-    @ensureDeferred
-    async def test_no_contenders(self):
-        clock = task.Clock()
-        s = transit.TransitSender("", reactor=clock, no_listen=True)
-        s.set_transit_key(b"key")
-        hints = await s.get_connection_hints()  # start the listener
-        del hints
-        s.add_connection_hints([])  # no hints at all
-        s._start_connector = self._start_connector
-
-        with mock.patch("wormhole.transit.endpoint_from_hint_obj",
-                        self._endpoint_from_hint_obj):
-            d = s.connect()
-            f = self.failureResultOf(d, transit.TransitError)
-            self.assertEqual(str(f.value), "No contenders for connection")
+        fc._waiters[0].callback("winner")
+        assert await d == "winner"
 
 
-class RelayHandshake(unittest.TestCase):
-    def old_build_relay_handshake(self, key):
-        token = HKDF(key, 32, CTXinfo=b"transit_relay_token")
-        return (token, b"please relay " + hexlify(token) + b"\n")
+@ensureDeferred
+async def test_no_direct_hints():
+    clock = task.Clock()
+    fc = FakeConnector()
+    s = transit.TransitSender("", reactor=clock, no_listen=True)
+    s.set_transit_key(b"key")
+    hints = await s.get_connection_hints()  # start the listener
+    del hints
+    # include hints that can't be turned into an endpoint at runtime
+    s.add_connection_hints([
+        UNRECOGNIZED_HINT_JSON, UNAVAILABLE_HINT_JSON, RELAY_HINT2_JSON,
+        UNAVAILABLE_RELAY_HINT_JSON
+    ])
+    s._start_connector = fc._start_connector
 
-    def test_old(self):
-        key = b"\x00"
-        token, old_handshake = self.old_build_relay_handshake(key)
-        tc = transit_server.TransitConnection()
-        tc.factory = mock.Mock()
-        tc.factory.connection_got_token = mock.Mock()
-        tc.transport = mock.Mock()
-        tc.connectionMade()
-        tc._state.please_relay = mock.Mock()
-        tc._state.please_relay_for_side = mock.Mock()
-        tc.dataReceived(old_handshake[:-1])
-        self.assertEqual(tc._state.please_relay.mock_calls, [])
-        tc.dataReceived(old_handshake[-1:])
-        self.assertEqual(tc._state.please_relay.mock_calls,
-                         [mock.call(hexlify(token))])
-        self.assertEqual(tc._state.please_relay_for_side.mock_calls, [])
+    with mock.patch("wormhole.transit.endpoint_from_hint_obj",
+                    _endpoint_from_hint_obj):
+        d = s.connect()
+        assert not d.called
+        # since there are no usable direct hints, the relay connector will
+        # only be stalled for 0 seconds
+        assert fc._connectors == []
 
-    def test_new(self):
-        c = transit.Common(None)
-        c.set_transit_key(b"\x00")
-        new_handshake = c._build_relay_handshake()
-        token, old_handshake = self.old_build_relay_handshake(b"\x00")
+        clock.advance(0)
+        assert fc._connectors == ["relay"]
 
-        tc = transit_server.TransitConnection()
-        tc.factory = mock.Mock()
-        tc.transport = mock.Mock()
-        tc.connectionMade()
-        tc._state._real_register_token_for_side = m = mock.Mock()
-        tc.dataReceived(new_handshake[:-1])
-        self.assertEqual(m.mock_calls, [])
-        tc.dataReceived(new_handshake[-1:])
-        self.assertEqual(
-            m.mock_calls,
-            [mock.call(hexlify(token), c._side.encode("ascii"))])
+        fc._waiters[0].callback("winner")
+        assert await d == "winner"
 
 
-class Full(ServerBase, unittest.TestCase):
-    def doBoth(self, d1, d2):
-        return gatherResults([d1, d2], True)
+@ensureDeferred
+async def test_no_contenders():
+    clock = task.Clock()
+    fc = FakeConnector()
+    s = transit.TransitSender("", reactor=clock, no_listen=True)
+    s.set_transit_key(b"key")
+    hints = await s.get_connection_hints()  # start the listener
+    del hints
+    s.add_connection_hints([])  # no hints at all
+    s._start_connector = fc._start_connector
 
-    @ensureDeferred
-    async def test_direct(self):
-        KEY = b"k" * 32
-        s = transit.TransitSender(None)
-        r = transit.TransitReceiver(None)
+    with mock.patch("wormhole.transit.endpoint_from_hint_obj",
+                    _endpoint_from_hint_obj):
+        d = s.connect()
+        with pytest.raises(transit.TransitError) as f:
+            await d
+        assert str(f.value) == "No contenders for connection"
 
-        s.set_transit_key(KEY)
-        r.set_transit_key(KEY)
 
-        # TODO: this sometimes fails with EADDRINUSE
-        shints = await s.get_connection_hints()
-        rhints = await r.get_connection_hints()
+def old_build_relay_handshake(key):
+    token = HKDF(key, 32, CTXinfo=b"transit_relay_token")
+    return (token, b"please relay " + hexlify(token) + b"\n")
 
-        s.add_connection_hints(rhints)
-        r.add_connection_hints(shints)
 
-        (x, y) = await self.doBoth(s.connect(), r.connect())
-        self.assertIsInstance(x, transit.Connection)
-        self.assertIsInstance(y, transit.Connection)
 
-        d = y.receive_record()
+def test_old():
+    key = b"\x00"
+    token, old_handshake = old_build_relay_handshake(key)
+    tc = transit_server.TransitConnection()
+    tc.factory = mock.Mock()
+    tc.factory.connection_got_token = mock.Mock()
+    tc.transport = mock.Mock()
+    tc.connectionMade()
+    tc._state.please_relay = mock.Mock()
+    tc._state.please_relay_for_side = mock.Mock()
+    tc.dataReceived(old_handshake[:-1])
+    assert tc._state.please_relay.mock_calls == []
+    tc.dataReceived(old_handshake[-1:])
+    assert tc._state.please_relay.mock_calls == \
+                     [mock.call(hexlify(token))]
+    assert tc._state.please_relay_for_side.mock_calls == []
 
-        x.send_record(b"record1")
-        r = await d
-        self.assertEqual(r, b"record1")
 
-        x.close()
-        y.close()
+def test_new():
+    c = transit.Common(None)
+    c.set_transit_key(b"\x00")
+    new_handshake = c._build_relay_handshake()
+    token, old_handshake = old_build_relay_handshake(b"\x00")
 
-    @ensureDeferred
-    async def test_relay(self):
-        KEY = b"k" * 32
-        s = transit.TransitSender(self.transit, no_listen=True)
-        r = transit.TransitReceiver(self.transit, no_listen=True)
+    tc = transit_server.TransitConnection()
+    tc.factory = mock.Mock()
+    tc.transport = mock.Mock()
+    tc.connectionMade()
+    tc._state._real_register_token_for_side = m = mock.Mock()
+    tc.dataReceived(new_handshake[:-1])
+    assert m.mock_calls == []
+    tc.dataReceived(new_handshake[-1:])
+    assert m.mock_calls == \
+        [mock.call(hexlify(token), c._side.encode("ascii"))]
 
-        s.set_transit_key(KEY)
-        r.set_transit_key(KEY)
 
-        shints = await s.get_connection_hints()
-        rhints = await r.get_connection_hints()
+async def doBoth(d1, d2):
+    return await gatherResults([d1, d2], True)
 
-        s.add_connection_hints(rhints)
-        r.add_connection_hints(shints)
 
-        (x, y) = await self.doBoth(s.connect(), r.connect())
-        self.assertIsInstance(x, transit.Connection)
-        self.assertIsInstance(y, transit.Connection)
+@ensureDeferred
+async def test_direct():
+    KEY = b"k" * 32
+    s = transit.TransitSender(None)
+    r = transit.TransitReceiver(None)
 
-        d = y.receive_record()
+    s.set_transit_key(KEY)
+    r.set_transit_key(KEY)
 
-        x.send_record(b"record1")
-        r = await d
-        self.assertEqual(r, b"record1")
+    # TODO: this sometimes fails with EADDRINUSE
+    shints = await s.get_connection_hints()
+    rhints = await r.get_connection_hints()
 
-        x.close()
-        y.close()
+    s.add_connection_hints(rhints)
+    r.add_connection_hints(shints)
+
+    (x, y) = await doBoth(s.connect(), r.connect())
+    assert isinstance(x, transit.Connection)
+    assert isinstance(y, transit.Connection)
+
+    d = y.receive_record()
+
+    x.send_record(b"record1")
+    r = await d
+    assert r == b"record1"
+
+    x.close()
+    y.close()
+
+
+@ensureDeferred
+async def test_relay(transit_relay):
+    KEY = b"k" * 32
+    s = transit.TransitSender(transit_relay, no_listen=True)
+    r = transit.TransitReceiver(transit_relay, no_listen=True)
+
+    s.set_transit_key(KEY)
+    r.set_transit_key(KEY)
+
+    shints = await s.get_connection_hints()
+    rhints = await r.get_connection_hints()
+
+    s.add_connection_hints(rhints)
+    r.add_connection_hints(shints)
+
+    (x, y) = await doBoth(s.connect(), r.connect())
+    assert isinstance(x, transit.Connection)
+    assert isinstance(y, transit.Connection)
+
+    d = y.receive_record()
+
+    x.send_record(b"record1")
+    r = await d
+    assert r == b"record1"
+
+    x.close()
+    y.close()

--- a/src/wormhole/test/test_util.py
+++ b/src/wormhole/test/test_util.py
@@ -4,8 +4,6 @@ from unittest import mock
 
 from .. import util
 
-import pytest
-
 def test_to_bytes():
     b = util.to_bytes("abc")
     assert isinstance(b, type(b""))
@@ -54,6 +52,6 @@ def test_no_statvfs():
     # the one platform that the code under test was supposed to help with
     try:
         with mock.patch("os.statvfs", side_effect=AttributeError()):
-            assert util.estimate_free_space(".") == None
+            assert util.estimate_free_space(".") is None
     except AttributeError:  # raised by mock.get_original()
         pass

--- a/src/wormhole/test/test_util.py
+++ b/src/wormhole/test/test_util.py
@@ -1,63 +1,59 @@
 import unicodedata
 
-from twisted.trial import unittest
-
 from unittest import mock
 
 from .. import util
 
+import pytest
 
-class Utils(unittest.TestCase):
-    def test_to_bytes(self):
-        b = util.to_bytes("abc")
-        self.assertIsInstance(b, type(b""))
-        self.assertEqual(b, b"abc")
+def test_to_bytes():
+    b = util.to_bytes("abc")
+    assert isinstance(b, type(b""))
+    assert b == b"abc"
 
-        A = unicodedata.lookup("LATIN SMALL LETTER A WITH DIAERESIS")
-        b = util.to_bytes(A + "bc")
-        self.assertIsInstance(b, type(b""))
-        self.assertEqual(b, b"\xc3\xa4\x62\x63")
+    A = unicodedata.lookup("LATIN SMALL LETTER A WITH DIAERESIS")
+    b = util.to_bytes(A + "bc")
+    assert isinstance(b, type(b""))
+    assert b == b"\xc3\xa4\x62\x63"
 
-    def test_bytes_to_hexstr(self):
-        b = b"\x00\x45\x91\xfe\xff"
-        hexstr = util.bytes_to_hexstr(b)
-        self.assertIsInstance(hexstr, type(""))
-        self.assertEqual(hexstr, "004591feff")
+def test_bytes_to_hexstr():
+    b = b"\x00\x45\x91\xfe\xff"
+    hexstr = util.bytes_to_hexstr(b)
+    assert isinstance(hexstr, type(""))
+    assert hexstr == "004591feff"
 
-    def test_hexstr_to_bytes(self):
-        hexstr = "004591feff"
-        b = util.hexstr_to_bytes(hexstr)
-        hexstr = util.bytes_to_hexstr(b)
-        self.assertIsInstance(b, type(b""))
-        self.assertEqual(b, b"\x00\x45\x91\xfe\xff")
+def test_hexstr_to_bytes():
+    hexstr = "004591feff"
+    b = util.hexstr_to_bytes(hexstr)
+    hexstr = util.bytes_to_hexstr(b)
+    assert isinstance(b, type(b""))
+    assert b == b"\x00\x45\x91\xfe\xff"
 
-    def test_dict_to_bytes(self):
-        d = {"a": "b"}
-        b = util.dict_to_bytes(d)
-        self.assertIsInstance(b, type(b""))
-        self.assertEqual(b, b'{"a": "b"}')
+def test_dict_to_bytes():
+    d = {"a": "b"}
+    b = util.dict_to_bytes(d)
+    assert isinstance(b, type(b""))
+    assert b == b'{"a": "b"}'
 
-    def test_bytes_to_dict(self):
-        b = b'{"a": "b", "c": 2}'
-        d = util.bytes_to_dict(b)
-        self.assertIsInstance(d, dict)
-        self.assertEqual(d, {"a": "b", "c": 2})
+def test_bytes_to_dict():
+    b = b'{"a": "b", "c": 2}'
+    d = util.bytes_to_dict(b)
+    assert isinstance(d, dict)
+    assert d == {"a": "b", "c": 2}
 
 
-class Space(unittest.TestCase):
-    def test_free_space(self):
-        free = util.estimate_free_space(".")
-        self.assert_(
-            isinstance(free, (int, type(None))), repr(free))
-        # some platforms (I think the VMs used by travis are in this
-        # category) return 0, and windows will return None, so don't assert
-        # anything more specific about the return value
+def test_free_space():
+    free = util.estimate_free_space(".")
+    assert isinstance(free, (int, type(None))), repr(free)
+    # some platforms (I think the VMs used by travis are in this
+    # category) return 0, and windows will return None, so don't assert
+    # anything more specific about the return value
 
-    def test_no_statvfs(self):
-        # this mock.patch fails on windows, which is sad because windows is
-        # the one platform that the code under test was supposed to help with
-        try:
-            with mock.patch("os.statvfs", side_effect=AttributeError()):
-                self.assertEqual(util.estimate_free_space("."), None)
-        except AttributeError:  # raised by mock.get_original()
-            pass
+def test_no_statvfs():
+    # this mock.patch fails on windows, which is sad because windows is
+    # the one platform that the code under test was supposed to help with
+    try:
+        with mock.patch("os.statvfs", side_effect=AttributeError()):
+            assert util.estimate_free_space(".") == None
+    except AttributeError:  # raised by mock.get_original()
+        pass

--- a/src/wormhole/test/test_util_attrs_zope.py
+++ b/src/wormhole/test/test_util_attrs_zope.py
@@ -1,9 +1,9 @@
 import zope.interface
-from twisted.trial import unittest
 from attr import Attribute
 from attr._make import NOTHING
 from wormhole.util import provides
 
+import pytest
 
 class IFoo(zope.interface.Interface):
     """
@@ -32,42 +32,37 @@ def simple_attr(name):
     )
 
 
-class TestProvides(unittest.TestCase):
+def test_success():
     """
-    Tests for `provides`.
+    Nothing happens if value provides requested interface.
     """
 
-    def test_success(self):
-        """
-        Nothing happens if value provides requested interface.
-        """
+    @zope.interface.implementer(IFoo)
+    class C(object):
+        def f(self):
+            pass
 
-        @zope.interface.implementer(IFoo)
-        class C(object):
-            def f(self):
-                pass
+    v = provides(IFoo)
+    v(None, simple_attr("x"), C())
 
-        v = provides(IFoo)
-        v(None, simple_attr("x"), C())
+def test_fail():
+    """
+    Raises `TypeError` if interfaces isn't provided by value.
+    """
+    value = object()
+    a = simple_attr("x")
 
-    def test_fail(self):
-        """
-        Raises `TypeError` if interfaces isn't provided by value.
-        """
-        value = object()
-        a = simple_attr("x")
+    v = provides(IFoo)
+    with pytest.raises(TypeError):
+        v(None, a, value)
 
-        v = provides(IFoo)
-        with self.assertRaises(TypeError):
-            v(None, a, value)
-
-    def test_repr(self):
-        """
-        Returned validator has a useful `__repr__`.
-        """
-        v = provides(IFoo)
-        assert (
-            "<provides validator for interface {interface!r}>".format(
-                interface=IFoo
-            )
-        ) == repr(v)
+def test_repr():
+    """
+    Returned validator has a useful `__repr__`.
+    """
+    v = provides(IFoo)
+    assert (
+        "<provides validator for interface {interface!r}>".format(
+            interface=IFoo
+        )
+    ) == repr(v)

--- a/src/wormhole/test/test_wordlist.py
+++ b/src/wormhole/test/test_wordlist.py
@@ -1,38 +1,29 @@
-from twisted.trial import unittest
-
 from unittest import mock
 
 from .._wordlist import PGPWordList
 
+import pytest
 
-class Completions(unittest.TestCase):
-    def test_completions(self):
-        wl = PGPWordList()
-        gc = wl.get_completions
-        self.assertEqual(gc("ar", 2), {"armistice-", "article-"})
-        self.assertEqual(gc("armis", 2), {"armistice-"})
-        self.assertEqual(gc("armistice", 2), {"armistice-"})
-        lots = gc("armistice-", 2)
-        self.assertEqual(len(lots), 256, lots)
-        first = list(lots)[0]
-        self.assert_(first.startswith("armistice-"), first)
-        self.assertEqual(
-            gc("armistice-ba", 2), {
-                "armistice-baboon", "armistice-backfield",
-                "armistice-backward", "armistice-banjo"
-            })
-        self.assertEqual(
-            gc("armistice-ba", 3), {
-                "armistice-baboon-", "armistice-backfield-",
-                "armistice-backward-", "armistice-banjo-"
-            })
-        self.assertEqual(gc("armistice-baboon", 2), {"armistice-baboon"})
-        self.assertEqual(gc("armistice-baboon", 3), {"armistice-baboon-"})
-        self.assertEqual(gc("armistice-baboon", 4), {"armistice-baboon-"})
+def test_completions():
+    wl = PGPWordList()
+    gc = wl.get_completions
+    assert gc("ar", 2) == {"armistice-", "article-"}
+    assert gc("armis", 2) == {"armistice-"}
+    assert gc("armistice", 2) == {"armistice-"}
+    lots = gc("armistice-", 2)
+    assert len(lots) == 256
+    first = list(lots)[0]
+    assert first.startswith("armistice-")
+    assert gc("armistice-ba", 2) == { "armistice-baboon", "armistice-backfield",
+            "armistice-backward", "armistice-banjo" }
+    assert gc("armistice-ba", 3) == { "armistice-baboon-", "armistice-backfield-",
+        "armistice-backward-", "armistice-banjo-" }
+    assert gc("armistice-baboon", 2) == {"armistice-baboon"}
+    assert gc("armistice-baboon", 3) == {"armistice-baboon-"}
+    assert gc("armistice-baboon", 4) == {"armistice-baboon-"}
 
 
-class Choose(unittest.TestCase):
-    def test_choose_words(self):
-        wl = PGPWordList()
-        with mock.patch("os.urandom", side_effect=[b"\x04", b"\x10"]):
-            self.assertEqual(wl.choose_words(2), "alkali-assume")
+def test_choose_words():
+    wl = PGPWordList()
+    with mock.patch("os.urandom", side_effect=[b"\x04", b"\x10"]):
+        assert wl.choose_words(2) == "alkali-assume"

--- a/src/wormhole/test/test_wordlist.py
+++ b/src/wormhole/test/test_wordlist.py
@@ -2,8 +2,6 @@ from unittest import mock
 
 from .._wordlist import PGPWordList
 
-import pytest
-
 def test_completions():
     wl = PGPWordList()
     gc = wl.get_completions

--- a/src/wormhole/test/test_wormhole.py
+++ b/src/wormhole/test/test_wormhole.py
@@ -3,7 +3,6 @@ import re
 
 from twisted.internet.defer import gatherResults
 from twisted.internet.error import ConnectionRefusedError
-from twisted.trial import unittest
 
 from unittest import mock
 from pytest_twisted import ensureDeferred

--- a/src/wormhole/test/test_wormhole.py
+++ b/src/wormhole/test/test_wormhole.py
@@ -14,7 +14,7 @@ from ..errors import (KeyFormatError, LonelyError, NoKeyError,
                       WrongPasswordError)
 from ..eventual import EventualQueue
 from ..transit import allocate_tcp_port
-from .common import ServerBase, poll_until
+from .common import poll_until
 import pytest
 
 APPID = "appid"

--- a/src/wormhole/test/test_wormhole.py
+++ b/src/wormhole/test/test_wormhole.py
@@ -86,7 +86,7 @@ async def test_delegated(reactor, mailbox):
 
     key1 = w1.derive_key("purpose", 16)
     assert len(key1) == 16
-    assert type(key1) == type(b"")
+    assert type(key1) is type(b"")
     with pytest.raises(TypeError):
         w1.derive_key(b"not unicode", 16)
     with pytest.raises(TypeError):
@@ -97,7 +97,7 @@ async def test_delegated(reactor, mailbox):
 
 
 @ensureDeferred
-async def test_allocate_code(reactor, mailbox):
+async def test_delegate_allocate_code(reactor, mailbox):
     dg = Delegate()
     w1 = wormhole.create(APPID, mailbox.url, reactor, delegate=dg)
     w1.allocate_code()
@@ -106,7 +106,7 @@ async def test_allocate_code(reactor, mailbox):
 
 
 @ensureDeferred
-async def test_input_code(reactor, mailbox):
+async def test_delegate_input_code(reactor, mailbox):
     dg = Delegate()
     w1 = wormhole.create(APPID, mailbox.url, reactor, delegate=dg)
     h = w1.input_code()
@@ -163,7 +163,7 @@ async def test_basic(reactor, mailbox):
 
     key1 = w1.derive_key("purpose", 16)
     assert len(key1) == 16
-    assert type(key1) == type(b"")
+    assert type(key1) is type(b"")
     with pytest.raises(TypeError):
         w1.derive_key(b"not unicode", 16)
     with pytest.raises(TypeError):
@@ -584,7 +584,7 @@ async def test_verifier(reactor, mailbox):
     w2.set_code(code)
     v1 = await w1.get_verifier()  # early
     v2 = await w2.get_verifier()
-    assert type(v1) == type(b"")
+    assert type(v1) is type(b"")
     assert v1 == v2
     w1.send_message(b"data1")
     w2.send_message(b"data2")

--- a/src/wormhole/test/test_wormhole.py
+++ b/src/wormhole/test/test_wormhole.py
@@ -1,7 +1,6 @@
 import io
 import re
 
-from twisted.internet import reactor
 from twisted.internet.defer import gatherResults
 from twisted.internet.error import ConnectionRefusedError
 from twisted.trial import unittest
@@ -16,6 +15,7 @@ from ..errors import (KeyFormatError, LonelyError, NoKeyError,
 from ..eventual import EventualQueue
 from ..transit import allocate_tcp_port
 from .common import ServerBase, poll_until
+import pytest
 
 APPID = "appid"
 
@@ -63,521 +63,589 @@ class Delegate:
         self.closed = result
 
 
-class Delegated(ServerBase, unittest.TestCase):
-    @ensureDeferred
-    async def test_delegated(self):
-        dg = Delegate()
-        w1 = wormhole.create(APPID, self.relayurl, reactor, delegate=dg)
-        # w1.debug_set_trace("W1")
-        with self.assertRaises(NoKeyError):
-            w1.derive_key("purpose", 12)
-        w1.set_code("1-abc")
-        self.assertEqual(dg.code, "1-abc")
-        w2 = wormhole.create(APPID, self.relayurl, reactor)
-        w2.set_code(dg.code)
-        await poll_until(lambda: dg.key is not None)
-        await poll_until(lambda: dg.verifier is not None)
-        await poll_until(lambda: dg.versions is not None)
+@ensureDeferred
+async def test_delegated(reactor, mailbox):
+    dg = Delegate()
+    w1 = wormhole.create(APPID, mailbox.url, reactor, delegate=dg)
+    # w1.debug_set_trace("W1")
+    with pytest.raises(NoKeyError):
+        w1.derive_key("purpose", 12)
+    w1.set_code("1-abc")
+    assert dg.code == "1-abc"
+    w2 = wormhole.create(APPID, mailbox.url, reactor)
+    w2.set_code(dg.code)
+    await poll_until(lambda: dg.key is not None)
+    await poll_until(lambda: dg.verifier is not None)
+    await poll_until(lambda: dg.versions is not None)
 
-        w1.send_message(b"ping")
-        got = await w2.get_message()
-        self.assertEqual(got, b"ping")
-        w2.send_message(b"pong")
-        await poll_until(lambda: dg.messages)
-        self.assertEqual(dg.messages[0], b"pong")
+    w1.send_message(b"ping")
+    got = await w2.get_message()
+    assert got == b"ping"
+    w2.send_message(b"pong")
+    await poll_until(lambda: dg.messages)
+    assert dg.messages[0] == b"pong"
 
-        key1 = w1.derive_key("purpose", 16)
-        self.assertEqual(len(key1), 16)
-        self.assertEqual(type(key1), type(b""))
-        with self.assertRaises(TypeError):
-            w1.derive_key(b"not unicode", 16)
-        with self.assertRaises(TypeError):
-            w1.derive_key(12345, 16)
+    key1 = w1.derive_key("purpose", 16)
+    assert len(key1) == 16
+    assert type(key1) == type(b"")
+    with pytest.raises(TypeError):
+        w1.derive_key(b"not unicode", 16)
+    with pytest.raises(TypeError):
+        w1.derive_key(12345, 16)
 
-        w1.close()
-        await w2.close()
-
-    @ensureDeferred
-    async def test_allocate_code(self):
-        dg = Delegate()
-        w1 = wormhole.create(APPID, self.relayurl, reactor, delegate=dg)
-        w1.allocate_code()
-        await poll_until(lambda: dg.code is not None)
-        w1.close()
-
-    @ensureDeferred
-    async def test_input_code(self):
-        dg = Delegate()
-        w1 = wormhole.create(APPID, self.relayurl, reactor, delegate=dg)
-        h = w1.input_code()
-        h.choose_nameplate("123")
-        h.choose_words("purple-elephant")
-        await poll_until(lambda: dg.code is not None)
-        w1.close()
+    w1.close()
+    await w2.close()
 
 
-class Wormholes(ServerBase, unittest.TestCase):
-    # integration test, with a real server
+@ensureDeferred
+async def test_allocate_code(reactor, mailbox):
+    dg = Delegate()
+    w1 = wormhole.create(APPID, mailbox.url, reactor, delegate=dg)
+    w1.allocate_code()
+    await poll_until(lambda: dg.code is not None)
+    w1.close()
 
-    @ensureDeferred
-    async def setUp(self):
-        # test_welcome wants to see [current_cli_version]
-        await self._setup_relay(None, advertise_version="advertised.version")
 
-    def doBoth(self, d1, d2):
-        return gatherResults([d1, d2], True)
+@ensureDeferred
+async def test_input_code(reactor, mailbox):
+    dg = Delegate()
+    w1 = wormhole.create(APPID, mailbox.url, reactor, delegate=dg)
+    h = w1.input_code()
+    h.choose_nameplate("123")
+    h.choose_words("purple-elephant")
+    await poll_until(lambda: dg.code is not None)
+    w1.close()
 
-    @ensureDeferred
-    async def test_allocate_default(self):
-        w1 = wormhole.create(APPID, self.relayurl, reactor)
-        w1.allocate_code()
-        code = await w1.get_code()
-        mo = re.search(r"^\d+-\w+-\w+$", code)
-        self.assert_(mo, code)
-        # w.close() fails because we closed before connecting
-        await self.assertFailure(w1.close(), LonelyError)
 
-    @ensureDeferred
-    async def test_allocate_more_words(self):
-        w1 = wormhole.create(APPID, self.relayurl, reactor)
-        w1.allocate_code(3)
-        code = await w1.get_code()
-        mo = re.search(r"^\d+-\w+-\w+-\w+$", code)
-        self.assert_(mo, code)
-        await self.assertFailure(w1.close(), LonelyError)
+# integration test, with a real server
 
-    @ensureDeferred
-    async def test_basic(self):
-        w1 = wormhole.create(APPID, self.relayurl, reactor)
-        # w1.debug_set_trace("W1")
-        with self.assertRaises(NoKeyError):
-            w1.derive_key("purpose", 12)
+async def doBoth(d1, d2):
+    return await gatherResults([d1, d2], True)
 
-        w2 = wormhole.create(APPID, self.relayurl, reactor)
-        # w2.debug_set_trace("  W2")
-        w1.allocate_code()
-        code = await w1.get_code()
-        w2.set_code(code)
 
+@ensureDeferred
+async def test_allocate_default(reactor, mailbox):
+    w1 = wormhole.create(APPID, mailbox.url, reactor)
+    w1.allocate_code()
+    code = await w1.get_code()
+    mo = re.search(r"^\d+-\w+-\w+$", code)
+    assert mo, code
+    # w.close() fails because we closed before connecting
+    with pytest.raises(LonelyError):
+        await w1.close()
+
+
+@ensureDeferred
+async def test_allocate_more_words(reactor, mailbox):
+    w1 = wormhole.create(APPID, mailbox.url, reactor)
+    w1.allocate_code(3)
+    code = await w1.get_code()
+    mo = re.search(r"^\d+-\w+-\w+-\w+$", code)
+    assert mo, code
+    with pytest.raises(LonelyError):
+        await w1.close()
+
+
+@ensureDeferred
+async def test_basic(reactor, mailbox):
+    w1 = wormhole.create(APPID, mailbox.url, reactor)
+    # w1.debug_set_trace("W1")
+    with pytest.raises(NoKeyError):
+        w1.derive_key("purpose", 12)
+
+    w2 = wormhole.create(APPID, mailbox.url, reactor)
+    # w2.debug_set_trace("  W2")
+    w1.allocate_code()
+    code = await w1.get_code()
+    w2.set_code(code)
+
+    await w1.get_unverified_key()
+    await w2.get_unverified_key()
+
+    key1 = w1.derive_key("purpose", 16)
+    assert len(key1) == 16
+    assert type(key1) == type(b"")
+    with pytest.raises(TypeError):
+        w1.derive_key(b"not unicode", 16)
+    with pytest.raises(TypeError):
+        w1.derive_key(12345, 16)
+
+    verifier1 = await w1.get_verifier()
+    verifier2 = await w2.get_verifier()
+    assert verifier1 == verifier2
+
+    versions1 = await w1.get_versions()
+    versions2 = await w2.get_versions()
+    # app-versions are exercised properly in test_versions, this just
+    # tests the defaults
+    assert versions1 == {}
+    assert versions2 == {}
+
+    w1.send_message(b"data1")
+    w2.send_message(b"data2")
+    dataX = await w1.get_message()
+    dataY = await w2.get_message()
+    assert dataX == b"data2"
+    assert dataY == b"data1"
+
+    versions1_again = await w1.get_versions()
+    assert versions1 == versions1_again
+
+    c1 = await w1.close()
+    assert c1 == "happy"
+    c2 = await w2.close()
+    assert c2 == "happy"
+
+
+@ensureDeferred
+async def test_get_code_early(reactor, mailbox):
+    eq = EventualQueue(reactor)
+    w1 = wormhole.create(APPID, mailbox.url, reactor, _eventual_queue=eq)
+    d = w1.get_code()
+    w1.set_code("1-abc")
+    await eq.flush()
+    code = await d
+    assert code == "1-abc"
+    with pytest.raises(LonelyError):
+        await w1.close()
+
+
+@ensureDeferred
+async def test_get_code_late(reactor, mailbox):
+    eq = EventualQueue(reactor)
+    w1 = wormhole.create(APPID, mailbox.url, reactor, _eventual_queue=eq)
+    w1.set_code("1-abc")
+    d = w1.get_code()
+    await eq.flush()
+    code = await d
+    assert code == "1-abc"
+    with pytest.raises(LonelyError):
+        await w1.close()
+
+
+@ensureDeferred
+async def test_same_message(reactor, mailbox):
+    # the two sides use random nonces for their messages, so it's ok for
+    # both to try and send the same body: they'll result in distinct
+    # encrypted messages
+    w1 = wormhole.create(APPID, mailbox.url, reactor)
+    w2 = wormhole.create(APPID, mailbox.url, reactor)
+    w1.allocate_code()
+    code = await w1.get_code()
+    w2.set_code(code)
+    w1.send_message(b"data")
+    w2.send_message(b"data")
+    dataX = await w1.get_message()
+    dataY = await w2.get_message()
+    assert dataX == b"data"
+    assert dataY == b"data"
+    await w1.close()
+    await w2.close()
+
+
+@ensureDeferred
+async def test_interleaved(reactor, mailbox):
+    w1 = wormhole.create(APPID, mailbox.url, reactor)
+    w2 = wormhole.create(APPID, mailbox.url, reactor)
+    w1.allocate_code()
+    code = await w1.get_code()
+    w2.set_code(code)
+    w1.send_message(b"data1")
+    dataY = await w2.get_message()
+    assert dataY == b"data1"
+    d = w1.get_message()
+    w2.send_message(b"data2")
+    dataX = await d
+    assert dataX == b"data2"
+    await w1.close()
+    await w2.close()
+
+
+@ensureDeferred
+async def test_unidirectional(reactor, mailbox):
+    w1 = wormhole.create(APPID, mailbox.url, reactor)
+    w2 = wormhole.create(APPID, mailbox.url, reactor)
+    w1.allocate_code()
+    code = await w1.get_code()
+    w2.set_code(code)
+    w1.send_message(b"data1")
+    dataY = await w2.get_message()
+    assert dataY == b"data1"
+    await w1.close()
+    await w2.close()
+
+
+@ensureDeferred
+async def test_early(reactor, mailbox):
+    w1 = wormhole.create(APPID, mailbox.url, reactor)
+    w1.send_message(b"data1")
+    w2 = wormhole.create(APPID, mailbox.url, reactor)
+    d = w2.get_message()
+    w1.set_code("123-abc-def")
+    w2.set_code("123-abc-def")
+    dataY = await d
+    assert dataY == b"data1"
+    await w1.close()
+    await w2.close()
+
+
+@ensureDeferred
+async def test_fixed_code(reactor, mailbox):
+    w1 = wormhole.create(APPID, mailbox.url, reactor)
+    w2 = wormhole.create(APPID, mailbox.url, reactor)
+    w1.set_code("123-purple-elephant")
+    w2.set_code("123-purple-elephant")
+    w1.send_message(b"data1"), w2.send_message(b"data2")
+    dl = await doBoth(w1.get_message(), w2.get_message())
+    (dataX, dataY) = dl
+    assert dataX == b"data2"
+    assert dataY == b"data1"
+    await w1.close()
+    await w2.close()
+
+
+@ensureDeferred
+async def test_input_code(reactor, mailbox):
+    w1 = wormhole.create(APPID, mailbox.url, reactor)
+    w2 = wormhole.create(APPID, mailbox.url, reactor)
+    w1.set_code("123-purple-elephant")
+    h = w2.input_code()
+    h.choose_nameplate("123")
+    # Pause to allow some messages to get delivered. Specifically we want
+    # to wait until w2 claims the nameplate, opens the mailbox, and
+    # receives the PAKE message, to exercise the PAKE-before-CODE path in
+    # Key.
+    await poll_until(lambda: w2._boss._K._debug_pake_stashed)
+    h.choose_words("purple-elephant")
+
+    w1.send_message(b"data1"), w2.send_message(b"data2")
+    dl = await doBoth(w1.get_message(), w2.get_message())
+    (dataX, dataY) = dl
+    assert dataX == b"data2"
+    assert dataY == b"data1"
+    await w1.close()
+    await w2.close()
+
+
+@ensureDeferred
+async def test_multiple_messages(reactor, mailbox):
+    w1 = wormhole.create(APPID, mailbox.url, reactor)
+    w2 = wormhole.create(APPID, mailbox.url, reactor)
+    w1.set_code("123-purple-elephant")
+    w2.set_code("123-purple-elephant")
+    w1.send_message(b"data1"), w2.send_message(b"data2")
+    w1.send_message(b"data3"), w2.send_message(b"data4")
+    dl = await doBoth(w1.get_message(), w2.get_message())
+    (dataX, dataY) = dl
+    assert dataX == b"data2"
+    assert dataY == b"data1"
+    dl = await doBoth(w1.get_message(), w2.get_message())
+    (dataX, dataY) = dl
+    assert dataX == b"data4"
+    assert dataY == b"data3"
+    await w1.close()
+    await w2.close()
+
+
+@ensureDeferred
+async def test_closed(reactor, mailbox):
+    eq = EventualQueue(reactor)
+    w1 = wormhole.create(APPID, mailbox.url, reactor, _eventual_queue=eq)
+    w2 = wormhole.create(APPID, mailbox.url, reactor, _eventual_queue=eq)
+    w1.set_code("123-foo")
+    w2.set_code("123-foo")
+
+    # let it connect and become HAPPY
+    await w1.get_versions()
+    await w2.get_versions()
+
+    await w1.close()
+    await w2.close()
+
+    # once closed, all Deferred-awaiting API calls get an prompt error
+    with pytest.raises(WormholeClosed):
+        await w1.get_welcome()
+    with pytest.raises(WormholeClosed) as f:
+        await w1.get_code()
+    assert f.value.args[0] == "happy"
+    with pytest.raises(WormholeClosed):
         await w1.get_unverified_key()
-        await w2.get_unverified_key()
-
-        key1 = w1.derive_key("purpose", 16)
-        self.assertEqual(len(key1), 16)
-        self.assertEqual(type(key1), type(b""))
-        with self.assertRaises(TypeError):
-            w1.derive_key(b"not unicode", 16)
-        with self.assertRaises(TypeError):
-            w1.derive_key(12345, 16)
-
-        verifier1 = await w1.get_verifier()
-        verifier2 = await w2.get_verifier()
-        self.assertEqual(verifier1, verifier2)
-
-        versions1 = await w1.get_versions()
-        versions2 = await w2.get_versions()
-        # app-versions are exercised properly in test_versions, this just
-        # tests the defaults
-        self.assertEqual(versions1, {})
-        self.assertEqual(versions2, {})
-
-        w1.send_message(b"data1")
-        w2.send_message(b"data2")
-        dataX = await w1.get_message()
-        dataY = await w2.get_message()
-        self.assertEqual(dataX, b"data2")
-        self.assertEqual(dataY, b"data1")
-
-        versions1_again = await w1.get_versions()
-        self.assertEqual(versions1, versions1_again)
-
-        c1 = await w1.close()
-        self.assertEqual(c1, "happy")
-        c2 = await w2.close()
-        self.assertEqual(c2, "happy")
-
-    @ensureDeferred
-    async def test_get_code_early(self):
-        eq = EventualQueue(reactor)
-        w1 = wormhole.create(APPID, self.relayurl, reactor, _eventual_queue=eq)
-        d = w1.get_code()
-        w1.set_code("1-abc")
-        await eq.flush()
-        code = self.successResultOf(d)
-        self.assertEqual(code, "1-abc")
-        await self.assertFailure(w1.close(), LonelyError)
-
-    @ensureDeferred
-    async def test_get_code_late(self):
-        eq = EventualQueue(reactor)
-        w1 = wormhole.create(APPID, self.relayurl, reactor, _eventual_queue=eq)
-        w1.set_code("1-abc")
-        d = w1.get_code()
-        await eq.flush()
-        code = self.successResultOf(d)
-        self.assertEqual(code, "1-abc")
-        await self.assertFailure(w1.close(), LonelyError)
-
-    @ensureDeferred
-    async def test_same_message(self):
-        # the two sides use random nonces for their messages, so it's ok for
-        # both to try and send the same body: they'll result in distinct
-        # encrypted messages
-        w1 = wormhole.create(APPID, self.relayurl, reactor)
-        w2 = wormhole.create(APPID, self.relayurl, reactor)
-        w1.allocate_code()
-        code = await w1.get_code()
-        w2.set_code(code)
-        w1.send_message(b"data")
-        w2.send_message(b"data")
-        dataX = await w1.get_message()
-        dataY = await w2.get_message()
-        self.assertEqual(dataX, b"data")
-        self.assertEqual(dataY, b"data")
-        await w1.close()
-        await w2.close()
-
-    @ensureDeferred
-    async def test_interleaved(self):
-        w1 = wormhole.create(APPID, self.relayurl, reactor)
-        w2 = wormhole.create(APPID, self.relayurl, reactor)
-        w1.allocate_code()
-        code = await w1.get_code()
-        w2.set_code(code)
-        w1.send_message(b"data1")
-        dataY = await w2.get_message()
-        self.assertEqual(dataY, b"data1")
-        d = w1.get_message()
-        w2.send_message(b"data2")
-        dataX = await d
-        self.assertEqual(dataX, b"data2")
-        await w1.close()
-        await w2.close()
-
-    @ensureDeferred
-    async def test_unidirectional(self):
-        w1 = wormhole.create(APPID, self.relayurl, reactor)
-        w2 = wormhole.create(APPID, self.relayurl, reactor)
-        w1.allocate_code()
-        code = await w1.get_code()
-        w2.set_code(code)
-        w1.send_message(b"data1")
-        dataY = await w2.get_message()
-        self.assertEqual(dataY, b"data1")
-        await w1.close()
-        await w2.close()
-
-    @ensureDeferred
-    async def test_early(self):
-        w1 = wormhole.create(APPID, self.relayurl, reactor)
-        w1.send_message(b"data1")
-        w2 = wormhole.create(APPID, self.relayurl, reactor)
-        d = w2.get_message()
-        w1.set_code("123-abc-def")
-        w2.set_code("123-abc-def")
-        dataY = await d
-        self.assertEqual(dataY, b"data1")
-        await w1.close()
-        await w2.close()
-
-    @ensureDeferred
-    async def test_fixed_code(self):
-        w1 = wormhole.create(APPID, self.relayurl, reactor)
-        w2 = wormhole.create(APPID, self.relayurl, reactor)
-        w1.set_code("123-purple-elephant")
-        w2.set_code("123-purple-elephant")
-        w1.send_message(b"data1"), w2.send_message(b"data2")
-        dl = await self.doBoth(w1.get_message(), w2.get_message())
-        (dataX, dataY) = dl
-        self.assertEqual(dataX, b"data2")
-        self.assertEqual(dataY, b"data1")
-        await w1.close()
-        await w2.close()
-
-    @ensureDeferred
-    async def test_input_code(self):
-        w1 = wormhole.create(APPID, self.relayurl, reactor)
-        w2 = wormhole.create(APPID, self.relayurl, reactor)
-        w1.set_code("123-purple-elephant")
-        h = w2.input_code()
-        h.choose_nameplate("123")
-        # Pause to allow some messages to get delivered. Specifically we want
-        # to wait until w2 claims the nameplate, opens the mailbox, and
-        # receives the PAKE message, to exercise the PAKE-before-CODE path in
-        # Key.
-        await poll_until(lambda: w2._boss._K._debug_pake_stashed)
-        h.choose_words("purple-elephant")
-
-        w1.send_message(b"data1"), w2.send_message(b"data2")
-        dl = await self.doBoth(w1.get_message(), w2.get_message())
-        (dataX, dataY) = dl
-        self.assertEqual(dataX, b"data2")
-        self.assertEqual(dataY, b"data1")
-        await w1.close()
-        await w2.close()
-
-    @ensureDeferred
-    async def test_multiple_messages(self):
-        w1 = wormhole.create(APPID, self.relayurl, reactor)
-        w2 = wormhole.create(APPID, self.relayurl, reactor)
-        w1.set_code("123-purple-elephant")
-        w2.set_code("123-purple-elephant")
-        w1.send_message(b"data1"), w2.send_message(b"data2")
-        w1.send_message(b"data3"), w2.send_message(b"data4")
-        dl = await self.doBoth(w1.get_message(), w2.get_message())
-        (dataX, dataY) = dl
-        self.assertEqual(dataX, b"data2")
-        self.assertEqual(dataY, b"data1")
-        dl = await self.doBoth(w1.get_message(), w2.get_message())
-        (dataX, dataY) = dl
-        self.assertEqual(dataX, b"data4")
-        self.assertEqual(dataY, b"data3")
-        await w1.close()
-        await w2.close()
-
-    @ensureDeferred
-    async def test_closed(self):
-        eq = EventualQueue(reactor)
-        w1 = wormhole.create(APPID, self.relayurl, reactor, _eventual_queue=eq)
-        w2 = wormhole.create(APPID, self.relayurl, reactor, _eventual_queue=eq)
-        w1.set_code("123-foo")
-        w2.set_code("123-foo")
-
-        # let it connect and become HAPPY
+    with pytest.raises(WormholeClosed):
+        await w1.get_verifier()
+    with pytest.raises(WormholeClosed):
         await w1.get_versions()
+    with pytest.raises(WormholeClosed):
+        await w1.get_message()
+
+
+@ensureDeferred
+async def test_closed_idle(reactor):
+    port = allocate_tcp_port()
+    # without a relay server, this won't ever connect
+    w1 = wormhole.create(APPID, f"ws://127.0.0.1:{port}/v1", reactor)
+
+    d_welcome = w1.get_welcome()
+    assert not d_welcome.called
+    d_code = w1.get_code()
+    d_key = w1.get_unverified_key()
+    d_verifier = w1.get_verifier()
+    d_versions = w1.get_versions()
+    d_message = w1.get_message()
+
+    with pytest.raises(LonelyError):
+        await w1.close()
+
+    with pytest.raises(LonelyError):
+        await d_welcome
+    with pytest.raises(LonelyError):
+        await d_code
+    with pytest.raises(LonelyError):
+        await d_key
+    with pytest.raises(LonelyError):
+        await d_verifier
+    with pytest.raises(LonelyError):
+        await d_versions
+    with pytest.raises(LonelyError):
+        await d_message
+
+
+@ensureDeferred
+async def test_wrong_password(reactor, mailbox):
+    eq = EventualQueue(reactor)
+    w1 = wormhole.create(APPID, mailbox.url, reactor, _eventual_queue=eq)
+    w2 = wormhole.create(APPID, mailbox.url, reactor, _eventual_queue=eq)
+    w1.allocate_code()
+    code = await w1.get_code()
+    w2.set_code(code + "not")
+    code2 = await w2.get_code()
+    assert code != code2
+    # That's enough to allow both sides to discover the mismatch, but
+    # only after the confirmation message gets through. API calls that
+    # don't wait will appear to work until the mismatched confirmation
+    # message arrives.
+    w1.send_message(b"should still work")
+    w2.send_message(b"should still work")
+
+    key2 = await w2.get_unverified_key()  # should work
+    # w2 has just received w1.PAKE, and is about to send w2.VERSION
+    key1 = await w1.get_unverified_key()  # should work
+    # w1 has just received w2.PAKE, and is about to send w1.VERSION, and
+    # then will receive w2.VERSION. When it sees w2.VERSION, it will
+    # learn about the WrongPasswordError.
+    assert key1 != key2
+
+    # API calls that wait (i.e. get) will errback. We collect all these
+    # Deferreds early to exercise the wait-then-fail path
+    d1_verified = w1.get_verifier()
+    d1_versions = w1.get_versions()
+    d1_received = w1.get_message()
+    d2_verified = w2.get_verifier()
+    d2_versions = w2.get_versions()
+    d2_received = w2.get_message()
+
+    # wait for each side to notice the failure
+    with pytest.raises(WrongPasswordError):
+        await w1.get_verifier()
+    with pytest.raises(WrongPasswordError):
+        await w2.get_verifier()
+    # the rest of the loops should fire within the next tick
+    await eq.flush()
+
+    # now all the rest should have fired already
+    with pytest.raises(WrongPasswordError):
+        await d1_verified
+    with pytest.raises(WrongPasswordError):
+        await d1_versions
+    with pytest.raises(WrongPasswordError):
+        await d1_received
+    with pytest.raises(WrongPasswordError):
+        await d2_verified
+    with pytest.raises(WrongPasswordError):
+        await d2_versions
+    with pytest.raises(WrongPasswordError):
+        await d2_received
+
+    # and at this point, with the failure safely noticed by both sides,
+    # new get_unverified_key() calls should signal the failure, even
+    # before we close
+
+    # any new calls in the error state should immediately fail
+    with pytest.raises(WrongPasswordError):
+        await w1.get_unverified_key()
+    with pytest.raises(WrongPasswordError):
+        await w1.get_verifier()
+    with pytest.raises(WrongPasswordError):
+        await w1.get_versions()
+    with pytest.raises(WrongPasswordError):
+        await w1.get_message()
+    with pytest.raises(WrongPasswordError):
+        await w2.get_unverified_key()
+    with pytest.raises(WrongPasswordError):
+        await w2.get_verifier()
+    with pytest.raises(WrongPasswordError):
         await w2.get_versions()
+    with pytest.raises(WrongPasswordError):
+        await w2.get_message()
 
+    with pytest.raises(WrongPasswordError):
         await w1.close()
+    with pytest.raises(WrongPasswordError):
         await w2.close()
 
-        # once closed, all Deferred-awaiting API calls get an prompt error
-        await self.assertFailure(w1.get_welcome(), WormholeClosed)
-        e = await self.assertFailure(w1.get_code(), WormholeClosed)
-        self.assertEqual(e.args[0], "happy")
-        await self.assertFailure(w1.get_unverified_key(), WormholeClosed)
-        await self.assertFailure(w1.get_verifier(), WormholeClosed)
-        await self.assertFailure(w1.get_versions(), WormholeClosed)
-        await self.assertFailure(w1.get_message(), WormholeClosed)
+    # API calls should still get the error, not WormholeClosed
+    with pytest.raises(WrongPasswordError):
+        await w1.get_unverified_key()
+    with pytest.raises(WrongPasswordError):
+        await w1.get_verifier()
+    with pytest.raises(WrongPasswordError):
+        await w1.get_versions()
+    with pytest.raises(WrongPasswordError):
+        await w1.get_message()
+    with pytest.raises(WrongPasswordError):
+        await w2.get_unverified_key()
+    with pytest.raises(WrongPasswordError):
+        await w2.get_verifier()
+    with pytest.raises(WrongPasswordError):
+        await w2.get_versions()
+    with pytest.raises(WrongPasswordError):
+        await w2.get_message()
 
-    @ensureDeferred
-    async def test_closed_idle(self):
-        await self._relay_server.disownServiceParent()
-        w1 = wormhole.create(APPID, self.relayurl, reactor)
-        # without a relay server, this won't ever connect
 
-        d_welcome = w1.get_welcome()
-        self.assertNoResult(d_welcome)
-        d_code = w1.get_code()
-        d_key = w1.get_unverified_key()
-        d_verifier = w1.get_verifier()
-        d_versions = w1.get_versions()
-        d_message = w1.get_message()
+@ensureDeferred
+async def test_wrong_password_with_spaces(reactor, mailbox):
+    w = wormhole.create(APPID, mailbox.url, reactor)
+    badcode = "4 oops spaces"
+    with pytest.raises(KeyFormatError) as ex:
+        w.set_code(badcode)
+    expected_msg = "Code '%s' contains spaces." % (badcode, )
+    assert expected_msg == str(ex.value)
+    with pytest.raises(LonelyError):
+        await w.close()
 
-        await self.assertFailure(w1.close(), LonelyError)
 
-        await self.assertFailure(d_welcome, LonelyError)
-        await self.assertFailure(d_code, LonelyError)
-        await self.assertFailure(d_key, LonelyError)
-        await self.assertFailure(d_verifier, LonelyError)
-        await self.assertFailure(d_versions, LonelyError)
-        await self.assertFailure(d_message, LonelyError)
+@ensureDeferred
+async def test_wrong_password_with_leading_space(reactor, mailbox):
+    w = wormhole.create(APPID, mailbox.url, reactor)
+    badcode = " 4-oops-space"
+    with pytest.raises(KeyFormatError) as ex:
+        w.set_code(badcode)
+    expected_msg = "Code '%s' contains spaces." % (badcode, )
+    assert expected_msg == str(ex.value)
+    with pytest.raises(LonelyError):
+        await w.close()
 
-    @ensureDeferred
-    async def test_wrong_password(self):
-        eq = EventualQueue(reactor)
-        w1 = wormhole.create(APPID, self.relayurl, reactor, _eventual_queue=eq)
-        w2 = wormhole.create(APPID, self.relayurl, reactor, _eventual_queue=eq)
-        w1.allocate_code()
-        code = await w1.get_code()
-        w2.set_code(code + "not")
-        code2 = await w2.get_code()
-        self.assertNotEqual(code, code2)
-        # That's enough to allow both sides to discover the mismatch, but
-        # only after the confirmation message gets through. API calls that
-        # don't wait will appear to work until the mismatched confirmation
-        # message arrives.
-        w1.send_message(b"should still work")
-        w2.send_message(b"should still work")
 
-        key2 = await w2.get_unverified_key()  # should work
-        # w2 has just received w1.PAKE, and is about to send w2.VERSION
-        key1 = await w1.get_unverified_key()  # should work
-        # w1 has just received w2.PAKE, and is about to send w1.VERSION, and
-        # then will receive w2.VERSION. When it sees w2.VERSION, it will
-        # learn about the WrongPasswordError.
-        self.assertNotEqual(key1, key2)
+@ensureDeferred
+async def test_wrong_password_with_non_numeric_nameplate(reactor, mailbox):
+    w = wormhole.create(APPID, mailbox.url, reactor)
+    badcode = "four-oops-space"
+    with pytest.raises(KeyFormatError) as ex:
+        w.set_code(badcode)
+    expected_msg = "Nameplate 'four' must be numeric, with no spaces."
+    assert expected_msg == str(ex.value)
+    with pytest.raises(LonelyError):
+        await w.close()
 
-        # API calls that wait (i.e. get) will errback. We collect all these
-        # Deferreds early to exercise the wait-then-fail path
-        d1_verified = w1.get_verifier()
-        d1_versions = w1.get_versions()
-        d1_received = w1.get_message()
-        d2_verified = w2.get_verifier()
-        d2_versions = w2.get_versions()
-        d2_received = w2.get_message()
 
-        # wait for each side to notice the failure
-        await self.assertFailure(w1.get_verifier(), WrongPasswordError)
-        await self.assertFailure(w2.get_verifier(), WrongPasswordError)
-        # the rest of the loops should fire within the next tick
-        await eq.flush()
+@ensureDeferred
+async def test_welcome(reactor, mailbox):
+    w1 = wormhole.create(APPID, mailbox.url, reactor)
+    wel1 = await w1.get_welcome()  # early: before connection established
+    wel2 = await w1.get_welcome()  # late: already received welcome
+    assert wel1 == wel2
+    assert "current_cli_version" in wel1
 
-        # now all the rest should have fired already
-        self.failureResultOf(d1_verified, WrongPasswordError)
-        self.failureResultOf(d1_versions, WrongPasswordError)
-        self.failureResultOf(d1_received, WrongPasswordError)
-        self.failureResultOf(d2_verified, WrongPasswordError)
-        self.failureResultOf(d2_versions, WrongPasswordError)
-        self.failureResultOf(d2_received, WrongPasswordError)
+    # cause an error, so a later get_welcome will return the error
+    w1.set_code("123-foo")
+    w2 = wormhole.create(APPID, mailbox.url, reactor)
+    w2.set_code("123-NOT")
+    with pytest.raises(WrongPasswordError):
+        await w1.get_verifier()
+    with pytest.raises(WrongPasswordError):
+        await w1.get_welcome()
 
-        # and at this point, with the failure safely noticed by both sides,
-        # new get_unverified_key() calls should signal the failure, even
-        # before we close
+    # we have to ensure w2 receives a "bad" message from w1 before
+    # the w2.close() assertion below will actually fail
+    with pytest.raises(WrongPasswordError):
+        await w2.get_verifier()
 
-        # any new calls in the error state should immediately fail
-        await self.assertFailure(w1.get_unverified_key(), WrongPasswordError)
-        await self.assertFailure(w1.get_verifier(), WrongPasswordError)
-        await self.assertFailure(w1.get_versions(), WrongPasswordError)
-        await self.assertFailure(w1.get_message(), WrongPasswordError)
-        await self.assertFailure(w2.get_unverified_key(), WrongPasswordError)
-        await self.assertFailure(w2.get_verifier(), WrongPasswordError)
-        await self.assertFailure(w2.get_versions(), WrongPasswordError)
-        await self.assertFailure(w2.get_message(), WrongPasswordError)
-
-        await self.assertFailure(w1.close(), WrongPasswordError)
-        await self.assertFailure(w2.close(), WrongPasswordError)
-
-        # API calls should still get the error, not WormholeClosed
-        await self.assertFailure(w1.get_unverified_key(), WrongPasswordError)
-        await self.assertFailure(w1.get_verifier(), WrongPasswordError)
-        await self.assertFailure(w1.get_versions(), WrongPasswordError)
-        await self.assertFailure(w1.get_message(), WrongPasswordError)
-        await self.assertFailure(w2.get_unverified_key(), WrongPasswordError)
-        await self.assertFailure(w2.get_verifier(), WrongPasswordError)
-        await self.assertFailure(w2.get_versions(), WrongPasswordError)
-        await self.assertFailure(w2.get_message(), WrongPasswordError)
-
-    @ensureDeferred
-    async def test_wrong_password_with_spaces(self):
-        w = wormhole.create(APPID, self.relayurl, reactor)
-        badcode = "4 oops spaces"
-        with self.assertRaises(KeyFormatError) as ex:
-            w.set_code(badcode)
-        expected_msg = "Code '%s' contains spaces." % (badcode, )
-        self.assertEqual(expected_msg, str(ex.exception))
-        await self.assertFailure(w.close(), LonelyError)
-
-    @ensureDeferred
-    async def test_wrong_password_with_leading_space(self):
-        w = wormhole.create(APPID, self.relayurl, reactor)
-        badcode = " 4-oops-space"
-        with self.assertRaises(KeyFormatError) as ex:
-            w.set_code(badcode)
-        expected_msg = "Code '%s' contains spaces." % (badcode, )
-        self.assertEqual(expected_msg, str(ex.exception))
-        await self.assertFailure(w.close(), LonelyError)
-
-    @ensureDeferred
-    async def test_wrong_password_with_non_numeric_nameplate(self):
-        w = wormhole.create(APPID, self.relayurl, reactor)
-        badcode = "four-oops-space"
-        with self.assertRaises(KeyFormatError) as ex:
-            w.set_code(badcode)
-        expected_msg = "Nameplate 'four' must be numeric, with no spaces."
-        self.assertEqual(expected_msg, str(ex.exception))
-        await self.assertFailure(w.close(), LonelyError)
-
-    @ensureDeferred
-    async def test_welcome(self):
-        w1 = wormhole.create(APPID, self.relayurl, reactor)
-        wel1 = await w1.get_welcome()  # early: before connection established
-        wel2 = await w1.get_welcome()  # late: already received welcome
-        self.assertEqual(wel1, wel2)
-        self.assertIn("current_cli_version", wel1)
-
-        # cause an error, so a later get_welcome will return the error
-        w1.set_code("123-foo")
-        w2 = wormhole.create(APPID, self.relayurl, reactor)
-        w2.set_code("123-NOT")
-        await self.assertFailure(w1.get_verifier(), WrongPasswordError)
-        await self.assertFailure(w1.get_welcome(), WrongPasswordError)  # late
-
-        # we have to ensure w2 receives a "bad" message from w1 before
-        # the w2.close() assertion below will actually fail
-        await self.assertFailure(w2.get_verifier(), WrongPasswordError)
-
-        await self.assertFailure(w1.close(), WrongPasswordError)
-        await self.assertFailure(w2.close(), WrongPasswordError)
-
-    @ensureDeferred
-    async def test_verifier(self):
-        eq = EventualQueue(reactor)
-        w1 = wormhole.create(APPID, self.relayurl, reactor, _eventual_queue=eq)
-        w2 = wormhole.create(APPID, self.relayurl, reactor, _eventual_queue=eq)
-        w1.allocate_code()
-        code = await w1.get_code()
-        w2.set_code(code)
-        v1 = await w1.get_verifier()  # early
-        v2 = await w2.get_verifier()
-        self.failUnlessEqual(type(v1), type(b""))
-        self.failUnlessEqual(v1, v2)
-        w1.send_message(b"data1")
-        w2.send_message(b"data2")
-        dataX = await w1.get_message()
-        dataY = await w2.get_message()
-        self.assertEqual(dataX, b"data2")
-        self.assertEqual(dataY, b"data1")
-
-        # calling get_verifier() this late should fire right away
-        d = w2.get_verifier()
-        await eq.flush()
-        v1_late = self.successResultOf(d)
-        self.assertEqual(v1_late, v1)
-
+    with pytest.raises(WrongPasswordError):
         await w1.close()
+    with pytest.raises(WrongPasswordError):
         await w2.close()
 
-    @ensureDeferred
-    async def test_versions(self):
-        # there's no API for this yet, but make sure the internals work
-        w1 = wormhole.create(
-            APPID, self.relayurl, reactor, versions={"w1": 123})
-        w2 = wormhole.create(
-            APPID, self.relayurl, reactor, versions={"w2": 456})
-        w1.allocate_code()
-        code = await w1.get_code()
-        w2.set_code(code)
-        w1_versions = await w2.get_versions()
-        self.assertEqual(w1_versions, {"w1": 123})
-        w2_versions = await w1.get_versions()
-        self.assertEqual(w2_versions, {"w2": 456})
-        await w1.close()
-        await w2.close()
 
-    @ensureDeferred
-    async def test_rx_dedup(self):
-        # Future clients will handle losing/reestablishing the Rendezvous
-        # Server connection by retransmitting messages, which will sometimes
-        # cause duplicate messages. Make sure this client can tolerate them.
-        # The first place this would fail was when the second copy of the
-        # incoming PAKE message was received, which would cause
-        # SPAKE2.finish() to be called a second time, which throws an error
-        # (which, being somewhat unexpected, caused a hang rather than a
-        # clear exception). The Mailbox object is responsible for
-        # deduplication, so we must patch the RendezvousConnector to simulate
-        # duplicated messages.
-        with mock.patch("wormhole._boss.RendezvousConnector", MessageDoubler):
-            w1 = wormhole.create(APPID, self.relayurl, reactor)
-        w2 = wormhole.create(APPID, self.relayurl, reactor)
-        w1.set_code("123-purple-elephant")
-        w2.set_code("123-purple-elephant")
-        w1.send_message(b"data1"), w2.send_message(b"data2")
-        dl = await self.doBoth(w1.get_message(), w2.get_message())
-        (dataX, dataY) = dl
-        self.assertEqual(dataX, b"data2")
-        self.assertEqual(dataY, b"data1")
-        await w1.close()
-        await w2.close()
+@ensureDeferred
+async def test_verifier(reactor, mailbox):
+    eq = EventualQueue(reactor)
+    w1 = wormhole.create(APPID, mailbox.url, reactor, _eventual_queue=eq)
+    w2 = wormhole.create(APPID, mailbox.url, reactor, _eventual_queue=eq)
+    w1.allocate_code()
+    code = await w1.get_code()
+    w2.set_code(code)
+    v1 = await w1.get_verifier()  # early
+    v2 = await w2.get_verifier()
+    assert type(v1) == type(b"")
+    assert v1 == v2
+    w1.send_message(b"data1")
+    w2.send_message(b"data2")
+    dataX = await w1.get_message()
+    dataY = await w2.get_message()
+    assert dataX == b"data2"
+    assert dataY == b"data1"
+
+    # calling get_verifier() this late should fire right away
+    d = w2.get_verifier()
+    await eq.flush()
+    v1_late = await d
+    assert v1_late == v1
+
+    await w1.close()
+    await w2.close()
+
+
+@ensureDeferred
+async def test_versions(reactor, mailbox):
+    # there's no API for this yet, but make sure the internals work
+    w1 = wormhole.create(
+        APPID, mailbox.url, reactor, versions={"w1": 123})
+    w2 = wormhole.create(
+        APPID, mailbox.url, reactor, versions={"w2": 456})
+    w1.allocate_code()
+    code = await w1.get_code()
+    w2.set_code(code)
+    w1_versions = await w2.get_versions()
+    assert w1_versions == {"w1": 123}
+    w2_versions = await w1.get_versions()
+    assert w2_versions == {"w2": 456}
+    await w1.close()
+    await w2.close()
+
+
+@ensureDeferred
+async def test_rx_dedup(reactor, mailbox):
+    # Future clients will handle losing/reestablishing the Rendezvous
+    # Server connection by retransmitting messages, which will sometimes
+    # cause duplicate messages. Make sure this client can tolerate them.
+    # The first place this would fail was when the second copy of the
+    # incoming PAKE message was received, which would cause
+    # SPAKE2.finish() to be called a second time, which throws an error
+    # (which, being somewhat unexpected, caused a hang rather than a
+    # clear exception). The Mailbox object is responsible for
+    # deduplication, so we must patch the RendezvousConnector to simulate
+    # duplicated messages.
+    with mock.patch("wormhole._boss.RendezvousConnector", MessageDoubler):
+        w1 = wormhole.create(APPID, mailbox.url, reactor)
+    w2 = wormhole.create(APPID, mailbox.url, reactor)
+    w1.set_code("123-purple-elephant")
+    w2.set_code("123-purple-elephant")
+    w1.send_message(b"data1"), w2.send_message(b"data2")
+    dl = await doBoth(w1.get_message(), w2.get_message())
+    (dataX, dataY) = dl
+    assert dataX == b"data2"
+    assert dataY == b"data1"
+    await w1.close()
+    await w2.close()
 
 
 class MessageDoubler(_rendezvous.RendezvousConnector):
@@ -592,178 +660,185 @@ class MessageDoubler(_rendezvous.RendezvousConnector):
         _rendezvous.RendezvousConnector._response_handle_message(self, msg)
 
 
-class Errors(ServerBase, unittest.TestCase):
-    @ensureDeferred
-    async def test_derive_key_early(self):
-        w = wormhole.create(APPID, self.relayurl, reactor)
-        # definitely too early
-        with self.assertRaises(NoKeyError):
-            w.derive_key("purpose", 12)
-        await self.assertFailure(w.close(), LonelyError)
-
-    @ensureDeferred
-    async def test_multiple_set_code(self):
-        w = wormhole.create(APPID, self.relayurl, reactor)
-        w.set_code("123-purple-elephant")
-        # code can only be set once
-        with self.assertRaises(OnlyOneCodeError):
-            w.set_code("123-nope")
-        await self.assertFailure(w.close(), LonelyError)
-
-    @ensureDeferred
-    async def test_allocate_and_set_code(self):
-        w = wormhole.create(APPID, self.relayurl, reactor)
-        w.allocate_code()
-        await w.get_code()
-        with self.assertRaises(OnlyOneCodeError):
-            w.set_code("123-nope")
-        await self.assertFailure(w.close(), LonelyError)
+@ensureDeferred
+async def test_derive_key_early(reactor, mailbox):
+    w = wormhole.create(APPID, mailbox.url, reactor)
+    # definitely too early
+    with pytest.raises(NoKeyError):
+        w.derive_key("purpose", 12)
+    with pytest.raises(LonelyError):
+        await w.close()
 
 
-class Reconnection(ServerBase, unittest.TestCase):
-    @ensureDeferred
-    async def test_basic(self):
-        w1 = wormhole.create(APPID, self.relayurl, reactor)
-        w1_in = []
-        w1._boss._RC._debug_record_inbound_f = w1_in.append
-        # w1.debug_set_trace("W1")
-        w1.allocate_code()
-        code = await w1.get_code()
-        w1.send_message(b"data1")  # queued until wormhole is established
-
-        # now wait until we've deposited all our messages on the server
-        def seen_our_pake():
-            for m in w1_in:
-                if m["type"] == "message" and m["phase"] == "pake":
-                    return True
-            return False
-
-        await poll_until(seen_our_pake)
-
-        w1_in[:] = []
-        # drop the connection
-        w1._boss._RC._ws.transport.loseConnection()
-        # wait for it to reconnect and redeliver all the messages. The server
-        # sends mtype=message messages in random order, but we've only sent
-        # one of them, so it's safe to wait for just the PAKE phase.
-        await poll_until(seen_our_pake)
-
-        # now let the second side proceed. this simulates the most common
-        # case: the server is bounced while the sender is waiting, before the
-        # receiver has started
-
-        w2 = wormhole.create(APPID, self.relayurl, reactor)
-        # w2.debug_set_trace("  W2")
-        w2.set_code(code)
-
-        dataY = await w2.get_message()
-        self.assertEqual(dataY, b"data1")
-
-        w2.send_message(b"data2")
-        dataX = await w1.get_message()
-        self.assertEqual(dataX, b"data2")
-
-        c1 = await w1.close()
-        self.assertEqual(c1, "happy")
-        c2 = await w2.close()
-        self.assertEqual(c2, "happy")
+@ensureDeferred
+async def test_multiple_set_code(reactor, mailbox):
+    w = wormhole.create(APPID, mailbox.url, reactor)
+    w.set_code("123-purple-elephant")
+    # code can only be set once
+    with pytest.raises(OnlyOneCodeError):
+        w.set_code("123-nope")
+    with pytest.raises(LonelyError):
+        await w.close()
 
 
-class InitialFailure(unittest.TestCase):
-    @ensureDeferred
-    async def assertSCEFailure(self, eq, d, innerType):
-        await eq.flush()
-        f = self.failureResultOf(d, ServerConnectionError)
-        inner = f.value.reason
-        self.assertIsInstance(inner, innerType)
-        return inner
-
-    @ensureDeferred
-    async def test_bad_dns(self):
-        eq = EventualQueue(reactor)
-        # point at a URL that will never connect
-        w = wormhole.create(
-            APPID, "ws://%%%.example.org:4000/v1", reactor, _eventual_queue=eq)
-        # that should have already received an error, when it tried to
-        # resolve the bogus DNS name. All API calls will return an error.
-
-        e = await self.assertSCEFailure(eq, w.get_unverified_key(), ValueError)
-        self.assertIsInstance(e, ValueError)
-        self.assertEqual(str(e), "invalid hostname: %%%.example.org")
-        await self.assertSCEFailure(eq, w.get_code(), ValueError)
-        await self.assertSCEFailure(eq, w.get_verifier(), ValueError)
-        await self.assertSCEFailure(eq, w.get_versions(), ValueError)
-        await self.assertSCEFailure(eq, w.get_message(), ValueError)
-
-    @ensureDeferred
-    async def assertSCE(self, d, innerType):
-        e = await self.assertFailure(d, ServerConnectionError)
-        inner = e.reason
-        self.assertIsInstance(inner, innerType)
-        return inner
-
-    @ensureDeferred
-    async def test_no_connection(self):
-        # point at a URL that will never connect
-        port = allocate_tcp_port()
-        w = wormhole.create(APPID, "ws://127.0.0.1:%d/v1" % port, reactor)
-        # nothing is listening, but it will take a turn to discover that
-        d1 = w.get_code()
-        d2 = w.get_unverified_key()
-        d3 = w.get_verifier()
-        d4 = w.get_versions()
-        d5 = w.get_message()
-        await self.assertSCE(d1, ConnectionRefusedError)
-        await self.assertSCE(d2, ConnectionRefusedError)
-        await self.assertSCE(d3, ConnectionRefusedError)
-        await self.assertSCE(d4, ConnectionRefusedError)
-        await self.assertSCE(d5, ConnectionRefusedError)
-
-    @ensureDeferred
-    async def test_all_deferreds(self):
-        # point at a URL that will never connect
-        port = allocate_tcp_port()
-        w = wormhole.create(APPID, "ws://127.0.0.1:%d/v1" % port, reactor)
-        # nothing is listening, but it will take a turn to discover that
-        w.allocate_code()
-        d1 = w.get_code()
-        d2 = w.get_unverified_key()
-        d3 = w.get_verifier()
-        d4 = w.get_versions()
-        d5 = w.get_message()
-        await self.assertSCE(d1, ConnectionRefusedError)
-        await self.assertSCE(d2, ConnectionRefusedError)
-        await self.assertSCE(d3, ConnectionRefusedError)
-        await self.assertSCE(d4, ConnectionRefusedError)
-        await self.assertSCE(d5, ConnectionRefusedError)
+@ensureDeferred
+async def test_allocate_and_set_code(reactor, mailbox):
+    w = wormhole.create(APPID, mailbox.url, reactor)
+    w.allocate_code()
+    await w.get_code()
+    with pytest.raises(OnlyOneCodeError):
+        w.set_code("123-nope")
+    with pytest.raises(LonelyError):
+        await w.close()
 
 
-class Trace(unittest.TestCase):
-    def test_basic(self):
-        w1 = wormhole.create(APPID, "ws://localhost:1", reactor)
-        stderr = io.StringIO()
-        w1.debug_set_trace("W1", file=stderr)
-        # if Automat doesn't have the tracing API, then we won't actually
-        # exercise the tracing function, so exercise the RendezvousConnector
-        # function manually (it isn't a state machine, so it will always wire
-        # up the tracer)
-        w1._boss._RC._debug("what")
+@ensureDeferred
+async def test_reconnection_basic(reactor, mailbox):
+    w1 = wormhole.create(APPID, mailbox.url, reactor)
+    w1_in = []
+    w1._boss._RC._debug_record_inbound_f = w1_in.append
+    # w1.debug_set_trace("W1")
+    w1.allocate_code()
+    code = await w1.get_code()
+    w1.send_message(b"data1")  # queued until wormhole is established
 
-        stderr = io.StringIO()
-        out = w1._boss._print_trace("OLD", "IN", "NEW", "C1", "M1", stderr)
-        self.assertEqual(stderr.getvalue().splitlines(),
-                         ["C1.M1[OLD].IN -> [NEW]"])
-        out("OUT1")
-        self.assertEqual(stderr.getvalue().splitlines(),
-                         ["C1.M1[OLD].IN -> [NEW]", " C1.M1.OUT1()"])
-        w1._boss._print_trace("", "R.connected", "", "C1", "RC1", stderr)
-        self.assertEqual(
-            stderr.getvalue().splitlines(),
-            ["C1.M1[OLD].IN -> [NEW]", " C1.M1.OUT1()", "C1.RC1.R.connected"])
+    # now wait until we've deposited all our messages on the server
+    def seen_our_pake():
+        for m in w1_in:
+            if m["type"] == "message" and m["phase"] == "pake":
+                return True
+        return False
 
-    def test_delegated(self):
-        dg = Delegate()
-        w1 = wormhole.create(APPID, "ws://localhost:1", reactor, delegate=dg)
-        stderr = io.StringIO()
-        w1.debug_set_trace("W1", file=stderr)
-        w1._boss._RC._debug("what")
+    await poll_until(seen_our_pake)
+
+    w1_in[:] = []
+    # drop the connection
+    w1._boss._RC._ws.transport.loseConnection()
+    # wait for it to reconnect and redeliver all the messages. The server
+    # sends mtype=message messages in random order, but we've only sent
+    # one of them, so it's safe to wait for just the PAKE phase.
+    await poll_until(seen_our_pake)
+
+    # now let the second side proceed. this simulates the most common
+    # case: the server is bounced while the sender is waiting, before the
+    # receiver has started
+
+    w2 = wormhole.create(APPID, mailbox.url, reactor)
+    # w2.debug_set_trace("  W2")
+    w2.set_code(code)
+
+    dataY = await w2.get_message()
+    assert dataY == b"data1"
+
+    w2.send_message(b"data2")
+    dataX = await w1.get_message()
+    assert dataX == b"data2"
+
+    c1 = await w1.close()
+    assert c1 == "happy"
+    c2 = await w2.close()
+    assert c2 == "happy"
+
+
+@ensureDeferred
+async def assertSCEFailure(eq, d, innerType):
+    await eq.flush()
+    with pytest.raises(ServerConnectionError) as f:
+        await d
+    inner = f.value.reason
+    assert isinstance(inner, innerType)
+    return inner
+
+
+@ensureDeferred
+async def test_bad_dns(reactor):
+    eq = EventualQueue(reactor)
+    # point at a URL that will never connect
+    w = wormhole.create(
+        APPID, "ws://%%%.example.org:4000/v1", reactor, _eventual_queue=eq)
+    # that should have already received an error, when it tried to
+    # resolve the bogus DNS name. All API calls will return an error.
+
+    e = await assertSCEFailure(eq, w.get_unverified_key(), ValueError)
+    assert isinstance(e, ValueError)
+    assert str(e) == "invalid hostname: %%%.example.org"
+    await assertSCEFailure(eq, w.get_code(), ValueError)
+    await assertSCEFailure(eq, w.get_verifier(), ValueError)
+    await assertSCEFailure(eq, w.get_versions(), ValueError)
+    await assertSCEFailure(eq, w.get_message(), ValueError)
+
+
+@ensureDeferred
+async def assertSCE(d, innerType):
+    with pytest.raises(ServerConnectionError) as f:
+        await d
+    inner = f.value.reason
+    assert isinstance(inner, innerType)
+    return inner
+
+
+@ensureDeferred
+async def test_no_connection(reactor):
+    # point at a URL that will never connect
+    port = allocate_tcp_port()
+    w = wormhole.create(APPID, f"ws://127.0.0.1:{port}/v1", reactor)
+    # nothing is listening, but it will take a turn to discover that
+    d1 = w.get_code()
+    d2 = w.get_unverified_key()
+    d3 = w.get_verifier()
+    d4 = w.get_versions()
+    d5 = w.get_message()
+    await assertSCE(d1, ConnectionRefusedError)
+    await assertSCE(d2, ConnectionRefusedError)
+    await assertSCE(d3, ConnectionRefusedError)
+    await assertSCE(d4, ConnectionRefusedError)
+    await assertSCE(d5, ConnectionRefusedError)
+
+
+@ensureDeferred
+async def test_all_deferreds(reactor):
+    # point at a URL that will never connect
+    port = allocate_tcp_port()
+    w = wormhole.create(APPID, f"ws://127.0.0.1:{port}/v1", reactor)
+    # nothing is listening, but it will take a turn to discover that
+    w.allocate_code()
+    d1 = w.get_code()
+    d2 = w.get_unverified_key()
+    d3 = w.get_verifier()
+    d4 = w.get_versions()
+    d5 = w.get_message()
+    await assertSCE(d1, ConnectionRefusedError)
+    await assertSCE(d2, ConnectionRefusedError)
+    await assertSCE(d3, ConnectionRefusedError)
+    await assertSCE(d4, ConnectionRefusedError)
+    await assertSCE(d5, ConnectionRefusedError)
+
+
+def test_trace_basic(reactor):
+    w1 = wormhole.create(APPID, "ws://localhost:1", reactor)
+    stderr = io.StringIO()
+    w1.debug_set_trace("W1", file=stderr)
+    # if Automat doesn't have the tracing API, then we won't actually
+    # exercise the tracing function, so exercise the RendezvousConnector
+    # function manually (it isn't a state machine, so it will always wire
+    # up the tracer)
+    w1._boss._RC._debug("what")
+
+    stderr = io.StringIO()
+    out = w1._boss._print_trace("OLD", "IN", "NEW", "C1", "M1", stderr)
+    assert stderr.getvalue().splitlines() == \
+                     ["C1.M1[OLD].IN -> [NEW]"]
+    out("OUT1")
+    assert stderr.getvalue().splitlines() == \
+                     ["C1.M1[OLD].IN -> [NEW]", " C1.M1.OUT1()"]
+    w1._boss._print_trace("", "R.connected", "", "C1", "RC1", stderr)
+    assert stderr.getvalue().splitlines() == \
+        ["C1.M1[OLD].IN -> [NEW]", " C1.M1.OUT1()", "C1.RC1.R.connected"]
+
+
+def test_trace_delegated(reactor):
+    dg = Delegate()
+    w1 = wormhole.create(APPID, "ws://localhost:1", reactor, delegate=dg)
+    stderr = io.StringIO()
+    w1.debug_set_trace("W1", file=stderr)
+    w1._boss._RC._debug("what")

--- a/src/wormhole/test/test_xfer_util.py
+++ b/src/wormhole/test/test_xfer_util.py
@@ -1,5 +1,4 @@
-from twisted.internet import defer, reactor
-from twisted.trial import unittest
+from twisted.internet import defer
 
 from pytest_twisted import ensureDeferred
 
@@ -17,7 +16,7 @@ async def test_xfer(reactor, mailbox):
     d2 = xfer_util.receive(reactor, APPID, mailbox.url, code)
     send_result = await d1
     receive_result = await d2
-    assert send_result == None
+    assert send_result is None
     assert receive_result == data
 
 
@@ -40,7 +39,7 @@ async def test_on_code(reactor, mailbox):
     receive_result = await d2
     assert send_code == [code]
     assert receive_code == [code]
-    assert send_result == None
+    assert send_result is None
     assert receive_result == data
 
 
@@ -59,5 +58,5 @@ async def test_make_code(reactor, mailbox):
     d2 = xfer_util.receive(reactor, APPID, mailbox.url, code)
     send_result = await d1
     receive_result = await d2
-    assert send_result == None
+    assert send_result is None
     assert receive_result == data

--- a/src/wormhole/test/test_xfer_util.py
+++ b/src/wormhole/test/test_xfer_util.py
@@ -4,59 +4,60 @@ from twisted.trial import unittest
 from pytest_twisted import ensureDeferred
 
 from .. import xfer_util
-from .common import ServerBase
+
 
 APPID = u"appid"
 
 
-class Xfer(ServerBase, unittest.TestCase):
-    @ensureDeferred
-    async def test_xfer(self):
-        code = u"1-code"
-        data = u"data"
-        d1 = xfer_util.send(reactor, APPID, self.relayurl, data, code)
-        d2 = xfer_util.receive(reactor, APPID, self.relayurl, code)
-        send_result = await d1
-        receive_result = await d2
-        self.assertEqual(send_result, None)
-        self.assertEqual(receive_result, data)
+@ensureDeferred
+async def test_xfer(reactor, mailbox):
+    code = u"1-code"
+    data = u"data"
+    d1 = xfer_util.send(reactor, APPID, mailbox.url, data, code)
+    d2 = xfer_util.receive(reactor, APPID, mailbox.url, code)
+    send_result = await d1
+    receive_result = await d2
+    assert send_result == None
+    assert receive_result == data
 
-    @ensureDeferred
-    async def test_on_code(self):
-        code = u"1-code"
-        data = u"data"
-        send_code = []
-        receive_code = []
-        d1 = xfer_util.send(
-            reactor,
-            APPID,
-            self.relayurl,
-            data,
-            code,
-            on_code=send_code.append)
-        d2 = xfer_util.receive(
-            reactor, APPID, self.relayurl, code, on_code=receive_code.append)
-        send_result = await d1
-        receive_result = await d2
-        self.assertEqual(send_code, [code])
-        self.assertEqual(receive_code, [code])
-        self.assertEqual(send_result, None)
-        self.assertEqual(receive_result, data)
 
-    @ensureDeferred
-    async def test_make_code(self):
-        data = u"data"
-        got_code = defer.Deferred()
-        d1 = xfer_util.send(
-            reactor,
-            APPID,
-            self.relayurl,
-            data,
-            code=None,
-            on_code=got_code.callback)
-        code = await got_code
-        d2 = xfer_util.receive(reactor, APPID, self.relayurl, code)
-        send_result = await d1
-        receive_result = await d2
-        self.assertEqual(send_result, None)
-        self.assertEqual(receive_result, data)
+@ensureDeferred
+async def test_on_code(reactor, mailbox):
+    code = u"1-code"
+    data = u"data"
+    send_code = []
+    receive_code = []
+    d1 = xfer_util.send(
+        reactor,
+        APPID,
+        mailbox.url,
+        data,
+        code,
+        on_code=send_code.append)
+    d2 = xfer_util.receive(
+        reactor, APPID, mailbox.url, code, on_code=receive_code.append)
+    send_result = await d1
+    receive_result = await d2
+    assert send_code == [code]
+    assert receive_code == [code]
+    assert send_result == None
+    assert receive_result == data
+
+
+@ensureDeferred
+async def test_make_code(reactor, mailbox):
+    data = u"data"
+    got_code = defer.Deferred()
+    d1 = xfer_util.send(
+        reactor,
+        APPID,
+        mailbox.url,
+        data,
+        code=None,
+        on_code=got_code.callback)
+    code = await got_code
+    d2 = xfer_util.receive(reactor, APPID, mailbox.url, code)
+    send_result = await d1
+    receive_result = await d2
+    assert send_result == None
+    assert receive_result == data


### PR DESCRIPTION
Convert the test suite to `pytest`.

Motivations:
- be able to use Hypothesis
- requires pytest, pytest_twisted for above
- some combination of: UnitTest, "normal" pytest tests and pytest_twisted causes weird test failures, seem related to reactor weirdness/contamination

While in principal the latter could be fixed, Shapr and I both like pytest for additional reasons.