### PR TITLE
add .hypothesis and ignore automat in any dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ htmlcov/
 nosetests.xml
 coverage.xml
 _trial_temp/
+.hypothesis
 
 # Translations
 *.mo
@@ -52,7 +53,7 @@ target/
 /twistd.pid
 /relay.sqlite
 /misc/node_modules/
-/.automat_visualize/
+.automat_visualize/
 /docs/state-machines/*.png
 
 # Virtual environment stuff


### PR DESCRIPTION
Hypothesis tests create a `.hypothesis` directory for state, and I sometimes create automat visualizations outside of the root dir of the project.
Thus I submit these changes for approval.