### PR TITLE
search for text mentions of .md files, replace with refs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -131,8 +131,8 @@ several optional arguments:
 -  ``delegate``: provide a Delegate object to enable “delegated mode”,
    or pass None (the default) to get “deferred mode”
 -  ``journal``: provide a Journal object to enable journaled mode. See
-   journal.md for details. Note that journals only work with delegated
-   mode, not with deferred mode.
+   :doc:`the journal docs <journal>` for details. Note that journals
+   only work with delegated mode, not with deferred mode.
 -  ``tor_manager``: to enable Tor support, create a
    ``wormhole.TorManager`` instance and pass it here. This will hide the
    client’s IP address by proxying all connections (mailbox and transit)
@@ -509,8 +509,8 @@ clients to ask for greater capacity when they connect (probably by
 passing additional “mailbox attribute” parameters with the
 ``allocate``/``claim``/``open`` messages).
 
-For bulk data transfer, see “transit.md”, or the “Dilation” section
-below.
+For bulk data transfer, see :doc:`the transit docs <transit>` ,
+or the “Dilation” section below.
 
 Closing
 -------
@@ -565,7 +565,7 @@ point at functions, which cannot be serialized easily). It also only
 works for “non-dilated” wormholes (see below).
 
 To ensure correct behavior, serialization should probably only be done
-in “journaled mode”. See journal.md for details.
+in “journaled mode”. See :doc:`the journal docs <journal>` for details.
 
 If you use serialization, be careful to never use the same partial
 wormhole object twice.

--- a/docs/dilation-protocol.rst
+++ b/docs/dilation-protocol.rst
@@ -8,9 +8,7 @@ transmitted in-order to the other peer. There are subchannels: logically
 separate streams as the application protocol requires. Multiple ways to
 connect are supported, via “hints”. These exist for direct TCP, TCP via
 Tor, and TCP to a central Transit helper (see also “Canonical hint
-encodings” in the `Transit
-documentation <https://github.com/magic-wormhole/magic-wormhole-protocols/blob/main/transit.md>`__
-).
+encodings” in the :doc:`Transit documentation <transit>`.
 
 These building-blocks allow “application” protocols to be simpler by
 not having to deal with re-connection attempts and network problems.

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -57,5 +57,5 @@ The ``wormhole`` API
 --------------------
 
 Application use the ``wormhole`` library to establish wormhole
-connections and exchange data through them. Please see ``api.md`` for a
-complete description of this interface.
+connections and exchange data through them. Please see :doc:`the API
+docs <api>` for a complete description of this interface.

--- a/docs/server-protocol.rst
+++ b/docs/server-protocol.rst
@@ -236,8 +236,8 @@ mailbox.
 When clients use the ``add`` command to add a client-to-client message,
 they will put the body (a bytestring) into the command as a hex-encoded
 string in the ``body`` key. They will also put the message’s “phase”, as
-a string, into the ``phase`` key. See client-protocol.md for details
-about how different phases are used.
+a string, into the ``phase`` key. See  :doc:`the client protocol
+docs <client-protocol>`  for details about how different phases are used.
 
 When a client sends ``open``, it will get back a ``message`` response
 for every message in the mailbox. It will also get a real-time
@@ -295,7 +295,7 @@ Clients which terminate entirely between messages (e.g. a secure chat
 application, which requires multiple wormhole messages to exchange
 address-book entries, and which must function even if the two apps are
 never both running at the same time) can use “Journal Mode” to ensure
-forward progress is made: see “journal.md” for details.
+forward progress is made: see :doc:`the journal docs <journal>` for details.
 
 
 Diagram of Normal Interaction

--- a/docs/welcome.rst
+++ b/docs/welcome.rst
@@ -308,7 +308,7 @@ Library
 The ``wormhole`` module makes it possible for other applications to use
 these code-protected channels. This includes Twisted support, and (in
 the future) will include blocking/synchronous support too. See
-docs/api.md for details.
+:doc:`the API docs <api>` for details.
 
 The file-transfer tools use a second module named ``wormhole.transit``,
 which provides an encrypted record-pipe. It knows how to use the Transit


### PR DESCRIPTION
I used the pattern of what appears to be a ref link in one RST file, hopefully this is the right thing.

<!-- readthedocs-preview magic-wormhole start -->
Please see the rendered documentation: https://magic-wormhole--614.org.readthedocs.build/en/614/
<!-- readthedocs-preview magic-wormhole end -->