### PR TITLE
probably fixes #541

### DIFF
--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -418,6 +418,7 @@ class Receiver:
                 disable=self.args.hide_progress,
                 unit="B",
                 unit_scale=True,
+                dynamic_ncols=True,
                 total=self.xfersize)
             hasher = hashlib.sha256()
             with progress:

--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -442,6 +442,7 @@ class Sender:
             disable=self._args.hide_progress,
             unit="B",
             unit_scale=True,
+            dynamic_ncols=True,
             total=filesize)
 
         def _count_and_hash(data):


### PR DESCRIPTION
Probably fixes #541 

I happened upon this marvelous article:
https://www.linusakesson.net/programming/tty/

I realized the bug linked above meant wormhole isn't handling SIGWINCH, the unix signal that notifies TUI programs that the value of COLUMNS has changed. (maybe rows too?)

I heard from @meejah that the TUI progress bar is handled by tqdm, and the tqdm docs include:

dynamic_ncols
If set, constantly alters ncols and nrows to the environment (allowing for window resizes) [default: False]

I turned this on, resized a wormhole send, and the progress bar changed width correctly!