### PR TITLE
remove 'u' prefix to strings

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,9 +46,9 @@ source_suffix = ['.rst']
 master_doc = 'index'
 
 # General information about the project.
-project = u'Magic-Wormhole'
-copyright = u'2017, Brian Warner'
-author = u'Brian Warner'
+project = 'Magic-Wormhole'
+copyright = '2017, Brian Warner'
+author = 'Brian Warner'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -160,8 +160,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'Magic-Wormhole.tex', u'Magic-Wormhole Documentation',
-     u'Brian Warner', 'manual'),
+    (master_doc, 'Magic-Wormhole.tex', 'Magic-Wormhole Documentation',
+     'Brian Warner', 'manual'),
 ]
 
 
@@ -170,7 +170,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'magic-wormhole', u'Magic-Wormhole Documentation',
+    (master_doc, 'magic-wormhole', 'Magic-Wormhole Documentation',
      [author], 1)
 ]
 
@@ -181,7 +181,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Magic-Wormhole', u'Magic-Wormhole Documentation',
+    (master_doc, 'Magic-Wormhole', 'Magic-Wormhole Documentation',
      author, 'Magic-Wormhole', 'One line description of project.',
      'Miscellaneous'),
 ]

--- a/src/wormhole/_boss.py
+++ b/src/wormhole/_boss.py
@@ -31,9 +31,9 @@ from .util import bytes_to_dict, provides
 @implementer(_interfaces.IBoss)
 class Boss(object):
     _W = attrib()
-    _side = attrib(validator=instance_of(type(u"")))
-    _url = attrib(validator=instance_of(type(u"")))
-    _appid = attrib(validator=instance_of(type(u"")))
+    _side = attrib(validator=instance_of(type("")))
+    _url = attrib(validator=instance_of(type("")))
+    _appid = attrib(validator=instance_of(type("")))
     _versions = attrib(validator=instance_of(dict))
     _client_version = attrib(validator=instance_of(tuple))
     _reactor = attrib()

--- a/src/wormhole/_dilation/connector.py
+++ b/src/wormhole/_dilation/connector.py
@@ -26,7 +26,7 @@ from ._noise import NoiseConnection
 
 
 def build_sided_relay_handshake(key, side):
-    assert isinstance(side, type(u""))
+    assert isinstance(side, type(""))
     # magic-wormhole-transit-relay expects a specific layout for the
     # handshake message: "please relay {64} for side {16}\n"
     assert len(side) == 8 * 2, side
@@ -75,14 +75,14 @@ class Connector(object):
     """
 
     _dilation_key = attrib(validator=instance_of(type(b"")))
-    _transit_relay_location = attrib(validator=optional(instance_of(type(u""))))
+    _transit_relay_location = attrib(validator=optional(instance_of(type(""))))
     _manager = attrib(validator=provides(IDilationManager))
     _reactor = attrib()
     _eventual_queue = attrib()
     _no_listen = attrib(validator=instance_of(bool))
     _tor = attrib()
     _timing = attrib()
-    _side = attrib(validator=instance_of(type(u"")))
+    _side = attrib(validator=instance_of(type("")))
     # was self._side = bytes_to_hexstr(os.urandom(8)) # unicode
     _role = attrib()
 

--- a/src/wormhole/_dilation/manager.py
+++ b/src/wormhole/_dilation/manager.py
@@ -270,7 +270,7 @@ class TrafficTimer(object):
 @implementer(IDilationManager)
 class Manager(object):
     _S = attrib(validator=provides(ISend), repr=False)
-    _my_side = attrib(validator=instance_of(type(u"")))
+    _my_side = attrib(validator=instance_of(type("")))
     _transit_relay_location = attrib(validator=optional(instance_of(str)))
     _reactor = attrib(repr=False)
     _eventual_queue = attrib(repr=False)

--- a/src/wormhole/_hints.py
+++ b/src/wormhole/_hints.py
@@ -37,7 +37,7 @@ def describe_hint_obj(hint, relay, tor):
 
 
 def parse_hint_argv(hint, stderr=sys.stderr):
-    assert isinstance(hint, type(u""))
+    assert isinstance(hint, type(""))
     # return tuple or None for an unparseable hint
     priority = 0.0
     # parse hint type

--- a/src/wormhole/_key.py
+++ b/src/wormhole/_key.py
@@ -63,9 +63,9 @@ def encrypt_data(key, plaintext):
 @attrs
 @implementer(_interfaces.IKey)
 class Key(object):
-    _appid = attrib(validator=instance_of(type(u"")))
+    _appid = attrib(validator=instance_of(type("")))
     _versions = attrib(validator=instance_of(dict))
-    _side = attrib(validator=instance_of(type(u"")))
+    _side = attrib(validator=instance_of(type("")))
     _timing = attrib(validator=provides(_interfaces.ITiming))
     m = MethodicalMachine()
     set_trace = getattr(m, "_setTrace",
@@ -129,9 +129,9 @@ class Key(object):
 
 @attrs
 class _SortedKey(object):
-    _appid = attrib(validator=instance_of(type(u"")))
+    _appid = attrib(validator=instance_of(type("")))
     _versions = attrib(validator=instance_of(dict))
-    _side = attrib(validator=instance_of(type(u"")))
+    _side = attrib(validator=instance_of(type("")))
     _timing = attrib(validator=provides(_interfaces.ITiming))
     m = MethodicalMachine()
     set_trace = getattr(m, "_setTrace",

--- a/src/wormhole/_mailbox.py
+++ b/src/wormhole/_mailbox.py
@@ -9,7 +9,7 @@ from . import _interfaces
 @attrs
 @implementer(_interfaces.IMailbox)
 class Mailbox(object):
-    _side = attrib(validator=instance_of(type(u"")))
+    _side = attrib(validator=instance_of(type("")))
     m = MethodicalMachine()
     set_trace = getattr(m, "_setTrace",
                         lambda self, f: None)  # pragma: no cover

--- a/src/wormhole/_order.py
+++ b/src/wormhole/_order.py
@@ -10,7 +10,7 @@ from .util import provides
 @attrs
 @implementer(_interfaces.IOrder)
 class Order(object):
-    _side = attrib(validator=instance_of(type(u"")))
+    _side = attrib(validator=instance_of(type("")))
     _timing = attrib(validator=provides(_interfaces.ITiming))
     m = MethodicalMachine()
     set_trace = getattr(m, "_setTrace",

--- a/src/wormhole/_receive.py
+++ b/src/wormhole/_receive.py
@@ -11,7 +11,7 @@ from .util import provides
 @attrs
 @implementer(_interfaces.IReceive)
 class Receive(object):
-    _side = attrib(validator=instance_of(type(u"")))
+    _side = attrib(validator=instance_of(type("")))
     _timing = attrib(validator=provides(_interfaces.ITiming))
     m = MethodicalMachine()
     set_trace = getattr(m, "_setTrace",

--- a/src/wormhole/_rendezvous.py
+++ b/src/wormhole/_rendezvous.py
@@ -62,9 +62,9 @@ class WSFactory(websocket.WebSocketClientFactory):
 @attrs
 @implementer(_interfaces.IRendezvousConnector)
 class RendezvousConnector(object):
-    _url = attrib(validator=instance_of(type(u"")))
-    _appid = attrib(validator=instance_of(type(u"")))
-    _side = attrib(validator=instance_of(type(u"")))
+    _url = attrib(validator=instance_of(type("")))
+    _appid = attrib(validator=instance_of(type("")))
+    _side = attrib(validator=instance_of(type("")))
     _reactor = attrib()
     _journal = attrib(validator=provides(_interfaces.IJournal))
     _tor = attrib(validator=optional(provides(_interfaces.ITorManager)))

--- a/src/wormhole/_send.py
+++ b/src/wormhole/_send.py
@@ -11,7 +11,7 @@ from .util import provides
 @attrs
 @implementer(_interfaces.ISend)
 class Send(object):
-    _side = attrib(validator=instance_of(type(u"")))
+    _side = attrib(validator=instance_of(type("")))
     _timing = attrib(validator=provides(_interfaces.ITiming))
     m = MethodicalMachine()
     set_trace = getattr(m, "_setTrace",

--- a/src/wormhole/cli/cli.py
+++ b/src/wormhole/cli/cli.py
@@ -103,7 +103,7 @@ class AliasedGroup(click.Group):
 )
 @click.option(
     "--dump-timing",
-    type=type(u""),  # TODO: hide from --help output
+    type=type(""),  # TODO: hide from --help output
     default=None,
     metavar="FILE.json",
     help="(debug) write timing data to file",
@@ -152,7 +152,7 @@ def _dispatch_command(reactor, cfg, command):
         print(str(e), file=cfg.stderr)
         raise SystemExit(1)
     except TransferError as e:
-        print(u"TransferError: %s" % str(e), file=cfg.stderr)
+        print("TransferError: %s" % str(e), file=cfg.stderr)
         raise SystemExit(1)
     except ServerConnectionError as e:
         msg = fill("ERROR: " + dedent(e.__doc__)) + "\n"
@@ -165,7 +165,7 @@ def _dispatch_command(reactor, cfg, command):
         # traceback.print_exc() just prints a TB to the "yield"
         # line above ...
         Failure().printTraceback(file=cfg.stderr)
-        print(u"ERROR:", str(e), file=cfg.stderr)
+        print("ERROR:", str(e), file=cfg.stderr)
         raise SystemExit(1)
 
     cfg.timing.add("exit")
@@ -274,7 +274,7 @@ def help(context, **kwargs):
     "--qr/--no-qr",
     default=True,
     help="Generate and show ASCII-based QR code.")
-@click.argument("what", required=False, type=click.Path(path_type=type(u"")))
+@click.argument("what", required=False, type=click.Path(path_type=type("")))
 @click.pass_obj
 def send(cfg, **kwargs):
     """Send a text message, file, or directory"""

--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -18,7 +18,7 @@ from ..util import (bytes_to_dict, bytes_to_hexstr, dict_to_bytes,
                     estimate_free_space)
 from .welcome import handle_welcome
 
-APPID = u"lothar.com/wormhole/text-or-file-xfer"
+APPID = "lothar.com/wormhole/text-or-file-xfer"
 
 KEY_TIMER = float(os.environ.get("_MAGIC_WORMHOLE_TEST_KEY_TIMER", 1.0))
 VERIFY_TIMER = float(os.environ.get("_MAGIC_WORMHOLE_TEST_VERIFY_TIMER", 1.0))
@@ -51,7 +51,7 @@ def receive(args, reactor=reactor, _debug_stash_wormhole=None):
 
 class Receiver:
     def __init__(self, args, reactor=reactor):
-        assert isinstance(args.relay_url, type(u""))
+        assert isinstance(args.relay_url, type(""))
         self.args = args
         self._reactor = reactor
         self._tor = None
@@ -128,7 +128,7 @@ class Receiver:
         yield self._handle_code(w)
 
         def on_slow_key():
-            print(u"Waiting for sender...", file=self.args.stderr)
+            print("Waiting for sender...", file=self.args.stderr)
 
         notify = self._reactor.callLater(KEY_TIMER, on_slow_key)
         try:
@@ -146,7 +146,7 @@ class Receiver:
 
         def on_slow_verification():
             print(
-                u"Key established, waiting for confirmation...",
+                "Key established, waiting for confirmation...",
                 file=self.args.stderr)
 
         notify = self._reactor.callLater(VERIFY_TIMER, on_slow_verification)
@@ -174,16 +174,16 @@ class Receiver:
         while True:
             them_d = yield self._get_data(w)
             recognized = False
-            if u"transit" in them_d:
+            if "transit" in them_d:
                 recognized = True
-                yield self._parse_transit(them_d[u"transit"], w)
-            if u"offer" in them_d:
+                yield self._parse_transit(them_d["transit"], w)
+            if "offer" in them_d:
                 recognized = True
                 if not want_offer:
                     raise TransferError("duplicate offer")
                 want_offer = False
                 try:
-                    yield self._parse_offer(them_d[u"offer"], w)
+                    yield self._parse_offer(them_d["offer"], w)
                 except RespondError as r:
                     self._send_data({"error": r.response}, w)
                     raise TransferError(r.response)
@@ -209,16 +209,16 @@ class Receiver:
         code = self.args.code
         if self.args.zeromode:
             assert not code
-            code = u"0-"
+            code = "0-"
         if code:
             w.set_code(code)
         else:
             if self.args.allocate:
                 w.allocate_code(self.args.code_length)
                 code = yield w.get_code()
-                print(u"Allocated code: {}".format(code), file=self.args.stderr)
-                print(u"On the other computer, please run:", file=self.args.stderr)
-                print(u"   wormhole send --code {} <filename>".format(code), file=self.args.stderr)
+                print("Allocated code: {}".format(code), file=self.args.stderr)
+                print("On the other computer, please run:", file=self.args.stderr)
+                print("   wormhole send --code {} <filename>".format(code), file=self.args.stderr)
 
             else:
                 prompt = "Enter receive wormhole code: "
@@ -233,7 +233,7 @@ class Receiver:
     def _show_verifier(self, verifier_bytes):
         verifier_hex = bytes_to_hexstr(verifier_bytes)
         if self.args.verify:
-            self._msg(u"Verifier %s." % verifier_hex)
+            self._msg("Verifier %s." % verifier_hex)
 
     @inlineCallbacks
     def _parse_transit(self, sender_transit, w):
@@ -256,8 +256,8 @@ class Receiver:
         # (issue #113), I forgot to also change this w.derive_key() (issue
         # #339). We're stuck with it now. Use a local constant to make this
         # clear.
-        BUG339_APPID = u"lothar.com/wormhole/text-or-file-xfer"
-        transit_key = w.derive_key(BUG339_APPID + u"/transit-key",
+        BUG339_APPID = "lothar.com/wormhole/text-or-file-xfer"
+        transit_key = w.derive_key(BUG339_APPID + "/transit-key",
                                    tr.TRANSIT_KEY_LENGTH)
         tr.set_transit_key(transit_key)
 
@@ -268,7 +268,7 @@ class Receiver:
             "abilities-v1": receiver_abilities,
             "hints-v1": receiver_hints,
         }
-        self._send_data({u"transit": receiver_transit}, w)
+        self._send_data({"transit": receiver_transit}, w)
         # TODO: send more hints as the TransitReceiver produces them
 
     @inlineCallbacks
@@ -292,8 +292,8 @@ class Receiver:
             self._write_directory(f)
             yield self._close_transit(rp, datahash)
         else:
-            self._msg(u"I don't know what they're offering\n")
-            self._msg(u"Offer details: %r" % (them_d, ))
+            self._msg("I don't know what they're offering\n")
+            self._msg("Offer details: %r" % (them_d, ))
             raise RespondError("unknown offer type")
 
     def _handle_text(self, them_d, w):
@@ -309,7 +309,7 @@ class Receiver:
         self.xfersize = file_data["filesize"]
         free = estimate_free_space(self.abs_destname)
         if free is not None and free < self.xfersize:
-            self._msg(u"Error: insufficient free space (%sB) for file (%sB)" %
+            self._msg("Error: insufficient free space (%sB) for file (%sB)" %
                       (free, self.xfersize))
             raise TransferRejectedError()
 
@@ -317,7 +317,7 @@ class Receiver:
         # against malicious filenames that might play with how
         # terminals display things. see also
         # e.g. https://github.com/magic-wormhole/magic-wormhole/issues/476
-        self._msg(u"Receiving file (%s) into: %s" %
+        self._msg("Receiving file (%s) into: %s" %
                   (naturalsize(self.xfersize),
                    repr(os.path.basename(self.abs_destname))))
         self._ask_permission()
@@ -328,7 +328,7 @@ class Receiver:
         file_data = them_d["directory"]
         zipmode = file_data["mode"]
         if not zipmode.startswith("zipfile"):
-            self._msg(u"Error: unknown directory-transfer mode '%s'" %
+            self._msg("Error: unknown directory-transfer mode '%s'" %
                       (zipmode, ))
             raise RespondError("unknown mode")
         self.abs_destname = self._decide_destname("directory",
@@ -337,14 +337,14 @@ class Receiver:
         free = estimate_free_space(self.abs_destname)
         if free is not None and free < file_data["numbytes"]:
             self._msg(
-                u"Error: insufficient free space (%sB) for directory (%sB)" %
+                "Error: insufficient free space (%sB) for directory (%sB)" %
                 (free, file_data["numbytes"]))
             raise TransferRejectedError()
 
-        self._msg(u"Receiving directory (%s) into: %s/" %
+        self._msg("Receiving directory (%s) into: %s/" %
                   (naturalsize(self.xfersize),
                    repr(os.path.basename(self.abs_destname))))
-        self._msg(u"%d files, %s (uncompressed)" %
+        self._msg("%d files, %s (uncompressed)" %
                   (file_data["numfiles"], naturalsize(file_data["numbytes"])))
         self._ask_permission()
         # max_size here matches the magic-number in cmd_send and will
@@ -370,12 +370,12 @@ class Receiver:
         # get confirmation from the user before writing to the local directory
         if os.path.exists(abs_destname):
             if self.args.output_file:  # overwrite is intentional
-                self._msg(u"Overwriting %s" % repr(destname))
+                self._msg("Overwriting %s" % repr(destname))
                 if self.args.accept_file:
                     self._remove_existing(abs_destname)
             else:
                 self._msg(
-                    u"Error: refusing to overwrite existing %s" % repr(destname))
+                    "Error: refusing to overwrite existing %s" % repr(destname))
                 raise TransferRejectedError()
         return abs_destname
 
@@ -393,7 +393,7 @@ class Receiver:
                     if os.path.exists(self.abs_destname):
                         self._remove_existing(self.abs_destname)
                     break
-                print(u"transfer rejected", file=sys.stderr)
+                print("transfer rejected", file=sys.stderr)
                 t.detail(answer="no")
                 raise TransferRejectedError()
             t.detail(answer="yes")
@@ -410,7 +410,7 @@ class Receiver:
     @inlineCallbacks
     def _transfer_data(self, record_pipe, f):
         # now receive the rest of the owl
-        self._msg(u"Receiving (%s).." % record_pipe.describe())
+        self._msg("Receiving (%s).." % record_pipe.describe())
 
         with self.args.timing.add("rx file"):
             progress = tqdm(
@@ -429,8 +429,8 @@ class Receiver:
         # except TransitError
         if received < self.xfersize:
             self._msg()
-            self._msg(u"Connection dropped before full file received")
-            self._msg(u"got %d bytes, wanted %d" % (received, self.xfersize))
+            self._msg("Connection dropped before full file received")
+            self._msg("got %d bytes, wanted %d" % (received, self.xfersize))
             raise TransferError("Connection dropped before full file received")
         assert received == self.xfersize
         return datahash
@@ -439,7 +439,7 @@ class Receiver:
         tmp_name = f.name
         f.close()
         os.rename(tmp_name, self.abs_destname)
-        self._msg(u"Received file written to %s" % os.path.basename(
+        self._msg("Received file written to %s" % os.path.basename(
             self.abs_destname))
 
     def _extract_file(self, zf, info, extract_dir):
@@ -462,20 +462,20 @@ class Receiver:
 
     def _write_directory(self, f):
 
-        self._msg(u"Unpacking zipfile..")
+        self._msg("Unpacking zipfile..")
         with self.args.timing.add("unpack zip"):
             with zipfile.ZipFile(f, "r") as zf:
                 for info in zf.infolist():
                     self._extract_file(zf, info, self.abs_destname)
 
-            self._msg(u"Received files written to %s/" % repr(os.path.basename(
+            self._msg("Received files written to %s/" % repr(os.path.basename(
                 self.abs_destname)))
             f.close()
 
     @inlineCallbacks
     def _close_transit(self, record_pipe, datahash):
         datahash_hex = bytes_to_hexstr(datahash)
-        ack = {u"ack": u"ok", u"sha256": datahash_hex}
+        ack = {"ack": "ok", "sha256": datahash_hex}
         ack_bytes = dict_to_bytes(ack)
         with self.args.timing.add("send ack"):
             yield record_pipe.send_record(ack_bytes)

--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -23,7 +23,7 @@ from .welcome import handle_welcome
 from iterableio import open_iterable
 from zipstream.ng import ZipStream, walk
 
-APPID = u"lothar.com/wormhole/text-or-file-xfer"
+APPID = "lothar.com/wormhole/text-or-file-xfer"
 VERIFY_TIMER = float(os.environ.get("_MAGIC_WORMHOLE_TEST_VERIFY_TIMER", 1.0))
 
 
@@ -51,7 +51,7 @@ class Sender:
 
     @inlineCallbacks
     def go(self):
-        assert isinstance(self._args.relay_url, type(u""))
+        assert isinstance(self._args.relay_url, type(""))
         if self._args.tor:
             with self._timing.add("import", which="tor_manager"):
                 from ..tor_manager import get_tor
@@ -118,13 +118,13 @@ class Sender:
         offer, self._fd_to_send = self._build_offer()
         args = self._args
 
-        other_cmd = u"wormhole receive"
+        other_cmd = "wormhole receive"
         if args.verify:
-            other_cmd = u"wormhole receive --verify"
+            other_cmd = "wormhole receive --verify"
         if args.zeromode:
             assert not args.code
-            args.code = u"0-"
-            other_cmd += u" -0"
+            args.code = "0-"
+            other_cmd += " -0"
 
         if args.code:
             w.set_code(args.code)
@@ -133,18 +133,18 @@ class Sender:
 
         code = yield w.get_code()
         if not args.zeromode:
-            print(u"Wormhole code is: %s" % code, file=args.stderr)
-            other_cmd += u" " + code
+            print("Wormhole code is: %s" % code, file=args.stderr)
+            other_cmd += " " + code
 
         if not args.zeromode and args.qr:
             qr = QRCode(border=1)
-            qr.add_data(u"wormhole-transfer:%s" % code)
+            qr.add_data("wormhole-transfer:%s" % code)
             qr.print_ascii(out=args.stderr)
 
-        print(u"On the other computer, please run:", file=args.stderr)
-        print(u"", file=args.stderr)
+        print("On the other computer, please run:", file=args.stderr)
+        print("", file=args.stderr)
         print(other_cmd, file=args.stderr)
-        print(u"", file=args.stderr)
+        print("", file=args.stderr)
         # flush stderr so the code is displayed immediately
         args.stderr.flush()
 
@@ -158,7 +158,7 @@ class Sender:
         # TODO: don't stall on w.get_verifier() unless they want it
         def on_slow_connection():
             print(
-                u"Key established, waiting for confirmation...",
+                "Key established, waiting for confirmation...",
                 file=args.stderr)
 
         notify = self._reactor.callLater(VERIFY_TIMER, on_slow_connection)
@@ -210,13 +210,13 @@ class Sender:
                 "abilities-v1": sender_abilities,
                 "hints-v1": sender_hints,
             }
-            self._send_data({u"transit": sender_transit}, w)
+            self._send_data({"transit": sender_transit}, w)
 
             # When I made it possible to override APPID with a CLI argument
             # (issue #113), I forgot to also change this w.derive_key()
             # (issue #339). We're stuck with it now. Use a local constant to
             # make this clear.
-            BUG339_APPID = u"lothar.com/wormhole/text-or-file-xfer"
+            BUG339_APPID = "lothar.com/wormhole/text-or-file-xfer"
 
             # TODO: move this down below w.get_message()
             transit_key = w.derive_key(BUG339_APPID + "/transit-key",
@@ -234,18 +234,18 @@ class Sender:
             them_d = bytes_to_dict(them_d_bytes)
             # print("GOT", them_d)
             recognized = False
-            if u"error" in them_d:
+            if "error" in them_d:
                 raise TransferError(
                     "remote error, transfer abandoned: %s" % them_d["error"])
-            if u"transit" in them_d:
+            if "transit" in them_d:
                 recognized = True
-                yield self._handle_transit(them_d[u"transit"])
-            if u"answer" in them_d:
+                yield self._handle_transit(them_d["transit"])
+            if "answer" in them_d:
                 recognized = True
                 if not want_answer:
                     raise TransferError("duplicate answer")
                 want_answer = True
-                yield self._handle_answer(them_d[u"answer"])
+                yield self._handle_answer(them_d["answer"])
                 return None
             if not recognized:
                 log.msg("unrecognized message %r" % (them_d, ))
@@ -272,14 +272,14 @@ class Sender:
         args = self._args
         text = args.text
         if text == "-":
-            print(u"Reading text message from stdin..", file=args.stderr)
+            print("Reading text message from stdin..", file=args.stderr)
             text = sys.stdin.read()
         if not text and not args.what:
             text = input("Text to send: ")
 
         if text is not None:
             print(
-                u"Sending text message (%s)" % naturalsize(len(text)),
+                "Sending text message (%s)" % naturalsize(len(text)),
                 file=args.stderr)
             offer = {"message": text}
             fd_to_send = None
@@ -342,14 +342,14 @@ class Sender:
                 "filesize": filesize,
             }
             print(
-                u"Sending %s file named '%s'" % (naturalsize(filesize),
+                "Sending %s file named '%s'" % (naturalsize(filesize),
                                                  basename),
                 file=args.stderr)
             fd_to_send = open(what, "rb")
             return offer, fd_to_send
 
         if os.path.isdir(what):
-            print(u"Building zipfile..", file=args.stderr)
+            print("Building zipfile..", file=args.stderr)
             # We're sending a directory, stream it as a zipfile
 
             zs = ZipStream(sized=True)
@@ -381,7 +381,7 @@ class Sender:
                 "numfiles": len(filesizes),
             }
             print(
-                u"Sending directory (%s compressed) named '%s'" %
+                "Sending directory (%s compressed) named '%s'" %
                 (naturalsize(filesize), basename),
                 file=args.stderr)
             return offer, zs
@@ -395,7 +395,7 @@ class Sender:
                 "filesize": filesize,
             }
             print(
-                u"Sending %s block device named '%s'" % (naturalsize(filesize),
+                "Sending %s block device named '%s'" % (naturalsize(filesize),
                                                          basename),
                 file=args.stderr)
 
@@ -408,7 +408,7 @@ class Sender:
     def _handle_answer(self, them_answer):
         if self._fd_to_send is None:
             if them_answer["message_ack"] == "ok":
-                print(u"text message sent", file=self._args.stderr)
+                print("text message sent", file=self._args.stderr)
                 return None
             raise TransferError("error sending text: %r" % (them_answer, ))
 
@@ -434,7 +434,7 @@ class Sender:
         self._timing.add("transit connected")
         # record_pipe should implement IConsumer, chunks are just records
         stderr = self._args.stderr
-        print(u"Sending (%s).." % record_pipe.describe(), file=stderr)
+        print("Sending (%s).." % record_pipe.describe(), file=stderr)
 
         hasher = hashlib.sha256()
         progress = tqdm(
@@ -463,18 +463,18 @@ class Sender:
 
         expected_hash = hasher.digest()
         expected_hex = bytes_to_hexstr(expected_hash)
-        print(u"File sent.. waiting for confirmation", file=stderr)
+        print("File sent.. waiting for confirmation", file=stderr)
         with self._timing.add("get ack") as t:
             ack_bytes = yield record_pipe.receive_record()
             record_pipe.close()
             ack = bytes_to_dict(ack_bytes)
-            ok = ack.get(u"ack", u"")
-            if ok != u"ok":
+            ok = ack.get("ack", "")
+            if ok != "ok":
                 t.detail(ack="failed")
                 raise TransferError("Transfer failed (remote says: %r)" % ack)
-            if u"sha256" in ack:
-                if ack[u"sha256"] != expected_hex:
+            if "sha256" in ack:
+                if ack["sha256"] != expected_hex:
                     t.detail(datahash="failed")
                     raise TransferError("Transfer failed (bad remote hash)")
-            print(u"Confirmation received. Transfer complete.", file=stderr)
+            print("Confirmation received. Transfer complete.", file=stderr)
             t.detail(ack="ok")

--- a/src/wormhole/cli/cmd_ssh.py
+++ b/src/wormhole/cli/cmd_ssh.py
@@ -65,7 +65,7 @@ def find_public_key(hint=None):
 def accept(cfg, reactor=reactor):
     yield xfer_util.send(
         reactor,
-        cfg.appid or u"lothar.com/wormhole/ssh-add",
+        cfg.appid or "lothar.com/wormhole/ssh-add",
         cfg.relay_url,
         data=cfg.public_key[2],
         code=cfg.code,
@@ -107,7 +107,7 @@ def invite(cfg, reactor=reactor):
 
     pubkey = yield xfer_util.receive(
         reactor,
-        cfg.appid or u"lothar.com/wormhole/ssh-add",
+        cfg.appid or "lothar.com/wormhole/ssh-add",
         cfg.relay_url,
         None,  # allocate a code for us
         use_tor=cfg.tor,

--- a/src/wormhole/cli/public_relay.py
+++ b/src/wormhole/cli/public_relay.py
@@ -1,4 +1,4 @@
 # This is a relay I run on a personal server. If it gets too expensive to
 # run, I'll shut it down.
-MAILBOX_RELAY = RENDEZVOUS_RELAY = u"ws://relay.magic-wormhole.io:4000/v1"
-TRANSIT_RELAY = u"tcp:transit.magic-wormhole.io:4001"
+MAILBOX_RELAY = RENDEZVOUS_RELAY = "ws://relay.magic-wormhole.io:4000/v1"
+TRANSIT_RELAY = "tcp:transit.magic-wormhole.io:4001"

--- a/src/wormhole/test/dilate/test_connector.py
+++ b/src/wormhole/test/dilate/test_connector.py
@@ -88,7 +88,7 @@ def make_connector(listen=True, tor=False, relay=None, role=roles.LEADER):
     if tor:
         h.tor = mock.Mock()
     timing = None
-    h.side = u"abcd1234abcd5678"
+    h.side = "abcd1234abcd5678"
     h.role = role
     c = Connector(h.dilation_key, h.relay, h.manager, h.reactor, h.eq,
                   not listen, h.tor, timing, h.side, h.role)

--- a/src/wormhole/test/dilate/test_full.py
+++ b/src/wormhole/test/dilate/test_full.py
@@ -10,7 +10,7 @@ from ..._interfaces import IDilationConnector
 from ...eventual import EventualQueue
 from ..._dilation._noise import NoiseConnection
 
-APPID = u"lothar.com/dilate-test"
+APPID = "lothar.com/dilate-test"
 
 
 def doBoth(d1, d2):

--- a/src/wormhole/test/dilate/test_manager.py
+++ b/src/wormhole/test/dilate/test_manager.py
@@ -241,7 +241,7 @@ def make_manager(leader=True):
 
 def test_make_side():
     side = make_side()
-    assert type(side) is type(u"")
+    assert type(side) is type("")
     assert len(side) == 2 * 8
 
 

--- a/src/wormhole/test/test_args.py
+++ b/src/wormhole/test/test_args.py
@@ -30,13 +30,13 @@ def test_send_appid():
 
 def test_send_file():
     cfg = config("send", "fn")
-    assert cfg.what == u"fn"
+    assert cfg.what == "fn"
     assert cfg.text is None
 
 def test_send_text():
     cfg = config("send", "--text", "hi")
     assert cfg.what is None
-    assert cfg.text == u"hi"
+    assert cfg.text == "hi"
 
 def test_send_nolisten():
     cfg = config("send", "--no-listen", "fn")
@@ -44,7 +44,7 @@ def test_send_nolisten():
 
 def test_send_code():
     cfg = config("send", "--code", "1-abc", "fn")
-    assert cfg.code == u"1-abc"
+    assert cfg.code == "1-abc"
 
 def test_send_code_length():
     cfg = config("send", "-c", "3", "fn")
@@ -124,7 +124,7 @@ def test_receive_nolisten():
 
 def test_receive_code():
     cfg = config("receive", "1-abc")
-    assert cfg.code == u"1-abc"
+    assert cfg.code == "1-abc"
 
 def test_receive_code_length():
     cfg = config("receive", "-c", "3", "--allocate")
@@ -160,7 +160,7 @@ def test_receive_accept_file():
 
 def test_receive_output_file():
     cfg = config("receive", "--output-file", "fn")
-    assert cfg.output_file == u"fn"
+    assert cfg.output_file == "fn"
 
 def test_receive_relay_env_var():
     relay_url = str(mock.sentinel.relay_url)

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -436,7 +436,7 @@ async def _do_test(
         cfg.relay_url = mailbox.url
         cfg.transit_helper = ""
         cfg.listen = True
-        cfg.code = u"1-abc"
+        cfg.code = "1-abc"
         cfg.stdout = io.StringIO()
         cfg.stderr = io.StringIO()
         cfg.verify = verify
@@ -450,7 +450,7 @@ async def _do_test(
     elif mode in ("file", "empty-file"):
         if mode == "empty-file":
             message = ""
-        send_filename = u"testfil\u00EB"  # e-with-diaeresis
+        send_filename = "testfil\u00EB"  # e-with-diaeresis
         with open(os.path.join(send_dir, send_filename), "w") as f:
             f.write(message)
         send_cfg.what = send_filename
@@ -458,7 +458,7 @@ async def _do_test(
 
         recv_cfg.accept_file = False if mock_accept else True
         if override_filename:
-            recv_cfg.output_file = receive_filename = u"outfile"
+            recv_cfg.output_file = receive_filename = "outfile"
         if overwrite:
             recv_cfg.output_file = receive_filename
             existing_file = os.path.join(receive_dir, receive_filename)
@@ -474,13 +474,13 @@ async def _do_test(
         # cd $receive_dir && wormhole receive
         # expect: $receive_dir/$dirname/[12345]
 
-        send_dirname = u"testdir"
+        send_dirname = "testdir"
 
         def message(i):
             return "test message %d\n" % i
 
-        os.mkdir(os.path.join(send_dir, u"middle"))
-        source_dir = os.path.join(send_dir, u"middle", send_dirname)
+        os.mkdir(os.path.join(send_dir, "middle"))
+        source_dir = os.path.join(send_dir, "middle", send_dirname)
         os.mkdir(source_dir)
         modes = {}
         for i in range(5):
@@ -490,7 +490,7 @@ async def _do_test(
             if i == 3:
                 os.chmod(path, 0o755)
             modes[i] = stat.S_IMODE(os.stat(path).st_mode)
-        send_dirname_arg = os.path.join(u"middle", send_dirname)
+        send_dirname_arg = os.path.join("middle", send_dirname)
         if addslash:
             send_dirname_arg += os.sep
         send_cfg.what = send_dirname_arg
@@ -498,7 +498,7 @@ async def _do_test(
 
         recv_cfg.accept_file = False if mock_accept else True
         if override_filename:
-            recv_cfg.output_file = receive_dirname = u"outdir"
+            recv_cfg.output_file = receive_dirname = "outdir"
         if overwrite:
             recv_cfg.output_file = receive_dirname
             os.mkdir(os.path.join(receive_dir, receive_dirname))
@@ -671,25 +671,25 @@ async def _do_test(
             )
             assert expected in send_stderr
     elif mode == "file":
-        expected = u"Sending {size:s} file named '{name}'{NL}".format(
+        expected = "Sending {size:s} file named '{name}'{NL}".format(
             size=naturalsize(len(message)),
             name=send_filename,
             NL=NL)
         assert expected in send_stderr
-        assert u"Wormhole code is: {code}{NL}".format(code=send_cfg.code, NL=NL) in send_stderr
-        expected = (u"On the other computer, please run:{NL}{NL}"
+        assert "Wormhole code is: {code}{NL}".format(code=send_cfg.code, NL=NL) in send_stderr
+        expected = ("On the other computer, please run:{NL}{NL}"
                     "wormhole receive {code}{NL}{NL}").format(code=send_cfg.code, NL=NL)
         assert expected in send_stderr
-        assert (u"File sent.. waiting for confirmation{NL}"
+        assert ("File sent.. waiting for confirmation{NL}"
                 "Confirmation received. Transfer complete.{NL}").format(NL=NL) in send_stderr
 
     elif mode == "directory":
-        assert u"Sending directory" in send_stderr
-        assert u"named 'testdir'" in send_stderr
-        assert u"Wormhole code is: {code}{NL}".format(code=send_cfg.code, NL=NL) in send_stderr
-        assert u"On the other computer, please run:{NL}{NL}wormhole receive {code}{NL}{NL}".format(code=send_cfg.code, NL=NL) in send_stderr
+        assert "Sending directory" in send_stderr
+        assert "named 'testdir'" in send_stderr
+        assert "Wormhole code is: {code}{NL}".format(code=send_cfg.code, NL=NL) in send_stderr
+        assert "On the other computer, please run:{NL}{NL}wormhole receive {code}{NL}{NL}".format(code=send_cfg.code, NL=NL) in send_stderr
 
-        assert u"File sent.. waiting for confirmation{NL}Confirmation received. Transfer complete.{NL}".format(NL=NL) in send_stderr
+        assert "File sent.. waiting for confirmation{NL}Confirmation received. Transfer complete.{NL}".format(NL=NL) in send_stderr
 
     # check receiver
     if mode in ("text", "slow-text", "slow-sender-text"):
@@ -708,12 +708,12 @@ async def _do_test(
             assert receive_stderr == "Waiting for sender...\n"
     elif mode == "file":
         assert receive_stdout == ""
-        want = u"Receiving file ({size:s}) into: {name!r}".format(
+        want = "Receiving file ({size:s}) into: {name!r}".format(
             size=naturalsize(len(message)),
             name=receive_filename,
         )
         assert want in receive_stderr
-        assert u"Received file written to " in receive_stderr
+        assert "Received file written to " in receive_stderr
         fn = os.path.join(receive_dir, receive_filename)
         assert os.path.exists(fn)
         with open(fn, "r") as f:
@@ -723,7 +723,7 @@ async def _do_test(
         want = (r"Receiving directory \(\d+ \w+\) into: {name!r}/"
                 .format(name=receive_dirname))
         assert re.search(want, receive_stderr), (want, receive_stderr)
-        assert u"Received files written to {name!r}".format(name=receive_dirname) in receive_stderr
+        assert "Received files written to {name!r}".format(name=receive_dirname) in receive_stderr
         fn = os.path.join(receive_dir, receive_dirname)
         assert os.path.exists(fn), fn
         for i in range(5):
@@ -822,7 +822,7 @@ async def _do_test_fail(wormhole_executable, scripts_env, relayurl, tmpdir_facto
         cfg.relay_url = relayurl
         cfg.transit_helper = ""
         cfg.listen = False
-        cfg.code = u"1-abc"
+        cfg.code = "1-abc"
         cfg.stdout = io.StringIO()
         cfg.stderr = io.StringIO()
 
@@ -907,7 +907,7 @@ async def _do_test_fail(wormhole_executable, scripts_env, relayurl, tmpdir_facto
         assert "Sending directory" in send_stderr
         assert "named 'testdir'" in send_stderr
         assert "Wormhole code is: {code}{NL}".format(code=send_cfg.code, NL=NL) in send_stderr
-        assert u"On the other computer, please run:{NL}{NL}wormhole receive {code}{NL}{NL}".format(code=send_cfg.code, NL=NL) in send_stderr
+        assert "On the other computer, please run:{NL}{NL}wormhole receive {code}{NL}{NL}".format(code=send_cfg.code, NL=NL) in send_stderr
 
     # check receiver
     if mode == "file":
@@ -1030,7 +1030,7 @@ def unwelcome_config(unwelcome_mailbox):
 @pytest_twisted.ensureDeferred
 async def test_sender_unwelcome(unwelcome_config):
     unwelcome_config.text = "hi"
-    unwelcome_config.code = u"1-abc"
+    unwelcome_config.code = "1-abc"
     unwelcome_config.verbose = True
     unwelcome_config.stdout = sys.stdout
     unwelcome_config.stderr = sys.stderr
@@ -1043,7 +1043,7 @@ async def test_sender_unwelcome(unwelcome_config):
 
 @pytest_twisted.ensureDeferred
 async def test_receiver_unwelcome(unwelcome_config):
-    unwelcome_config.code = u"1-abc"
+    unwelcome_config.code = "1-abc"
 
     receive_d = cmd_receive.receive(unwelcome_config)
     with pytest.raises(WelcomeError) as e:
@@ -1071,7 +1071,7 @@ async def test_sender(no_mailbox):
     cfg.stderr = io.StringIO()
 
     cfg.text = "hi"
-    cfg.code = u"1-abc"
+    cfg.code = "1-abc"
 
     with pytest.raises(ServerConnectionError) as e:
         await cmd_send.send(cfg)
@@ -1105,7 +1105,7 @@ async def test_receiver(no_mailbox):
     cfg.stdout = io.StringIO()
     cfg.stderr = io.StringIO()
 
-    cfg.code = u"1-abc"
+    cfg.code = "1-abc"
 
     with pytest.raises(ServerConnectionError) as e:
         await cmd_receive.receive(cfg)
@@ -1152,7 +1152,7 @@ async def test_text_wrong_password(mailbox):
     send_d = cmd_send.send(send_config)
 
     rx_cfg = create_named_config("send", mailbox.url)
-    rx_cfg.code = u"1-WRONG"
+    rx_cfg.code = "1-WRONG"
     receive_d = cmd_receive.receive(rx_cfg)
 
     # both sides should be capable of detecting the mismatch
@@ -1167,7 +1167,7 @@ async def test_text_wrong_password(mailbox):
 
 def test_filenames(tmpdir_factory):
     args = mock.Mock()
-    args.relay_url = u""
+    args.relay_url = ""
     ef = cmd_receive.Receiver(args)._extract_file
     extract_dir = os.path.abspath(tmpdir_factory.mktemp("filenames"))
 
@@ -1231,7 +1231,7 @@ async def test_override(request, reactor):
     used = mailbox.usage_db.execute(
         "SELECT DISTINCT `app_id` FROM `nameplates`").fetchall()
     assert len(used) == 1, f"Incorrect nameplates: {used}"
-    assert used[0]["app_id"] == u"appid2"
+    assert used[0]["app_id"] == "appid2"
 
 
 def _welcome_test(welcome_message, my_version="2.0"):
@@ -1417,7 +1417,7 @@ async def test_other_error(mailbox):
     f = mock.Mock()
 
     def mock_print(file):
-        file.write(u"<TRACEBACK>\n")
+        file.write("<TRACEBACK>\n")
 
     f.printTraceback = mock_print
     with mock.patch("wormhole.cli.cli.Failure", return_value=f):

--- a/src/wormhole/test/test_machines.py
+++ b/src/wormhole/test/test_machines.py
@@ -54,7 +54,7 @@ class Dummy:
 
 def build_send():
     events = []
-    s = _send.Send(u"side", timing.DebugTiming())
+    s = _send.Send("side", timing.DebugTiming())
     m = Dummy("m", events, IMailbox, "add_message")
     s.wire(m)
     return s, m, events
@@ -112,7 +112,7 @@ def test_key_first():
 
 def build_order():
     events = []
-    o = _order.Order(u"side", timing.DebugTiming())
+    o = _order.Order("side", timing.DebugTiming())
     k = Dummy("k", events, IKey, "got_pake")
     r = Dummy("r", events, IReceive, "got_message")
     o.wire(k, r)
@@ -121,34 +121,34 @@ def build_order():
 
 def test_in_order():
     o, k, r, events = build_order()
-    o.got_message(u"side", u"pake", b"body")
+    o.got_message("side", "pake", b"body")
     assert events == [("k.got_pake", b"body")]  # right away
-    o.got_message(u"side", u"version", b"body")
-    o.got_message(u"side", u"1", b"body")
+    o.got_message("side", "version", b"body")
+    o.got_message("side", "1", b"body")
     assert events == [
         ("k.got_pake", b"body"),
-        ("r.got_message", u"side", u"version", b"body"),
-        ("r.got_message", u"side", u"1", b"body"),
+        ("r.got_message", "side", "version", b"body"),
+        ("r.got_message", "side", "1", b"body"),
     ]
 
 def test_out_of_order():
     o, k, r, events = build_order()
-    o.got_message(u"side", u"version", b"body")
+    o.got_message("side", "version", b"body")
     assert events == []  # nothing yet
-    o.got_message(u"side", u"1", b"body")
+    o.got_message("side", "1", b"body")
     assert events == []  # nothing yet
-    o.got_message(u"side", u"pake", b"body")
+    o.got_message("side", "pake", b"body")
     # got_pake is delivered first
     assert events == [
         ("k.got_pake", b"body"),
-        ("r.got_message", u"side", u"version", b"body"),
-        ("r.got_message", u"side", u"1", b"body"),
+        ("r.got_message", "side", "version", b"body"),
+        ("r.got_message", "side", "1", b"body"),
     ]
 
 
 def build_receive():
     events = []
-    r = _receive.Receive(u"side", timing.DebugTiming())
+    r = _receive.Receive("side", timing.DebugTiming())
     b = Dummy("b", events, IBoss, "happy", "scared", "got_verifier",
               "got_message")
     s = Dummy("s", events, ISend, "got_verified_key")
@@ -162,27 +162,27 @@ def test_good_receive():
     r.got_key(key)
     assert events == []
     verifier = derive_key(key, b"wormhole:verifier")
-    phase1_key = derive_phase_key(key, u"side", u"phase1")
+    phase1_key = derive_phase_key(key, "side", "phase1")
     data1 = b"data1"
     good_body = encrypt_data(phase1_key, data1)
-    r.got_message(u"side", u"phase1", good_body)
+    r.got_message("side", "phase1", good_body)
     assert events == [
         ("s.got_verified_key", key),
         ("b.happy", ),
         ("b.got_verifier", verifier),
-        ("b.got_message", u"phase1", data1),
+        ("b.got_message", "phase1", data1),
     ]
 
-    phase2_key = derive_phase_key(key, u"side", u"phase2")
+    phase2_key = derive_phase_key(key, "side", "phase2")
     data2 = b"data2"
     good_body = encrypt_data(phase2_key, data2)
-    r.got_message(u"side", u"phase2", good_body)
+    r.got_message("side", "phase2", good_body)
     assert events == [
         ("s.got_verified_key", key),
         ("b.happy", ),
         ("b.got_verifier", verifier),
-        ("b.got_message", u"phase1", data1),
-        ("b.got_message", u"phase2", data2),
+        ("b.got_message", "phase1", data1),
+        ("b.got_message", "phase2", data2),
     ]
 
 def test_early_bad():
@@ -190,18 +190,18 @@ def test_early_bad():
     key = b"key"
     r.got_key(key)
     assert events == []
-    phase1_key = derive_phase_key(key, u"side", u"bad")
+    phase1_key = derive_phase_key(key, "side", "bad")
     data1 = b"data1"
     bad_body = encrypt_data(phase1_key, data1)
-    r.got_message(u"side", u"phase1", bad_body)
+    r.got_message("side", "phase1", bad_body)
     assert events == [
         ("b.scared", ),
     ]
 
-    phase2_key = derive_phase_key(key, u"side", u"phase2")
+    phase2_key = derive_phase_key(key, "side", "phase2")
     data2 = b"data2"
     good_body = encrypt_data(phase2_key, data2)
-    r.got_message(u"side", u"phase2", good_body)
+    r.got_message("side", "phase2", good_body)
     assert events == [
         ("b.scared", ),
     ]
@@ -212,42 +212,42 @@ def test_late_bad():
     r.got_key(key)
     assert events == []
     verifier = derive_key(key, b"wormhole:verifier")
-    phase1_key = derive_phase_key(key, u"side", u"phase1")
+    phase1_key = derive_phase_key(key, "side", "phase1")
     data1 = b"data1"
     good_body = encrypt_data(phase1_key, data1)
-    r.got_message(u"side", u"phase1", good_body)
+    r.got_message("side", "phase1", good_body)
     assert events == [
         ("s.got_verified_key", key),
         ("b.happy", ),
         ("b.got_verifier", verifier),
-        ("b.got_message", u"phase1", data1),
+        ("b.got_message", "phase1", data1),
     ]
 
-    phase2_key = derive_phase_key(key, u"side", u"bad")
+    phase2_key = derive_phase_key(key, "side", "bad")
     data2 = b"data2"
     bad_body = encrypt_data(phase2_key, data2)
-    r.got_message(u"side", u"phase2", bad_body)
+    r.got_message("side", "phase2", bad_body)
     assert events == [
         ("s.got_verified_key", key),
         ("b.happy", ),
         ("b.got_verifier", verifier),
-        ("b.got_message", u"phase1", data1),
+        ("b.got_message", "phase1", data1),
         ("b.scared", ),
     ]
-    r.got_message(u"side", u"phase1", good_body)
-    r.got_message(u"side", u"phase2", bad_body)
+    r.got_message("side", "phase1", good_body)
+    r.got_message("side", "phase2", bad_body)
     assert events == [
         ("s.got_verified_key", key),
         ("b.happy", ),
         ("b.got_verifier", verifier),
-        ("b.got_message", u"phase1", data1),
+        ("b.got_message", "phase1", data1),
         ("b.scared", ),
     ]
 
 
 def build_key():
     events = []
-    k = _key.Key(u"appid", {}, u"side", timing.DebugTiming())
+    k = _key.Key("appid", {}, "side", timing.DebugTiming())
     b = Dummy("b", events, IBoss, "scared", "got_key")
     m = Dummy("m", events, IMailbox, "add_message")
     r = Dummy("r", events, IReceive, "got_key")
@@ -257,7 +257,7 @@ def build_key():
 
 def test_good_key():
     k, b, m, r, events = build_key()
-    code = u"1-foo"
+    code = "1-foo"
     k.got_code(code)
     assert len(events) == 1
     assert events[0][:2] == ("m.add_message", "pake")
@@ -265,7 +265,7 @@ def test_good_key():
     events[:] = []
     msg1 = json.loads(msg1_json)
     msg1_bytes = hexstr_to_bytes(msg1["pake_v1"])
-    sp = SPAKE2_Symmetric(to_bytes(code), idSymmetric=to_bytes(u"appid"))
+    sp = SPAKE2_Symmetric(to_bytes(code), idSymmetric=to_bytes("appid"))
     msg2_bytes = sp.start()
     key2 = sp.finish(msg1_bytes)
     msg2 = dict_to_bytes({"pake_v1": bytes_to_hexstr(msg2_bytes)})
@@ -277,7 +277,7 @@ def test_good_key():
 
 def test_bad():
     k, b, m, r, events = build_key()
-    code = u"1-foo"
+    code = "1-foo"
     k.got_code(code)
     assert len(events) == 1
     assert events[0][:2] == ("m.add_message", "pake")
@@ -298,9 +298,9 @@ def test_reversed():
     # PAKE message until the code is set (allowing the PAKE computation
     # to finish). This test exercises that PAKE-then-code sequence.
     k, b, m, r, events = build_key()
-    code = u"1-foo"
+    code = "1-foo"
 
-    sp = SPAKE2_Symmetric(to_bytes(code), idSymmetric=to_bytes(u"appid"))
+    sp = SPAKE2_Symmetric(to_bytes(code), idSymmetric=to_bytes("appid"))
     msg2_bytes = sp.start()
     msg2 = dict_to_bytes({"pake_v1": bytes_to_hexstr(msg2_bytes)})
     k.got_pake(msg2)
@@ -332,32 +332,32 @@ def build_code():
 
 def test_set_code():
     c, b, a, n, k, i, events = build_code()
-    c.set_code(u"1-code")
+    c.set_code("1-code")
     assert events == [
-        ("n.set_nameplate", u"1"),
-        ("b.got_code", u"1-code"),
-        ("k.got_code", u"1-code"),
+        ("n.set_nameplate", "1"),
+        ("b.got_code", "1-code"),
+        ("k.got_code", "1-code"),
     ]
 
 def test_set_code_invalid():
     c, b, a, n, k, i, events = build_code()
     with pytest.raises(errors.KeyFormatError) as e:
-        c.set_code(u"1-code ")
+        c.set_code("1-code ")
     assert str(e.value) == "Code '1-code ' contains spaces."
     with pytest.raises(errors.KeyFormatError) as e:
-        c.set_code(u" 1-code")
+        c.set_code(" 1-code")
     assert str(e.value) == "Code ' 1-code' contains spaces."
     with pytest.raises(errors.KeyFormatError) as e:
-        c.set_code(u"code-code")
+        c.set_code("code-code")
     assert str(e.value) == \
         "Nameplate 'code' must be numeric, with no spaces."
 
     # it should still be possible to use the wormhole at this point
-    c.set_code(u"1-code")
+    c.set_code("1-code")
     assert events == [
-        ("n.set_nameplate", u"1"),
-        ("b.got_code", u"1-code"),
-        ("k.got_code", u"1-code"),
+        ("n.set_nameplate", "1"),
+        ("b.got_code", "1-code"),
+        ("k.got_code", "1-code"),
     ]
 
 def test_allocate_code():
@@ -368,9 +368,9 @@ def test_allocate_code():
     events[:] = []
     c.allocated("1", "1-code")
     assert events == [
-        ("n.set_nameplate", u"1"),
-        ("b.got_code", u"1-code"),
-        ("k.got_code", u"1-code"),
+        ("n.set_nameplate", "1"),
+        ("b.got_code", "1-code"),
+        ("k.got_code", "1-code"),
     ]
 
 def test_input_code():
@@ -380,13 +380,13 @@ def test_input_code():
     events[:] = []
     c.got_nameplate("1")
     assert events == [
-        ("n.set_nameplate", u"1"),
+        ("n.set_nameplate", "1"),
     ]
     events[:] = []
     c.finished_input("1-code")
     assert events == [
-        ("b.got_code", u"1-code"),
-        ("k.got_code", u"1-code"),
+        ("b.got_code", "1-code"),
+        ("k.got_code", "1-code"),
     ]
 
 

--- a/src/wormhole/test/test_rlcompleter.py
+++ b/src/wormhole/test/test_rlcompleter.py
@@ -137,7 +137,7 @@ def test_bytes(input, ci):
     used = _input_code_with_completion(prompt, input_helper, reactor)
     assert used is trueish
     assert ci.mock_calls == [mock.call(input_helper, reactor)]
-    assert c.mock_calls == [mock.call.finish(u"code")]
+    assert c.mock_calls == [mock.call.finish("code")]
     assert input.mock_calls == [mock.call(prompt)]
 
 

--- a/src/wormhole/test/test_ssh.py
+++ b/src/wormhole/test/test_ssh.py
@@ -11,7 +11,7 @@ OTHERS = ["config", "config~", "known_hosts", "known_hosts~"]
 
 def test_find_one():
     files = OTHERS + ["id_rsa.pub", "id_rsa"]
-    pubkey_data = u"ssh-rsa AAAAkeystuff email@host\n"
+    pubkey_data = "ssh-rsa AAAAkeystuff email@host\n"
     pubkey_file = io.StringIO(pubkey_data)
     with mock.patch("wormhole.cli.cmd_ssh.exists", return_value=True):
         with mock.patch("os.listdir", return_value=files) as ld:
@@ -43,7 +43,7 @@ def test_bad_hint():
 
 def test_find_multiple():
     files = OTHERS + ["id_rsa.pub", "id_rsa", "id_dsa.pub", "id_dsa"]
-    pubkey_data = u"ssh-rsa AAAAkeystuff email@host\n"
+    pubkey_data = "ssh-rsa AAAAkeystuff email@host\n"
     pubkey_file = io.StringIO(pubkey_data)
     with mock.patch("wormhole.cli.cmd_ssh.exists", return_value=True):
         with mock.patch("os.listdir", return_value=files):
@@ -62,7 +62,7 @@ def test_find_multiple():
 
 def test_comment_with_spaces():
     files = OTHERS + ["id_ed25519.pub", "id_ed25519"]
-    pubkey_data = u"ssh-ed25519 AAAAkeystuff comment with spaces"
+    pubkey_data = "ssh-ed25519 AAAAkeystuff comment with spaces"
     pubkey_file = io.StringIO(pubkey_data)
 
     with mock.patch("wormhole.cli.cmd_ssh.exists", return_value=True):

--- a/src/wormhole/test/test_transit.py
+++ b/src/wormhole/test/test_transit.py
@@ -941,7 +941,7 @@ async def make_connection():
 async def test_records_not_binary():
     t, c, owner = await make_connection()
 
-    RECORD1 = u"not binary"
+    RECORD1 = "not binary"
     with pytest.raises(InternalError):
         c.send_record(RECORD1)
 

--- a/src/wormhole/test/test_xfer_util.py
+++ b/src/wormhole/test/test_xfer_util.py
@@ -5,13 +5,13 @@ from pytest_twisted import ensureDeferred
 from .. import xfer_util
 
 
-APPID = u"appid"
+APPID = "appid"
 
 
 @ensureDeferred
 async def test_xfer(reactor, mailbox):
-    code = u"1-code"
-    data = u"data"
+    code = "1-code"
+    data = "data"
     d1 = xfer_util.send(reactor, APPID, mailbox.url, data, code)
     d2 = xfer_util.receive(reactor, APPID, mailbox.url, code)
     send_result = await d1
@@ -22,8 +22,8 @@ async def test_xfer(reactor, mailbox):
 
 @ensureDeferred
 async def test_on_code(reactor, mailbox):
-    code = u"1-code"
-    data = u"data"
+    code = "1-code"
+    data = "data"
     send_code = []
     receive_code = []
     d1 = xfer_util.send(
@@ -45,7 +45,7 @@ async def test_on_code(reactor, mailbox):
 
 @ensureDeferred
 async def test_make_code(reactor, mailbox):
-    data = u"data"
+    data = "data"
     got_code = defer.Deferred()
     d1 = xfer_util.send(
         reactor,

--- a/src/wormhole/transit.py
+++ b/src/wormhole/transit.py
@@ -81,7 +81,7 @@ def build_sender_handshake(key):
 
 
 def build_sided_relay_handshake(key, side):
-    assert isinstance(side, type(u""))
+    assert isinstance(side, type(""))
     assert len(side) == 8 * 2
     token = HKDF(key, 32, CTXinfo=b"transit_relay_token")
     return b"please relay " + hexlify(token) + b" for side " + side.encode(
@@ -558,7 +558,7 @@ class Common:
                  timing=None):
         self._side = bytes_to_hexstr(os.urandom(8))  # unicode
         if transit_relay:
-            if not isinstance(transit_relay, type(u"")):
+            if not isinstance(transit_relay, type("")):
                 raise InternalError
             # TODO: allow multiple hints for a single relay
             relay_hint = parse_hint_argv(transit_relay)
@@ -599,10 +599,10 @@ class Common:
     def get_connection_abilities(self):
         return [
             {
-                u"type": u"direct-tcp-v1"
+                "type": "direct-tcp-v1"
             },
             {
-                u"type": u"relay-v1"
+                "type": "relay-v1"
             },
         ]
 
@@ -612,19 +612,19 @@ class Common:
         direct_hints = yield self._get_direct_hints()
         for dh in direct_hints:
             hints.append({
-                u"type": u"direct-tcp-v1",
-                u"priority": dh.priority,
-                u"hostname": dh.hostname,
-                u"port": dh.port,  # integer
+                "type": "direct-tcp-v1",
+                "priority": dh.priority,
+                "hostname": dh.hostname,
+                "port": dh.port,  # integer
             })
         for relay in self._transit_relays:
-            rhint = {u"type": u"relay-v1", u"hints": []}
+            rhint = {"type": "relay-v1", "hints": []}
             for rh in relay.hints:
-                rhint[u"hints"].append({
-                    u"type": u"direct-tcp-v1",
-                    u"priority": rh.priority,
-                    u"hostname": rh.hostname,
-                    u"port": rh.port
+                rhint["hints"].append({
+                    "type": "direct-tcp-v1",
+                    "priority": rh.priority,
+                    "hostname": rh.hostname,
+                    "port": rh.port
                 })
             hints.append(rhint)
         return hints
@@ -676,18 +676,18 @@ class Common:
 
     def add_connection_hints(self, hints):
         for h in hints:  # hint structs
-            hint_type = h.get(u"type", u"")
-            if hint_type in [u"direct-tcp-v1", u"tor-tcp-v1"]:
+            hint_type = h.get("type", "")
+            if hint_type in ["direct-tcp-v1", "tor-tcp-v1"]:
                 dh = parse_tcp_v1_hint(h)
                 if dh:
                     self._their_direct_hints.append(dh)  # hint_obj
-            elif hint_type == u"relay-v1":
+            elif hint_type == "relay-v1":
                 # TODO: each relay-v1 clause describes a different relay,
                 # with a set of equally-valid ways to connect to it. Treat
                 # them as separate relays, instead of merging them all
                 # together like this.
                 relay_hints = []
-                for rhs in h.get(u"hints", []):
+                for rhs in h.get("hints", []):
                     h = parse_tcp_v1_hint(rhs)
                     if h:
                         relay_hints.append(h)

--- a/src/wormhole/util.py
+++ b/src/wormhole/util.py
@@ -34,7 +34,7 @@ def to_bytes(u):
 
 
 def to_unicode(any):
-    if isinstance(any, type(u"")):
+    if isinstance(any, type("")):
         return any
     return any.decode("ascii")
 
@@ -42,12 +42,12 @@ def to_unicode(any):
 def bytes_to_hexstr(b):
     assert isinstance(b, type(b""))
     hexstr = hexlify(b).decode("ascii")
-    assert isinstance(hexstr, type(u""))
+    assert isinstance(hexstr, type(""))
     return hexstr
 
 
 def hexstr_to_bytes(hexstr):
-    assert isinstance(hexstr, type(u""))
+    assert isinstance(hexstr, type(""))
     b = unhexlify(hexstr.encode("ascii"))
     assert isinstance(b, type(b""))
     return b


### PR DESCRIPTION
It's unneeded and more consistent with the other strings.

In the patch, there are several `instance_of(type(u"")`. They could be replaced by `str`. I can rewrite the commit to replace them if you want.

<!-- readthedocs-preview magic-wormhole start -->
Please see the rendered documentation: https://magic-wormhole--636.org.readthedocs.build/en/636/
<!-- readthedocs-preview magic-wormhole end -->