### PR TITLE
refactoring: use classes directly instead of type() calls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ User-visible changes in "magic-wormhole":
 
 * (add release-notes here when making PRs)
 * Update minimal Python version in README.md (#634 @sblondon)
+* Remove 'u' prefix to strings (#636 @sblondon)
+* Use classes directly instead of type() calls (#637 @sblondon)
 
 
 ## Release 0.19.2 (30-May-2025)

--- a/src/wormhole/_boss.py
+++ b/src/wormhole/_boss.py
@@ -31,9 +31,9 @@ from .util import bytes_to_dict, provides
 @implementer(_interfaces.IBoss)
 class Boss(object):
     _W = attrib()
-    _side = attrib(validator=instance_of(type("")))
-    _url = attrib(validator=instance_of(type("")))
-    _appid = attrib(validator=instance_of(type("")))
+    _side = attrib(validator=instance_of(str))
+    _url = attrib(validator=instance_of(str))
+    _appid = attrib(validator=instance_of(str))
     _versions = attrib(validator=instance_of(dict))
     _client_version = attrib(validator=instance_of(tuple))
     _reactor = attrib()
@@ -298,8 +298,8 @@ class Boss(object):
         pass
 
     def got_message(self, phase, plaintext):
-        assert isinstance(phase, type("")), type(phase)
-        assert isinstance(plaintext, type(b"")), type(plaintext)
+        assert isinstance(phase, str), type(phase)
+        assert isinstance(plaintext, bytes), type(plaintext)
         d_mo = re.search(r'^dilate-(\d+)$', phase)
         if phase == "version":
             self._got_version(plaintext)
@@ -353,7 +353,7 @@ class Boss(object):
 
     @m.output()
     def S_send(self, plaintext):
-        assert isinstance(plaintext, type(b"")), type(plaintext)
+        assert isinstance(plaintext, bytes), type(plaintext)
         phase = self._next_tx_phase
         self._next_tx_phase += 1
         self._S.send("%d" % phase, plaintext)

--- a/src/wormhole/_dilation/connector.py
+++ b/src/wormhole/_dilation/connector.py
@@ -26,7 +26,7 @@ from ._noise import NoiseConnection
 
 
 def build_sided_relay_handshake(key, side):
-    assert isinstance(side, type(""))
+    assert isinstance(side, str)
     # magic-wormhole-transit-relay expects a specific layout for the
     # handshake message: "please relay {64} for side {16}\n"
     assert len(side) == 8 * 2, side
@@ -74,7 +74,7 @@ class Connector(object):
     or not.
     """
 
-    _dilation_key = attrib(validator=instance_of(type(b"")))
+    _dilation_key = attrib(validator=instance_of(bytes))
     _transit_relay_location = attrib(validator=optional(instance_of(type(""))))
     _manager = attrib(validator=provides(IDilationManager))
     _reactor = attrib()

--- a/src/wormhole/_dilation/subchannel.py
+++ b/src/wormhole/_dilation/subchannel.py
@@ -270,7 +270,7 @@ class SubChannel(object):
 
     # ITransport
     def write(self, data):
-        assert isinstance(data, type(b""))
+        assert isinstance(data, bytes)
         assert len(data) <= MAX_FRAME_LENGTH
         self.local_data(data)
 

--- a/src/wormhole/_hints.py
+++ b/src/wormhole/_hints.py
@@ -37,7 +37,7 @@ def describe_hint_obj(hint, relay, tor):
 
 
 def parse_hint_argv(hint, stderr=sys.stderr):
-    assert isinstance(hint, type(""))
+    assert isinstance(hint, str)
     # return tuple or None for an unparseable hint
     priority = 0.0
     # parse hint type
@@ -115,7 +115,7 @@ def parse_tcp_v1_hint(hint):  # hint_struct -> hint_obj
         log.msg("unknown hint type: %r" % (hint, ))
         return None
     if not ("hostname" in hint and
-            isinstance(hint["hostname"], type(""))):
+            isinstance(hint["hostname"], str)):
         log.msg("invalid hostname in hint: %r" % (hint, ))
         return None
     if not ("port" in hint and

--- a/src/wormhole/_key.py
+++ b/src/wormhole/_key.py
@@ -18,9 +18,9 @@ __all__ = ["derive_key", "derive_phase_key", "CryptoError", "Key"]
 
 
 def derive_key(key, purpose, length=SecretBox.KEY_SIZE):
-    if not isinstance(key, type(b"")):
+    if not isinstance(key, bytes):
         raise TypeError(type(key))
-    if not isinstance(purpose, type(b"")):
+    if not isinstance(purpose, bytes):
         raise TypeError(type(purpose))
     if not isinstance(length, int):
         raise TypeError(type(length))
@@ -28,8 +28,8 @@ def derive_key(key, purpose, length=SecretBox.KEY_SIZE):
 
 
 def derive_phase_key(key, side, phase):
-    assert isinstance(side, type("")), type(side)
-    assert isinstance(phase, type("")), type(phase)
+    assert isinstance(side, str), type(side)
+    assert isinstance(phase, str), type(phase)
     side_bytes = side.encode("ascii")
     phase_bytes = phase.encode("ascii")
     purpose = (b"wormhole:phase:" + sha256(side_bytes).digest() +
@@ -38,8 +38,8 @@ def derive_phase_key(key, side, phase):
 
 
 def decrypt_data(key, encrypted):
-    assert isinstance(key, type(b"")), type(key)
-    assert isinstance(encrypted, type(b"")), type(encrypted)
+    assert isinstance(key, bytes), type(key)
+    assert isinstance(encrypted, bytes), type(encrypted)
     assert len(key) == SecretBox.KEY_SIZE, len(key)
     box = SecretBox(key)
     data = box.decrypt(encrypted)
@@ -47,8 +47,8 @@ def decrypt_data(key, encrypted):
 
 
 def encrypt_data(key, plaintext):
-    assert isinstance(key, type(b"")), type(key)
-    assert isinstance(plaintext, type(b"")), type(plaintext)
+    assert isinstance(key, bytes), type(key)
+    assert isinstance(plaintext, bytes), type(plaintext)
     assert len(key) == SecretBox.KEY_SIZE, len(key)
     box = SecretBox(key)
     nonce = utils.random(SecretBox.NONCE_SIZE)
@@ -63,9 +63,9 @@ def encrypt_data(key, plaintext):
 @attrs
 @implementer(_interfaces.IKey)
 class Key(object):
-    _appid = attrib(validator=instance_of(type("")))
+    _appid = attrib(validator=instance_of(str))
     _versions = attrib(validator=instance_of(dict))
-    _side = attrib(validator=instance_of(type("")))
+    _side = attrib(validator=instance_of(str))
     _timing = attrib(validator=provides(_interfaces.ITiming))
     m = MethodicalMachine()
     set_trace = getattr(m, "_setTrace",
@@ -129,9 +129,9 @@ class Key(object):
 
 @attrs
 class _SortedKey(object):
-    _appid = attrib(validator=instance_of(type("")))
+    _appid = attrib(validator=instance_of(str))
     _versions = attrib(validator=instance_of(dict))
-    _side = attrib(validator=instance_of(type("")))
+    _side = attrib(validator=instance_of(str))
     _timing = attrib(validator=provides(_interfaces.ITiming))
     m = MethodicalMachine()
     set_trace = getattr(m, "_setTrace",
@@ -165,7 +165,7 @@ class _SortedKey(object):
 
     # from Ordering
     def got_pake(self, body):
-        assert isinstance(body, type(b"")), type(body)
+        assert isinstance(body, bytes), type(body)
         payload = bytes_to_dict(body)
         if "pake_v1" in payload:
             self.got_pake_good(hexstr_to_bytes(payload["pake_v1"]))
@@ -195,7 +195,7 @@ class _SortedKey(object):
 
     @m.output()
     def compute_key(self, msg2):
-        assert isinstance(msg2, type(b""))
+        assert isinstance(msg2, bytes)
         with self._timing.add("pake2", waiting="crypto"):
             key = self._sp.finish(msg2)
         # TODO: make B.got_key() an eventual send, since it will fire the

--- a/src/wormhole/_mailbox.py
+++ b/src/wormhole/_mailbox.py
@@ -9,7 +9,7 @@ from . import _interfaces
 @attrs
 @implementer(_interfaces.IMailbox)
 class Mailbox(object):
-    _side = attrib(validator=instance_of(type("")))
+    _side = attrib(validator=instance_of(str))
     m = MethodicalMachine()
     set_trace = getattr(m, "_setTrace",
                         lambda self, f: None)  # pragma: no cover
@@ -95,9 +95,9 @@ class Mailbox(object):
         pass
 
     def rx_message(self, side, phase, body):
-        assert isinstance(side, type("")), type(side)
-        assert isinstance(phase, type("")), type(phase)
-        assert isinstance(body, type(b"")), type(body)
+        assert isinstance(side, str), type(side)
+        assert isinstance(phase, str), type(phase)
+        assert isinstance(body, bytes), type(body)
         if side == self._side:
             self.rx_message_ours(phase, body)
         else:
@@ -131,8 +131,8 @@ class Mailbox(object):
 
     @m.output()
     def queue(self, phase, body):
-        assert isinstance(phase, type("")), type(phase)
-        assert isinstance(body, type(b"")), (type(body), phase, body)
+        assert isinstance(phase, str), type(phase)
+        assert isinstance(body, bytes), (type(body), phase, body)
         self._pending_outbound[phase] = body
 
     @m.output()
@@ -151,8 +151,8 @@ class Mailbox(object):
 
     @m.output()
     def RC_tx_add(self, phase, body):
-        assert isinstance(phase, type("")), type(phase)
-        assert isinstance(body, type(b"")), type(body)
+        assert isinstance(phase, str), type(phase)
+        assert isinstance(body, bytes), type(body)
         self._RC.tx_add(phase, body)
 
     @m.output()

--- a/src/wormhole/_order.py
+++ b/src/wormhole/_order.py
@@ -10,7 +10,7 @@ from .util import provides
 @attrs
 @implementer(_interfaces.IOrder)
 class Order(object):
-    _side = attrib(validator=instance_of(type("")))
+    _side = attrib(validator=instance_of(str))
     _timing = attrib(validator=provides(_interfaces.ITiming))
     m = MethodicalMachine()
     set_trace = getattr(m, "_setTrace",
@@ -34,9 +34,9 @@ class Order(object):
 
     def got_message(self, side, phase, body):
         # print("ORDER[%s].got_message(%s)" % (self._side, phase))
-        assert isinstance(side, type("")), type(phase)
-        assert isinstance(phase, type("")), type(phase)
-        assert isinstance(body, type(b"")), type(body)
+        assert isinstance(side, str), type(phase)
+        assert isinstance(phase, str), type(phase)
+        assert isinstance(body, bytes), type(body)
         if phase == "pake":
             self.got_pake(side, phase, body)
         else:
@@ -52,9 +52,9 @@ class Order(object):
 
     @m.output()
     def queue(self, side, phase, body):
-        assert isinstance(side, type("")), type(phase)
-        assert isinstance(phase, type("")), type(phase)
-        assert isinstance(body, type(b"")), type(body)
+        assert isinstance(side, str), type(phase)
+        assert isinstance(phase, str), type(phase)
+        assert isinstance(body, bytes), type(body)
         self._queue.append((side, phase, body))
 
     @m.output()

--- a/src/wormhole/_receive.py
+++ b/src/wormhole/_receive.py
@@ -11,7 +11,7 @@ from .util import provides
 @attrs
 @implementer(_interfaces.IReceive)
 class Receive(object):
-    _side = attrib(validator=instance_of(type("")))
+    _side = attrib(validator=instance_of(str))
     _timing = attrib(validator=provides(_interfaces.ITiming))
     m = MethodicalMachine()
     set_trace = getattr(m, "_setTrace",
@@ -42,9 +42,9 @@ class Receive(object):
 
     # from Ordering
     def got_message(self, side, phase, body):
-        assert isinstance(side, type("")), type(phase)
-        assert isinstance(phase, type("")), type(phase)
-        assert isinstance(body, type(b"")), type(body)
+        assert isinstance(side, str), type(phase)
+        assert isinstance(phase, str), type(phase)
+        assert isinstance(body, bytes), type(body)
         assert self._key
         data_key = derive_phase_key(self._key, side, phase)
         try:
@@ -86,8 +86,8 @@ class Receive(object):
 
     @m.output()
     def W_got_message(self, phase, plaintext):
-        assert isinstance(phase, type("")), type(phase)
-        assert isinstance(plaintext, type(b"")), type(plaintext)
+        assert isinstance(phase, str), type(phase)
+        assert isinstance(plaintext, bytes), type(plaintext)
         self._B.got_message(phase, plaintext)
 
     @m.output()

--- a/src/wormhole/_rendezvous.py
+++ b/src/wormhole/_rendezvous.py
@@ -141,8 +141,8 @@ class RendezvousConnector(object):
         self._tx("open", mailbox=mailbox)
 
     def tx_add(self, phase, body):
-        assert isinstance(phase, type("")), type(phase)
-        assert isinstance(body, type(b"")), type(body)
+        assert isinstance(phase, str), type(phase)
+        assert isinstance(body, bytes), type(body)
         self._tx("add", phase=phase, body=bytes_to_hexstr(body))
 
     def tx_release(self, nameplate):
@@ -279,7 +279,7 @@ class RendezvousConnector(object):
 
     def _response_handle_allocated(self, msg):
         nameplate = msg["nameplate"]
-        assert isinstance(nameplate, type("")), type(nameplate)
+        assert isinstance(nameplate, str), type(nameplate)
         self._A.rx_allocated(nameplate)
 
     def _response_handle_nameplates(self, msg):
@@ -290,7 +290,7 @@ class RendezvousConnector(object):
         for n in nameplates:
             assert isinstance(n, dict), type(n)
             nameplate_id = n["id"]
-            assert isinstance(nameplate_id, type("")), type(nameplate_id)
+            assert isinstance(nameplate_id, str), type(nameplate_id)
             nids.add(nameplate_id)
         # deliver a set of nameplate ids
         self._L.rx_nameplates(nids)
@@ -312,13 +312,13 @@ class RendezvousConnector(object):
 
     def _response_handle_claimed(self, msg):
         mailbox = msg["mailbox"]
-        assert isinstance(mailbox, type("")), type(mailbox)
+        assert isinstance(mailbox, str), type(mailbox)
         self._N.rx_claimed(mailbox)
 
     def _response_handle_message(self, msg):
         side = msg["side"]
         phase = msg["phase"]
-        assert isinstance(phase, type("")), type(phase)
+        assert isinstance(phase, str), type(phase)
         body = hexstr_to_bytes(msg["body"])  # bytes
         self._M.rx_message(side, phase, body)
 

--- a/src/wormhole/_send.py
+++ b/src/wormhole/_send.py
@@ -43,8 +43,8 @@ class Send(object):
 
     @m.output()
     def queue(self, phase, plaintext):
-        assert isinstance(phase, type("")), type(phase)
-        assert isinstance(plaintext, type(b"")), type(plaintext)
+        assert isinstance(phase, str), type(phase)
+        assert isinstance(plaintext, bytes), type(plaintext)
         self._queue.append((phase, plaintext))
 
     @m.output()
@@ -60,8 +60,8 @@ class Send(object):
 
     @m.output()
     def deliver(self, phase, plaintext):
-        assert isinstance(phase, type("")), type(phase)
-        assert isinstance(plaintext, type(b"")), type(plaintext)
+        assert isinstance(phase, str), type(phase)
+        assert isinstance(plaintext, bytes), type(plaintext)
         self._encrypt_and_send(phase, plaintext)
 
     def _encrypt_and_send(self, phase, plaintext):

--- a/src/wormhole/cli/cli.py
+++ b/src/wormhole/cli/cli.py
@@ -103,7 +103,7 @@ class AliasedGroup(click.Group):
 )
 @click.option(
     "--dump-timing",
-    type=type(""),  # TODO: hide from --help output
+    type=str,  # TODO: hide from --help output
     default=None,
     metavar="FILE.json",
     help="(debug) write timing data to file",
@@ -274,7 +274,7 @@ def help(context, **kwargs):
     "--qr/--no-qr",
     default=True,
     help="Generate and show ASCII-based QR code.")
-@click.argument("what", required=False, type=click.Path(path_type=type("")))
+@click.argument("what", required=False, type=click.Path(path_type=str))
 @click.pass_obj
 def send(cfg, **kwargs):
     """Send a text message, file, or directory"""

--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -51,7 +51,7 @@ def receive(args, reactor=reactor, _debug_stash_wormhole=None):
 
 class Receiver:
     def __init__(self, args, reactor=reactor):
-        assert isinstance(args.relay_url, type(""))
+        assert isinstance(args.relay_url, str)
         self.args = args
         self._reactor = reactor
         self._tor = None

--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -51,7 +51,7 @@ class Sender:
 
     @inlineCallbacks
     def go(self):
-        assert isinstance(self._args.relay_url, type(""))
+        assert isinstance(self._args.relay_url, str)
         if self._args.tor:
             with self._timing.add("import", which="tor_manager"):
                 from ..tor_manager import get_tor

--- a/src/wormhole/test/dilate/test_manager.py
+++ b/src/wormhole/test/dilate/test_manager.py
@@ -241,7 +241,7 @@ def make_manager(leader=True):
 
 def test_make_side():
     side = make_side()
-    assert type(side) is type("")
+    assert type(side) is str
     assert len(side) == 2 * 8
 
 

--- a/src/wormhole/test/test_util.py
+++ b/src/wormhole/test/test_util.py
@@ -6,31 +6,31 @@ from .. import util
 
 def test_to_bytes():
     b = util.to_bytes("abc")
-    assert isinstance(b, type(b""))
+    assert isinstance(b, bytes)
     assert b == b"abc"
 
     A = unicodedata.lookup("LATIN SMALL LETTER A WITH DIAERESIS")
     b = util.to_bytes(A + "bc")
-    assert isinstance(b, type(b""))
+    assert isinstance(b, bytes)
     assert b == b"\xc3\xa4\x62\x63"
 
 def test_bytes_to_hexstr():
     b = b"\x00\x45\x91\xfe\xff"
     hexstr = util.bytes_to_hexstr(b)
-    assert isinstance(hexstr, type(""))
+    assert isinstance(hexstr, str)
     assert hexstr == "004591feff"
 
 def test_hexstr_to_bytes():
     hexstr = "004591feff"
     b = util.hexstr_to_bytes(hexstr)
     hexstr = util.bytes_to_hexstr(b)
-    assert isinstance(b, type(b""))
+    assert isinstance(b, bytes)
     assert b == b"\x00\x45\x91\xfe\xff"
 
 def test_dict_to_bytes():
     d = {"a": "b"}
     b = util.dict_to_bytes(d)
-    assert isinstance(b, type(b""))
+    assert isinstance(b, bytes)
     assert b == b'{"a": "b"}'
 
 def test_bytes_to_dict():

--- a/src/wormhole/test/test_wormhole.py
+++ b/src/wormhole/test/test_wormhole.py
@@ -86,7 +86,7 @@ async def test_delegated(reactor, mailbox):
 
     key1 = w1.derive_key("purpose", 16)
     assert len(key1) == 16
-    assert type(key1) is type(b"")
+    assert type(key1) is bytes
     with pytest.raises(TypeError):
         w1.derive_key(b"not unicode", 16)
     with pytest.raises(TypeError):
@@ -163,7 +163,7 @@ async def test_basic(reactor, mailbox):
 
     key1 = w1.derive_key("purpose", 16)
     assert len(key1) == 16
-    assert type(key1) is type(b"")
+    assert type(key1) is bytes
     with pytest.raises(TypeError):
         w1.derive_key(b"not unicode", 16)
     with pytest.raises(TypeError):
@@ -584,7 +584,7 @@ async def test_verifier(reactor, mailbox):
     w2.set_code(code)
     v1 = await w1.get_verifier()  # early
     v2 = await w2.get_verifier()
-    assert type(v1) is type(b"")
+    assert type(v1) is bytes
     assert v1 == v2
     w1.send_message(b"data1")
     w2.send_message(b"data2")

--- a/src/wormhole/tor_manager.py
+++ b/src/wormhole/tor_manager.py
@@ -69,7 +69,7 @@ def get_tor(reactor,
 
     if not isinstance(launch_tor, bool):  # note: False is int
         raise TypeError("launch_tor= must be boolean")
-    if not isinstance(tor_control_port, (type(""), type(None))):
+    if not isinstance(tor_control_port, (str, type(None))):
         raise TypeError("tor_control_port= must be str or None")
     assert tor_control_port != ""
     if launch_tor and tor_control_port is not None:

--- a/src/wormhole/transit.py
+++ b/src/wormhole/transit.py
@@ -81,7 +81,7 @@ def build_sender_handshake(key):
 
 
 def build_sided_relay_handshake(key, side):
-    assert isinstance(side, type(""))
+    assert isinstance(side, str)
     assert len(side) == 8 * 2
     token = HKDF(key, 32, CTXinfo=b"transit_relay_token")
     return b"please relay " + hexlify(token) + b" for side " + side.encode(
@@ -238,7 +238,7 @@ class Connection(protocol.Protocol, policies.TimeoutMixin):
         return self._description
 
     def send_record(self, record):
-        if not isinstance(record, type(b"")):
+        if not isinstance(record, bytes):
             raise InternalError
         assert SecretBox.NONCE_SIZE == 24
         assert self.send_nonce < 2**(8 * 24)
@@ -558,7 +558,7 @@ class Common:
                  timing=None):
         self._side = bytes_to_hexstr(os.urandom(8))  # unicode
         if transit_relay:
-            if not isinstance(transit_relay, type("")):
+            if not isinstance(transit_relay, str):
                 raise InternalError
             # TODO: allow multiple hints for a single relay
             relay_hint = parse_hint_argv(transit_relay)
@@ -738,7 +738,7 @@ class Common:
                 CTXinfo=b"transit_record_sender_key")
 
     def set_transit_key(self, key):
-        assert isinstance(key, type(b"")), type(key)
+        assert isinstance(key, bytes), type(key)
         # We use pubsub to protect against the race where the sender knows
         # the hints and the key, and connects to the receiver's transit
         # socket before the receiver gets the relay message (and thus the

--- a/src/wormhole/util.py
+++ b/src/wormhole/util.py
@@ -34,34 +34,34 @@ def to_bytes(u):
 
 
 def to_unicode(any):
-    if isinstance(any, type("")):
+    if isinstance(any, str):
         return any
     return any.decode("ascii")
 
 
 def bytes_to_hexstr(b):
-    assert isinstance(b, type(b""))
+    assert isinstance(b, bytes)
     hexstr = hexlify(b).decode("ascii")
-    assert isinstance(hexstr, type(""))
+    assert isinstance(hexstr, str)
     return hexstr
 
 
 def hexstr_to_bytes(hexstr):
-    assert isinstance(hexstr, type(""))
+    assert isinstance(hexstr, str)
     b = unhexlify(hexstr.encode("ascii"))
-    assert isinstance(b, type(b""))
+    assert isinstance(b, bytes)
     return b
 
 
 def dict_to_bytes(d):
     assert isinstance(d, dict)
     b = json.dumps(d).encode("utf-8")
-    assert isinstance(b, type(b""))
+    assert isinstance(b, bytes)
     return b
 
 
 def bytes_to_dict(b):
-    assert isinstance(b, type(b""))
+    assert isinstance(b, bytes)
     d = json.loads(b.decode("utf-8"))
     assert isinstance(d, dict)
     return d

--- a/src/wormhole/wormhole.py
+++ b/src/wormhole/wormhole.py
@@ -82,7 +82,7 @@ class _DelegatedWormhole(object):
         cannot be called until when_verifier() has fired, nor after close()
         was called.
         """
-        if not isinstance(purpose, type("")):
+        if not isinstance(purpose, str):
             raise TypeError(type(purpose))
         if not self._key:
             raise NoKeyError()
@@ -185,7 +185,7 @@ class _DeferredWormhole(object):
         cannot be called until when_verified() has fired, nor after close()
         was called.
         """
-        if not isinstance(purpose, type("")):
+        if not isinstance(purpose, str):
             raise TypeError(type(purpose))
         if not self._key:
             raise NoKeyError()
@@ -293,7 +293,7 @@ def create(
         wormhole_versions = {}  # don't advertise Dilation yet: not ready
     wormhole_versions["app_versions"] = versions  # app-specific capabilities
     v = __version__
-    if isinstance(v, type(b"")):
+    if isinstance(v, bytes):
         v = v.decode("utf-8", errors="replace")
     client_version = ("python", v)
     b = Boss(w, side, relay_url, appid, wormhole_versions, client_version,


### PR DESCRIPTION
This PR follows the discussion in PR #636.

I also replaced `type(b'')`.
I did not replaced `instance_of()` calls. They seem less obvious changes.

