### PR TITLE
doc: remove details about python2 types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@ User-visible changes in "magic-wormhole":
 * Update minimal Python version in README.md (#634 @sblondon)
 * Remove 'u' prefix to strings (#636 @sblondon)
 * Use classes directly instead of type() calls (#637 @sblondon)
-
+* Doc: remove details about python2 types (#638 @sblondon)
 
 ## Release 0.19.2 (30-May-2025)
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -723,15 +723,14 @@ subchannel.
 Bytes, Strings, Unicode, and Python 3
 -------------------------------------
 
-All cryptographically-sensitive parameters are passed as bytes (“str” in
-python2, “bytes” in python3):
+All cryptographically-sensitive parameters are passed as bytes (“bytes” in
+python3):
 
 -  verifier string
 -  data in/out
 -  transit records in/out
 
-Other (human-facing) values are always unicode (“unicode” in python2,
-“str” in python3):
+Other (human-facing) values are always unicode (“str” in python3):
 
 -  wormhole code
 -  relay URL


### PR DESCRIPTION
Python 2 was dropped since release 0.13.0 (10-Aug-2023).

There is another reference to python2 in documentation : in [welcome.rst](https://github.com/magic-wormhole/magic-wormhole/blob/750e938743242d0c5ff792e2c16143d1cc8ec318/docs/welcome.rst?plain=1#L190) ('On Windows, python2 may work better than python3.'). Is this line removable too?

<!-- readthedocs-preview magic-wormhole start -->
Please see the rendered documentation: https://magic-wormhole--638.org.readthedocs.build/en/638/
<!-- readthedocs-preview magic-wormhole end -->