### PR TITLE
test_receive_{send,receive}: disable pytest's output capturing

### DIFF
--- a/src/wormhole/test/test_args.py
+++ b/src/wormhole/test/test_args.py
@@ -192,10 +192,12 @@ def test_receive_accept_file_env_var():
     assert cfg.accept_file
 
 
-def test_receive_send():
-    cfg = config("send")
-    assert cfg.stdout == sys.stdout
+def test_receive_send(capsys):
+    with capsys.disabled():
+        cfg = config("send")
+        assert cfg.stdout == sys.stdout
 
-def test_receive_receive():
-    cfg = config("receive")
-    assert cfg.stdout == sys.stdout
+def test_receive_receive(capsys):
+    with capsys.disabled():
+        cfg = config("receive")
+        assert cfg.stdout == sys.stdout


### PR DESCRIPTION
These tests might otherwise fail, unless pytest is invoked with --capture=no.