### PR TITLE
Add magic-wormhole CLI command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(name="magic-wormhole",
           "console_scripts":
           [
               "wormhole = wormhole.cli.cli:wormhole",
-              "magic-wormhole = wormhole.cli.cli:wormhole",
+              "magic-wormhole = wormhole.cli.cli:wormhole", # it's advantageous to have an entry point that matches the package name, for things like `uv tool run`
           ]
       },
       install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(name="magic-wormhole",
           "console_scripts":
           [
               "wormhole = wormhole.cli.cli:wormhole",
+              "magic-wormhole = wormhole.cli.cli:wormhole",
           ]
       },
       install_requires=[


### PR DESCRIPTION
Right now it's a bit confusing to use `magic-wormhole` using `uvx`, because the package `magic-wormhole` comes with a command `wormhole`. To make it work you have to pass both to `uvx`:

```
uvx --from magic-wormhole wormhole
```

To make it easer for those users, this PR adds a second command `magic-wormhole` that does exactly the same as the short command, and allows the convenient call to

```
uvx magic-wormhole
```