### PR TITLE
Fix #650 bare pytest does not work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ lint:
 	tox -e flake8less
 
 test:
-	python -m pytest -W ignore::DeprecationWarning -r w -v -s src/wormhole/test
+	python -m pytest
 
 completions:
 	bash -c '_WORMHOLE_COMPLETE=bash_source wormhole > wormhole_complete.bash'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,8 @@ versionfile_source = "src/wormhole/_version.py"
 versionfile_build = "wormhole/_version.py"
 tag_prefix = ""
 parentdir_prefix = "magic-wormhole-"
+[tool.pytest.ini_options]
+addopts = "-W ignore::DeprecationWarning -r w -v -s"
+testpaths = [
+    "src/wormhole/test",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ versionfile_build = "wormhole/_version.py"
 tag_prefix = ""
 parentdir_prefix = "magic-wormhole-"
 [tool.pytest.ini_options]
-addopts = "-W ignore::DeprecationWarning -r w -v -s"
+addopts = "-W ignore::DeprecationWarning -r w -v"
 testpaths = [
     "src/wormhole/test",
 ]


### PR DESCRIPTION
Hello, the problem come from both `-s`  and the test path being required. So on master this works:
```shell
pytest src/wormhole/test/test_args.py::test_receive_send
pytest -k test_receive_send -s
```
but this doesn't:
```sh
pytest -k test_receive_send
```

So it seems something outside the `test` directory is interfering with `sys.stdout` when it's collected by pytest. But I am not able to tell what it is. 
Anyway, we want to restrict which directories pytest browses. And specifying `testpaths` solves the issue.
 
 I dropped `-s` as it is not required. If you find it nice to have the live stdout/stderr, then `--capture=tee-sys` could be used to [have the best of both worlds](https://docs.pytest.org/en/stable/how-to/capture-stdout-stderr.html#setting-capturing-methods-or-disabling-capturing).