### PR TITLE
SubchannelDemultiplex._pending_opens: fix type

### DIFF
--- a/src/wormhole/_dilation/subchannel.py
+++ b/src/wormhole/_dilation/subchannel.py
@@ -375,7 +375,7 @@ class SubchannelDemultiplex:
     """
     def __init__(self):
         self._factories = dict()  # name -> IProtocolFactory
-        self._pending_opens = defaultdict(list)  # name -> Sequence[[transport, address]]
+        self._pending_opens = defaultdict(deque)  # name -> Sequence[[transport, address]]
 
     # from manager (actually Inbound)
     # t is Subchannel (transport) instance


### PR DESCRIPTION
_pending_opens should contain deques, as popleft does not work on lists.