### PR TITLE
667: do not overwrite output directory

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@ User-visible changes in "magic-wormhole":
 * Produce errors for unwanted incoming subprotocols when user code asks (#660 @meejah, @shapr)
 * Correct types in Dilation subprotocols (#665 @mjoerg)
 * Support Bash < 4.0 completions for MacOS (#524 @meejah @niu541412)
+* Do not overwrite local directory specified with --output-file (#667 @dslemusp @meejah)
 
 
 ## Release 0.20.0 (30-Jul-2025)

--- a/src/wormhole/cli/cli.py
+++ b/src/wormhole/cli/cli.py
@@ -316,7 +316,9 @@ def go(f, cfg):
     "-o",
     metavar="FILENAME|DIRNAME",
     help=("The file or directory to create, overriding the name suggested"
-          " by the sender."),
+          " by the sender. If the directory exists already, the incoming transfer"
+          " will be put inside the specified directory."
+    ),
 )
 @click.option(
     "--allocate",

--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -457,7 +457,7 @@ class Receiver:
         tmp_name = f.name
         f.close()
         os.rename(tmp_name, self.abs_destname)
-        self._msg(f"Received file written to {os.path.basename(self.abs_destname)}")
+        self._msg(f"Received file written to: {self.abs_destname}")
 
     def _extract_file(self, zf, info, extract_dir):
         """
@@ -478,15 +478,13 @@ class Receiver:
         os.chmod(out_path, perm)
 
     def _write_directory(self, f):
-
         self._msg("Unpacking zipfile..")
         with self.args.timing.add("unpack zip"):
             with zipfile.ZipFile(f, "r") as zf:
                 for info in zf.infolist():
                     self._extract_file(zf, info, self.abs_destname)
 
-            self._msg("Received files written to %s/" % repr(os.path.basename(
-                self.abs_destname)))
+            self._msg(f"Received files written to: {self.abs_destname}")
             f.close()
 
     @inlineCallbacks

--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -1,6 +1,5 @@
 import hashlib
 import os
-import shutil
 import sys
 import tempfile
 import zipfile
@@ -365,24 +364,25 @@ class Receiver:
         """
         # the basename() is intended to protect us against
         # "~/.ssh/authorized_keys" and other attacks
-        destname = os.path.basename(destname)
+        if self.args.output_file:
+            abs_destname = os.path.abspath(os.path.join(self.args.cwd, self.args.output_file))
+        else:
+            abs_destname = os.path.abspath(os.path.join(self.args.cwd, destname))
         overwrite_allowed = False
         if self.args.output_file:
-            if os.path.exists(self.args.output_file):
-                if os.path.isdir(self.args.output_file):
+             if os.path.exists(abs_destname):
+                if os.path.isdir(abs_destname):
                     # '--output-file' is an existing directory so put
                     # the incoming file _inside_ of it (i.e.. don't
                     # delete + overwrite whole tree)
-                    destname = os.path.join(self.args.output_file, destname)
+                    abs_destname = os.path.abspath(
+                        os.path.join(self.args.cwd, self.args.output_file, destname)
+                    )
+                    overwrite_allowed = True
                 else:
                     # the user specified an existing _file_, so we can
                     # overwrite it
                     overwrite_allowed = True
-                    destname = self.args.output_file  # override
-            else:
-                # the user specified a non-existing file
-                destname = self.args.output_file  # override
-        abs_destname = os.path.abspath(os.path.join(self.args.cwd, destname))
 
         # get confirmation from the user before writing to the local directory
         if os.path.exists(abs_destname):

--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -387,7 +387,7 @@ class Receiver:
         # get confirmation from the user before writing to the local directory
         if os.path.exists(abs_destname):
             if overwrite_allowed:  # overwrite is intentional
-                self._msg(f"Overwriting {repr(destname)}")
+                self._msg(f"Overwriting {repr(self.args.output_file)}")
                 if self.args.accept_file:
                     self._remove_existing(abs_destname)
             else:

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -1201,7 +1201,7 @@ def test_existing_destdir(tmpdir_factory):
     """
     We should preserve user data when they specify an existing
     destination _directory_ via --output-file (whereas we overwrite
-    files if exlicitly specified like this)
+    files if explicitly specified like this)
     """
     args = mock.Mock()
     args.relay_url = ""

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -1208,9 +1208,6 @@ def test_existing_destdir(tmpdir_factory):
     tmpdir = tempfile.mkdtemp()
     args.cwd = os.getcwd()
     args.output_file = tmpdir
-    # 1. create tempdir
-    # 2. specify ^ as --output-file
-    # 3. call "_decide_destname"
     cmd = cmd_receive.Receiver(args)
 
     s = cmd._decide_destname(None, "destination_file")

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -1217,6 +1217,20 @@ def test_existing_destdir(tmpdir_factory):
     assert s == os.path.join(tmpdir, "destination_file")
 
 
+def test_not_remove_existing_destdir(tmpdir_factory):
+    """
+    Do not remove an entire existing directory.
+    """
+    args = mock.Mock()
+    args.relay_url = ""
+    tmpdir = tempfile.mkdtemp()
+    args.cwd = os.getcwd()
+    args.output_file = tmpdir
+    cmd = cmd_receive.Receiver(args)
+    with pytest.raises(cmd_receive.TransferRejectedError):
+        cmd._remove_existing(tmpdir)
+
+
 @pytest_twisted.ensureDeferred
 async def test_override(request, reactor):
     # note: we do not use the "mailbox" fixture because that is

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -501,7 +501,9 @@ async def _do_test(
             recv_cfg.output_file = receive_dirname = "outdir"
         if overwrite:
             recv_cfg.output_file = receive_dirname
-            os.mkdir(os.path.join(receive_dir, receive_dirname))
+            existing_file = os.path.join(receive_dir, receive_dirname)
+            with open(existing_file, 'w') as f:
+                f.write('pls overwrite me')
 
     if as_subprocess:
         if send_cfg.text:
@@ -713,7 +715,7 @@ async def _do_test(
             name=receive_filename,
         )
         assert want in receive_stderr
-        assert "Received file written to " in receive_stderr
+        assert "Received file written to:" in receive_stderr
         fn = os.path.join(receive_dir, receive_filename)
         assert os.path.exists(fn)
         with open(fn) as f:
@@ -723,7 +725,8 @@ async def _do_test(
         want = (r"Receiving directory \(\d+ \w+\) into: {name!r}/"
                 .format(name=receive_dirname))
         assert re.search(want, receive_stderr), (want, receive_stderr)
-        assert f"Received files written to {receive_dirname!r}" in receive_stderr
+        assert "Received files written to" in receive_stderr
+        assert f"{receive_dirname!r}" in receive_stderr
         fn = os.path.join(receive_dir, receive_dirname)
         assert os.path.exists(fn), fn
         for i in range(5):
@@ -787,19 +790,6 @@ async def test_directory_override(wormhole_executable, scripts_env, mailbox, tra
 
 async def test_directory_overwrite(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
     await _do_test(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory, mode="directory", overwrite=True)
-
-
-async def test_directory_overwrite_mock_accept(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
-    await _do_test(
-        wormhole_executable,
-        scripts_env,
-        mailbox,
-        transit_relay,
-        tmpdir_factory,
-        mode="directory",
-        overwrite=True,
-        mock_accept=True,
-    )
 
 
 async def test_slow_text(wormhole_executable, scripts_env, mailbox, transit_relay, tmpdir_factory):
@@ -911,13 +901,13 @@ async def _do_test_fail(wormhole_executable, scripts_env, relayurl, tmpdir_facto
 
     # check receiver
     if mode == "file":
-        assert "Received file written to " not in receive_stderr
+        assert "Received file written to:" not in receive_stderr
         if failmode == "noclobber":
             assert f"Error: refusing to overwrite existing 'testfile'{NL}" in receive_stderr
         else:
             assert f"Error: insufficient free space (0B) for file ({size:d}B){NL}" in receive_stderr
     elif mode == "directory":
-        assert f"Received files written to {receive_name!r}" not in receive_stderr
+        assert "Received files written to" not in receive_stderr
         # want = (r"Receiving directory \(\d+ \w+\) into: {name}/"
         #        .format(name=receive_name))
         # self.failUnless(re.search(want, receive_stderr),
@@ -1223,9 +1213,8 @@ def test_existing_destdir(tmpdir_factory):
     # 3. call "_decide_destname"
     cmd = cmd_receive.Receiver(args)
 
-    dst = cmd._decide_destname(None, "destination_file")
-    expected = os.path.join(tmpdir, "destination_file")
-    assert dst == os.path.abspath(expected)
+    s = cmd._decide_destname(None, "destination_file")
+    assert s == os.path.join(tmpdir, "destination_file")
 
 
 @pytest_twisted.ensureDeferred


### PR DESCRIPTION
Fixes #667 

This changes the behavior of `--output-file` when it is pointed at a directory: instead of deleting the entire target directory tree, the delivered file (or directory) is placed inside the target (more like what `cp` or `mv` would do)