### PR TITLE
protocol versioning documentation

### DIFF
--- a/docs/server-protocol.rst
+++ b/docs/server-protocol.rst
@@ -41,6 +41,22 @@ Each client has a randomly-generated “side”, a short hex string, used to
 differentiate between echoes of a client’s own message, and real
 messages from the other client.
 
+
+Protocol Versioning
+-------------------
+
+Different versions of the Mailbox protocol are indicated by the WebSocket URI used to access the service.
+For example, ``ws://relay.magic-wormhole.io:4000/v1`` is the default (public) Mailbox server.
+The version is indicated by the ``/v1`` path; "version 2" would be at ``ws://relay.magic-wormhole.io:4000/v2``.
+
+A server may offer multiple different versions.
+
+The following versions exist:
+
+- ``/v1/``: the first published version
+- ``/v2/``: introduces a ``"you"`` key in the ``"welcome"`` message. ``"you"`` points at a ``dict`` containing an integer ``"port"`` number, and either an ``"ipv4"`` or ``"ipv6"`` containing a string representation of the IPv4 or IPv6 address that you are visible to the server as.
+
+
 Application IDs
 ---------------
 

--- a/docs/server-protocol.rst
+++ b/docs/server-protocol.rst
@@ -53,8 +53,12 @@ A server may offer multiple different versions.
 
 The following versions exist:
 
-- ``/v1/``: the first published version
-- ``/v2/``: introduces a ``"you"`` key in the ``"welcome"`` message. ``"you"`` points at a ``dict`` containing an integer ``"port"`` number, and either an ``"ipv4"`` or ``"ipv6"`` containing a string representation of the IPv4 or IPv6 address that you are visible to the server as.
+``/v1/``
+~~~~~~~~
+
+This is the first public version, and still  (as of May, 2026) the only deployed version.
+
+- after server version **0.8.0**, the ``"welcome"`` message may include a ``"your-address"`` key.
 
 
 Application IDs
@@ -141,6 +145,7 @@ respectively) that all subsequent messages will be scoped to.
 
 The first thing the server sends to each client is the ``welcome`` message.
 This is intended to deliver important status information to the client that might influence its operation.
+Clients SHOULD ignore any extra keys in the Welcome message.
 The Python client currently reacts to the following keys (and ignores all others):
 
 -  ``current_cli_version``: prompts the user to upgrade if the server’s
@@ -154,6 +159,11 @@ The Python client currently reacts to the following keys (and ignores all others
    ticket or other authorization record, the server can send ``error``
    (explaining the requirement) if it does not see this ticket arrive
    before the ``bind``.
+- ``your-address``: a ``dict`` containing an integer ``"port"``
+  number, and either an ``"ipv4"`` or ``"ipv6"`` containing a string
+  representation of the IPv4 or IPv6 address that you are visible to
+  the server as.
+
 
 .. seqdiag::
 


### PR DESCRIPTION
If https://github.com/magic-wormhole/magic-wormhole-mailbox-server/pull/63 is merged, then this becomes relevant and may also be merged.

<!-- readthedocs-preview magic-wormhole start -->
Please see the rendered documentation: https://magic-wormhole--684.org.readthedocs.build/en/684/
<!-- readthedocs-preview magic-wormhole end -->