### PR TITLE
Add PyApp update reminder

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@ User-visible changes in "magic-wormhole":
 
 ## Upcoming Release
 
-* (add release-notes here when making PRs)
+* Remind PyApp users to run ``wormhole self update`` when their installed
+  release is more than six months old (#707)
 
 
 ## Release 0.23.0 (10-Mar-2026)

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(name="magic-wormhole",
           "zipstream-ng >= 1.7.1, <2.0.0",
           "iterable-io >= 1.0.0, <2.0.0",
           "qrcode >= 8.0",
+          "platformdirs >= 4.0",
       ],
       extras_require={
           ':sys_platform=="win32"': ["pywin32"],

--- a/src/wormhole/cli/update_reminder.py
+++ b/src/wormhole/cli/update_reminder.py
@@ -1,0 +1,108 @@
+import json
+import os
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+from platformdirs import user_state_path
+
+from .._version import get_versions
+
+
+STALE_RELEASE_DAYS = 183
+REMINDER_DAYS = 30
+STATE_FILENAME = "pyapp-update-reminder.json"
+
+
+def _parse_datetime(value):
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _load_last_reminder(state_path):
+    if not state_path.exists():
+        return None
+    with state_path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    last_reminder = data.get("last_reminder")
+    if last_reminder is None:
+        return None
+    return date.fromisoformat(last_reminder)
+
+
+def _write_last_reminder(state_path, today):
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    with state_path.open("w", encoding="utf-8") as f:
+        json.dump({"last_reminder": today.isoformat()}, f)
+        f.write("\n")
+
+
+def _default_state_path():
+    return user_state_path(
+        appname="magic-wormhole",
+        appauthor=False,
+    ) / STATE_FILENAME
+
+
+def maybe_remind_about_pyapp_update(
+        my_version,
+        stderr,
+        now=None,
+        environ=None,
+        state_path=None,
+        release_date=None):
+    """
+    Remind PyApp users to manually check for updates when a release is old.
+
+    PyApp sets ``PYAPP`` for launched applications. This function deliberately
+    does not make any network requests; it only uses release metadata bundled
+    into the installed package and a local state file.
+    """
+    environ = os.environ if environ is None else environ
+    if "PYAPP" not in environ:
+        return
+    if "+" in my_version:
+        return
+
+    now = datetime.now(timezone.utc) if now is None else now
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=timezone.utc)
+    now = now.astimezone(timezone.utc)
+
+    if release_date is None:
+        release_date = get_versions().get("date")
+    release_datetime = _parse_datetime(release_date)
+    if release_datetime is None:
+        return
+
+    if (now - release_datetime).days <= STALE_RELEASE_DAYS:
+        return
+
+    try:
+        today = now.date()
+        state_path = (
+            _default_state_path()
+            if state_path is None else Path(state_path)
+        )
+        last_reminder = _load_last_reminder(state_path)
+        if (last_reminder is not None and
+                (today - last_reminder).days < REMINDER_DAYS):
+            return
+        _write_last_reminder(state_path, today)
+    except Exception:
+        return
+
+    command = environ.get("PYAPP_COMMAND_NAME", "self")
+    print(
+        (
+            "This Magic Wormhole release is more than six months old. "
+            f"To check for a newer PyApp build, run: wormhole {command} update"
+        ),
+        file=stderr,
+    )

--- a/src/wormhole/cli/welcome.py
+++ b/src/wormhole/cli/welcome.py
@@ -1,3 +1,6 @@
+from .update_reminder import maybe_remind_about_pyapp_update
+
+
 def handle_welcome(welcome, relay_url, my_version, stderr):
     if "motd" in welcome:
         motd_lines = welcome["motd"].splitlines()
@@ -19,3 +22,5 @@ def handle_welcome(welcome, relay_url, my_version, stderr):
             "Server claims %s is current, but ours is %s" %
             (welcome["current_cli_version"], my_version),
             file=stderr)
+
+    maybe_remind_about_pyapp_update(my_version, stderr)

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -1,5 +1,7 @@
 import builtins
+import datetime
 import io
+import json
 import os
 import re
 import stat
@@ -26,7 +28,7 @@ import pytest_twisted
 
 from .. import __version__
 from .._interfaces import ITorManager
-from ..cli import cli, cmd_receive, cmd_send, welcome
+from ..cli import cli, cmd_receive, cmd_send, update_reminder, welcome
 from ..errors import (ServerConnectionError, ServerError, TransferError,
                       UnsendableFileError, WelcomeError, WrongPasswordError)
 from .common import config, setup_mailbox
@@ -1323,6 +1325,119 @@ def test_version_unreleased():
 def test_motd():
     stderr = _welcome_test({"motd": "hello"})
     assert stderr == "Server (at url) says:\n hello\n"
+
+
+def _reminder_test(
+        tmp_path,
+        *,
+        my_version="2.0",
+        now=datetime.datetime(2026, 10, 1, tzinfo=datetime.timezone.utc),
+        environ=None,
+        release_date="2026-03-01T00:00:00+00:00"):
+    stderr = io.StringIO()
+    state_path = tmp_path / "pyapp-update-reminder.json"
+    update_reminder.maybe_remind_about_pyapp_update(
+        my_version,
+        stderr,
+        now=now,
+        environ={} if environ is None else environ,
+        state_path=state_path,
+        release_date=release_date,
+    )
+    return stderr.getvalue(), state_path
+
+
+def test_pyapp_update_reminder_ignores_non_pyapp(tmp_path):
+    stderr, state_path = _reminder_test(tmp_path)
+    assert stderr == ""
+    assert not state_path.exists()
+
+
+def test_pyapp_update_reminder_ignores_unreleased_versions(tmp_path):
+    stderr, state_path = _reminder_test(
+        tmp_path,
+        my_version="2.0+middle.something",
+        environ={"PYAPP": "1"},
+    )
+    assert stderr == ""
+    assert not state_path.exists()
+
+
+def test_pyapp_update_reminder_ignores_recent_releases(tmp_path):
+    stderr, state_path = _reminder_test(
+        tmp_path,
+        now=datetime.datetime(2026, 4, 1, tzinfo=datetime.timezone.utc),
+        environ={"PYAPP": "1"},
+    )
+    assert stderr == ""
+    assert not state_path.exists()
+
+
+def test_pyapp_update_reminder_warns_for_old_releases(tmp_path):
+    stderr, state_path = _reminder_test(tmp_path, environ={"PYAPP": "1"})
+    expected = (
+        "This Magic Wormhole release is more than six months old. "
+        "To check for a newer PyApp build, run: wormhole self update\n"
+    )
+    assert stderr == expected
+    assert json.loads(state_path.read_text()) == {
+        "last_reminder": "2026-10-01",
+    }
+
+
+def test_pyapp_update_reminder_honors_command_name(tmp_path):
+    stderr, state_path = _reminder_test(
+        tmp_path,
+        environ={
+            "PYAPP": "1",
+            "PYAPP_COMMAND_NAME": "manage",
+        },
+    )
+    expected = (
+        "This Magic Wormhole release is more than six months old. "
+        "To check for a newer PyApp build, run: wormhole manage update\n"
+    )
+    assert stderr == expected
+    assert state_path.exists()
+
+
+def test_pyapp_update_reminder_suppresses_recent_reminders(tmp_path):
+    state_path = tmp_path / "pyapp-update-reminder.json"
+    state_path.write_text('{"last_reminder": "2026-09-15"}\n')
+    stderr, _ = _reminder_test(tmp_path, environ={"PYAPP": "1"})
+    assert stderr == ""
+    assert json.loads(state_path.read_text()) == {
+        "last_reminder": "2026-09-15",
+    }
+
+
+def test_pyapp_update_reminder_repeats_after_thirty_days(tmp_path):
+    state_path = tmp_path / "pyapp-update-reminder.json"
+    state_path.write_text('{"last_reminder": "2026-08-31"}\n')
+    stderr, _ = _reminder_test(tmp_path, environ={"PYAPP": "1"})
+    expected = (
+        "This Magic Wormhole release is more than six months old. "
+        "To check for a newer PyApp build, run: wormhole self update\n"
+    )
+    assert stderr == expected
+    assert json.loads(state_path.read_text()) == {
+        "last_reminder": "2026-10-01",
+    }
+
+
+def test_pyapp_update_reminder_ignores_state_failures(tmp_path):
+    blocked = tmp_path / "blocked"
+    blocked.write_text("not a directory")
+    stderr = io.StringIO()
+    update_reminder.maybe_remind_about_pyapp_update(
+        "2.0",
+        stderr,
+        now=datetime.datetime(2026, 10, 1, tzinfo=datetime.timezone.utc),
+        environ={"PYAPP": "1"},
+        state_path=blocked / "pyapp-update-reminder.json",
+        release_date="2026-03-01T00:00:00+00:00",
+    )
+    assert stderr.getvalue() == ""
 
 
 @pytest_twisted.ensureDeferred


### PR DESCRIPTION
PyApp builds can update themselves, but the client should not phone home just to discover whether it is stale. This adds a local reminder that only runs when PyApp has set the `PYAPP` environment variable and the installed release metadata is more than six months old.

The reminder records its last display date under the platformdirs user state directory and only repeats after 30 days. If the state directory or file cannot be read or written, the reminder is suppressed so users are not nagged repeatedly.

Changes:
- `cli/update_reminder.py`: add PyApp detection, Versioneer release-date handling, platformdirs state storage, and reminder throttling.
- `cli/welcome.py`: invoke the reminder from the existing welcome path without adding any network activity.
- `test_cli.py`: cover non-PyApp runs, unreleased versions, recent releases, old releases, custom PyApp command names, reminder throttling, and state-storage failures.
- `setup.py` and `NEWS.md`: declare the new runtime dependency and release note.

Tests:
- `python -m pytest src/wormhole/test/test_cli.py -k "pyapp_update_reminder or test_empty or test_version_current or test_version_old or test_version_unreleased or test_motd"`
- `python -m pytest src/wormhole/test/test_cli.py`
- `python -m pyflakes setup.py src/wormhole/cli/welcome.py src/wormhole/cli/update_reminder.py src/wormhole/test/test_cli.py`
- `tox -e flake8less`
- `git diff --check`

Fixes #707