### PR TITLE
fix: install shell completion scripts into standard data dirs (#619)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,11 @@ setup(name="magic-wormhole",
                 "wormhole.test",
                 "wormhole.test.dilate",
                 ],
-      data_files=[(".", ["wormhole_complete.bash", "wormhole_complete.zsh", "wormhole_complete.fish"])],
+      data_files=[
+          ("share/bash-completion/completions", ["wormhole_complete.bash"]),
+          ("share/zsh/site-functions", ["wormhole_complete.zsh"]),
+          ("share/fish/vendor_completions.d", ["wormhole_complete.fish"]),
+      ],
       entry_points={
           "console_scripts":
           [


### PR DESCRIPTION
## Summary

Move shell completion scripts out of the install prefix root and into the standard XDG data directories each shell looks in.

## Why this matters

The reporter on #619 ran into this from pkgsrc, where a wheel install at `/usr/pkg` results in `/usr/pkg/wormhole_complete.bash`, `wormhole_complete.zsh`, and `wormhole_complete.fish` sitting directly at the top of the prefix. Their workaround was to drop the line from `setup.py` and skip completion installation entirely.

The current `setup.py:40` is:

```python
data_files=[(".", ["wormhole_complete.bash", "wormhole_complete.zsh", "wormhole_complete.fish"])],
```

`(".", [...])` resolves to the install prefix itself, which is where the files end up. None of the three shells look there for completions.

## Changes

`setup.py:40` — split the single tuple into three, one per shell, each pointing at the shell's own completion data dir:

- `share/bash-completion/completions/wormhole_complete.bash` — searched by `bash-completion` >= 2.x
- `share/zsh/site-functions/wormhole_complete.zsh` — searched by zsh's autoloader (`fpath`)
- `share/fish/vendor_completions.d/wormhole_complete.fish` — vendor location fish auto-sources

For a wheel installed at any prefix `$P`, the files land at `$P/share/<shell>/.../` instead of `$P/`.

## Testing

- `python3 -c "import ast; ast.parse(open('setup.py').read())"` — clean.
- `data_files` is a setuptools structure, not exercised by the test suite. The runtime effect (`pip install` write locations) is what changes.

Fixes #619
