### PR TITLE
fix(ssh) : Correct permission on authorized_keys creation

### DIFF
--- a/src/wormhole/cli/cmd_ssh.py
+++ b/src/wormhole/cli/cmd_ssh.py
@@ -120,9 +120,11 @@ def invite(cfg, reactor=reactor):
     kind = parts[0]
     keyid = 'unknown' if len(parts) <= 2 else parts[2]
 
-    if not exists(auth_key_path):
-        if not exists(ssh_path):
-            os.mkdir(ssh_path, mode=0o700)
-    with open(auth_key_path, 'a', 0o600) as f:
+    if not exists(ssh_path):
+        os.mkdir(ssh_path, mode=0o700)
+
+    auth_key_path_fd = os.open(auth_key_path, os.O_WRONLY | os.O_APPEND | os.O_CREAT, 0o600)
+    with os.fdopen(auth_key_path_fd, 'a') as f:
         f.write(f'{pubkey.strip()}\n')
+
     print(f"Appended key type='{kind}' id='{keyid}' to '{auth_key_path}'")


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug in `cmd_ssh.py` where a newly created `authorized_keys` file would inherit the user's default `umask` (e.g., `0o644`) instead of enforcing the strict `0o600` permissions required by OpenSSH.

### Why is this necessary?
Around line 128, the code used Python's built-in `open()`:
`with open(auth_key_path, 'a', 0o600) as f:`

The third argument of the built-in `open()` function is the `buffering` size, not the file `mode`. As a result, `0o600` was simply evaluated as an integer (384 bytes of buffer), and the file creation fell back to the system's `umask`. 

Because the SSH daemon is strictly paranoid and ignores `authorized_keys` files with broad access permissions, this bug could inadvertently break a user's SSH setup if Wormhole was the one creating the file.

### How was it fixed?
I replaced the built-in `open()` with `os.open()` using explicit flags (`os.O_CREAT | os.O_APPEND | os.O_WRONLY`) and explicitly passed `mode=0o600`. This ensures the file is created securely, bypassing the umask, before wrapping it back into a standard Python file object with `os.fdopen()`.