### PR TITLE
docs: fix typo in NEWS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -502,7 +502,7 @@ Github.
   suitably-permissioned remote `~/.ssh/authorized_keys` file. These commands
   are experimental: the syntax might be changed in the future, or they might
   be removed altogether.
-* CLI: "wormhole recv" and "wormhole recieve" are now accepted as aliases for
+* CLI: "wormhole recv" and "wormhole receive" are now accepted as aliases for
   "wormhole receive", to help bad spelers :)
 * CLI: improve display of abbreviated file sizes
 * CLI: don't print traceback upon "normal" errors


### PR DESCRIPTION
Fixes a small spelling typo in NEWS.md: `recieve` → `receive`.

This is a documentation-only change.