### PR TITLE
Adding winget

### DIFF
--- a/docs/welcome.rst
+++ b/docs/welcome.rst
@@ -190,15 +190,22 @@ a third-party package (published by the “snapcrafters” group):
 Windows
 ~~~~~~~
 
+The binaries for Windows are provided by this project:
+https://github.com/aquacash5/magic-wormhole-exe
+
+Winget
+^^^^^^
+
+::
+
+   $ winget install -e --id magic-wormhole.magic-wormhole
+
 Chocolatey
 ^^^^^^^^^^
 
 ::
 
    $ choco install magic-wormhole
-
-The binaries for Windows are provided from this project:
-https://github.com/aquacash5/magic-wormhole-exe
 
 Install from Source
 ~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
`winget` is more available on Windows than chocolatey:  WinGet comes pre-installed on Windows 11 and modern versions of Windows 10 as part of the "App Installer"

Therefore, I added the `winget` program as first. 

<!-- readthedocs-preview magic-wormhole start -->
Please see the rendered documentation: https://magic-wormhole--721.org.readthedocs.build/en/721/
<!-- readthedocs-preview magic-wormhole end -->