### PR TITLE
Update Wormhole Android application link

### DIFF
--- a/docs/welcome.rst
+++ b/docs/welcome.rst
@@ -72,7 +72,7 @@ Motivational Use-Cases
 
 * ``wormhole send`` + ``wormhole receive`` (as demonstrated above) are provided by this package and allow transfer of arbitrary files and directories;
 * `Warp <https://gitlab.gnome.org/World/warp>`_ is a Gnome GUI application to transfer files and directories (works with the CLI);
-* `Wormhole <https://gitlab.com/lukas-heiligenbrunner/wormhole>`_: phone application for Android;
+* `Wormhole <https://github.com/wormhole-app/wormhole>`_: phone application for Android;
 * `git withme <https://git.sr.ht/~meejah/git-withme>`_ allows two peers to directly use Git together (without any hosting service like GitLab or `gitolite <https://gitolite.com/gitolite/>`_);
 * `Pear On <https://git.sr.ht/~meejah/pear-on>`_ allows two peers to use `tty-share; <https://github.com/elisescu/tty-share>`_ directly, without running or using a centralized server;
 * See :doc:`ecosystem` for more implementations and applications


### PR DESCRIPTION
https://gitlab.com/lukas-heiligenbrunner/wormhole is the old link as its README mentions:

> ⚠️ **Project Notice**  
> This project is **no longer active on GitLab**.  
> Development has **moved to GitHub**: [👉 github.com/wormhole-app/wormhole](https://github.com/wormhole-app/wormhole)


<!-- readthedocs-preview magic-wormhole start -->
Please see the rendered documentation: https://magic-wormhole--723.org.readthedocs.build/en/723/
<!-- readthedocs-preview magic-wormhole end -->