### PR TITLE
Docs: Fix typo in ecosystem.rst

### DIFF
--- a/docs/ecosystem.rst
+++ b/docs/ecosystem.rst
@@ -116,7 +116,7 @@ End User / Client Applications
 ------------------------------
 
 Based on the above libraries, there are several end-user applications targeting different platforms.
-Unless otherwise noted, these "inherit" any limitations of their langauge's library implementation from the above table.
+Unless otherwise noted, these "inherit" any limitations of their language's library implementation from the above table.
 
 Library and CLI
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fix typo in ecosystem.rst: `langauge` to `language`

<!-- readthedocs-preview magic-wormhole start -->
Please see the rendered documentation: https://magic-wormhole--727.org.readthedocs.build/en/727/
<!-- readthedocs-preview magic-wormhole end -->