### PR TITLE
bail with CrowdedError if we see messages from a third side

### DIFF
--- a/src/wormhole/_boss.py
+++ b/src/wormhole/_boss.py
@@ -23,7 +23,7 @@ from ._status import WormholeStatus, AllegedSharedKey, ConfirmedKey, Closed
 from ._terminator import Terminator
 from ._wordlist import PGPWordList
 from .errors import (LonelyError, OnlyOneCodeError, ServerError, WelcomeError,
-                     WrongPasswordError, _UnknownPhaseError)
+                     WrongPasswordError, _UnknownPhaseError, CrowdedError)
 from .util import bytes_to_dict, provides
 
 
@@ -82,7 +82,7 @@ class Boss:
         )
 
         self._N.wire(self._M, self._I, self._RC, self._T)
-        self._M.wire(self._N, self._RC, self._O, self._T)
+        self._M.wire(self, self._N, self._RC, self._O, self._T)
         self._S.wire(self._M)
         self._O.wire(self._K, self._R)
         self._K.wire(self, self._M, self._R)
@@ -289,12 +289,17 @@ class Boss:
 
     # Key sends (got_key, scared)
     # Receive sends (got_message, happy, got_verifier, scared)
+    # Mailbox sends (crowded)
     @m.input()
     def happy(self):
         pass
 
     @m.input()
     def scared(self):
+        pass
+
+    @m.input()
+    def crowded(self):
         pass
 
     def got_message(self, phase, plaintext):
@@ -375,6 +380,11 @@ class Boss:
         self._T.close("scary")
 
     @m.output()
+    def close_crowded(self):
+        self._result = CrowdedError()
+        self._T.close("crowded")
+
+    @m.output()
     def close_lonely(self):
         self._result = LonelyError()
         self._T.close("lonely")
@@ -453,6 +463,7 @@ class Boss:
     S1_lonely.upon(rx_unwelcome, enter=S3_closing, outputs=[close_unwelcome])
     S1_lonely.upon(happy, enter=S2_happy, outputs=[])
     S1_lonely.upon(scared, enter=S3_closing, outputs=[close_scared])
+    S1_lonely.upon(crowded, enter=S3_closing, outputs=[close_crowded])
     S1_lonely.upon(close, enter=S3_closing, outputs=[close_lonely])
     S1_lonely.upon(send, enter=S1_lonely, outputs=[S_send])
     S1_lonely.upon(got_key, enter=S1_lonely, outputs=[W_got_key, D_got_key, send_status_peer_key])
@@ -465,6 +476,7 @@ class Boss:
     S2_happy.upon(_got_version, enter=S2_happy, outputs=[process_version, send_status_confirmed_key])
     S2_happy.upon(_got_dilate, enter=S2_happy, outputs=[D_received_dilate])
     S2_happy.upon(scared, enter=S3_closing, outputs=[close_scared])
+    S2_happy.upon(crowded, enter=S3_closing, outputs=[close_crowded])
     S2_happy.upon(close, enter=S3_closing, outputs=[close_happy])
     S2_happy.upon(send, enter=S2_happy, outputs=[S_send])
     S2_happy.upon(rx_error, enter=S3_closing, outputs=[close_error])
@@ -478,6 +490,7 @@ class Boss:
     S3_closing.upon(_got_dilate, enter=S3_closing, outputs=[])
     S3_closing.upon(happy, enter=S3_closing, outputs=[])
     S3_closing.upon(scared, enter=S3_closing, outputs=[])
+    S3_closing.upon(crowded, enter=S3_closing, outputs=[])
     S3_closing.upon(close, enter=S3_closing, outputs=[])
     S3_closing.upon(send, enter=S3_closing, outputs=[])
     S3_closing.upon(closed, enter=S4_closed, outputs=[W_closed, send_status_closed])
@@ -490,6 +503,7 @@ class Boss:
     S4_closed.upon(_got_dilate, enter=S4_closed, outputs=[])
     S4_closed.upon(happy, enter=S4_closed, outputs=[])
     S4_closed.upon(scared, enter=S4_closed, outputs=[])
+    S4_closed.upon(crowded, enter=S4_closed, outputs=[])
     S4_closed.upon(close, enter=S4_closed, outputs=[])
     S4_closed.upon(send, enter=S4_closed, outputs=[])
     S4_closed.upon(error, enter=S4_closed, outputs=[])

--- a/src/wormhole/_mailbox.py
+++ b/src/wormhole/_mailbox.py
@@ -16,10 +16,12 @@ class Mailbox:
 
     def __attrs_post_init__(self):
         self._mailbox = None
+        self._their_side = None # set by first non-ours message
         self._pending_outbound = {}
         self._processed = set()
 
-    def wire(self, nameplate, rendezvous_connector, ordering, terminator):
+    def wire(self, boss, nameplate, rendezvous_connector, ordering, terminator):
+        self._B = _interfaces.IBoss(boss)
         self._N = _interfaces.INameplate(nameplate)
         self._RC = _interfaces.IRendezvousConnector(rendezvous_connector)
         self._O = _interfaces.IOrder(ordering)
@@ -101,7 +103,12 @@ class Mailbox:
         if side == self._side:
             self.rx_message_ours(phase, body)
         else:
-            self.rx_message_theirs(side, phase, body)
+            if self._their_side is None:
+                self._their_side = side
+            if side == self._their_side:
+                self.rx_message_theirs(side, phase, body)
+            else:
+                self._B.crowded()
 
     @m.input()
     def rx_message_ours(self, phase, body):

--- a/src/wormhole/errors.py
+++ b/src/wormhole/errors.py
@@ -43,6 +43,8 @@ class LonelyError(WormholeError):
     """wormhole.close() was called before the peer connection could be
     established"""
 
+class CrowdedError(WormholeError):
+    """We received messages from multiple peers, there can be only one."""
 
 class WrongPasswordError(WormholeError):
     """

--- a/src/wormhole/test/test_machines.py
+++ b/src/wormhole/test/test_machines.py
@@ -1049,13 +1049,14 @@ def test_close_while_done_but_disconnected():
 def build_mailbox():
     events = []
     m = _mailbox.Mailbox("side1")
+    b = Dummy("b", events, IBoss, "crowded")
     n = Dummy("n", events, INameplate, "release")
     rc = Dummy("rc", events, IRendezvousConnector, "tx_add", "tx_open",
                "tx_close")
     o = Dummy("o", events, IOrder, "got_message")
     t = Dummy("t", events, ITerminator, "mailbox_done")
-    m.wire(n, rc, o, t)
-    return m, n, rc, o, t, events
+    m.wire(b, n, rc, o, t)
+    return m, b, n, rc, o, t, events
 
     # TODO: test moods
 
@@ -1067,7 +1068,7 @@ def assert_events(events, initial_events, tx_add_events):
 
 
 def test_connect_first_mailbox():  # connect before got_mailbox
-    m, n, rc, o, t, events = build_mailbox()
+    m, b, n, rc, o, t, events = build_mailbox()
     m.add_message("phase1", b"msg1")
     assert events == []
 
@@ -1160,7 +1161,7 @@ def test_connect_first_mailbox():  # connect before got_mailbox
     assert events == []
 
 def test_mailbox_first():  # got_mailbox before connect
-    m, n, rc, o, t, events = build_mailbox()
+    m, b, n, rc, o, t, events = build_mailbox()
     m.add_message("phase1", b"msg1")
     assert events == []
 
@@ -1175,27 +1176,42 @@ def test_mailbox_first():  # got_mailbox before connect
         ("rc.tx_add", "phase2", b"msg2"),
     })
 
+def test_mailbox_crowded():
+    m, b, n, rc, o, t, events = build_mailbox()
+    m.connected()
+    m.got_mailbox("mbox1")
+    assert events == [("rc.tx_open", "mbox1")]
+    events.clear()
+    m.rx_message("side2", "phase1", b"msg1")  # new message from peer
+    assert events == [
+        ("n.release", ),
+        ("o.got_message", "side2", "phase1", b"msg1"),
+    ]
+    events.clear()
+    # message from a third peer should break the connection
+    m.rx_message("side3", "phase1", b"msg3")
+    assert events == [("b.crowded", )]
 
 def test_close_while_idle():
-    m, n, rc, o, t, events = build_mailbox()
+    m, b, n, rc, o, t, events = build_mailbox()
     m.close("happy")
     assert events == [("t.mailbox_done", )]
 
 
 def test_close_while_idle_but_connected():
-    m, n, rc, o, t, events = build_mailbox()
+    m, b, n, rc, o, t, events = build_mailbox()
     m.connected()
     m.close("happy")
     assert events == [("t.mailbox_done", )]
 
 def test_close_while_mailbox_disconnected():
-    m, n, rc, o, t, events = build_mailbox()
+    m, b, n, rc, o, t, events = build_mailbox()
     m.got_mailbox("mbox1")
     m.close("happy")
     assert events == [("t.mailbox_done", )]
 
 def test_close_while_reconnecting():
-    m, n, rc, o, t, events = build_mailbox()
+    m, b, n, rc, o, t, events = build_mailbox()
     m.got_mailbox("mbox1")
     m.connected()
     assert events == [("rc.tx_open", "mbox1")]
@@ -1425,6 +1441,24 @@ def test_internal_error():
     assert events[0][0] == "w.closed"
     assert isinstance(events[0][1], ValueError)
     assert events[0][1].args[0] == "catch me"
+
+def test_boss_crowded():
+    b, events = build_boss()
+    # we can't become crowded without messages from a mailbox, which
+    # we can't get until we claim a nameplate, which we can't get
+    # without a code
+    b.set_code("1-code")
+    b.got_code("1-code")
+    assert events == [("c.set_code", "1-code"), ("w.got_code", "1-code")]
+    events.clear()
+
+    b.crowded()
+    assert events == [("t.close", "crowded")]
+    events.clear()
+    b.closed()
+    assert events[0][0] == "w.closed"
+    assert isinstance(events[0][1], errors.CrowdedError)
+    assert len(events) == 1
 
 def test_close_early():
     b, events = build_boss()


### PR DESCRIPTION
This changes the mailbox state machine to "imprint" upon the first side it sees, and reject any others by terminating with a CrowdedError. This is like WrongPasswordError (which indicates a cryptographic error) but merely means more than the two peers tried to use the same nameplate, usually because someone mistakenly attempted to reuse an old code.

A correctly-behaving mailbox server will not allow this to happen: when the third side appears, the server marks the mailbox as CROWDED, and clients who OPEN that mailbox (or CLAIM its nameplate) get back a "crowded" error before they can receive any of the extra messages. But a misbehaving server might let those messages get through, so clients should not accept them. And since a crowded mailbox means we don't really know which side is the "right" one, the safest thing to do is to terminate the wormhole and allow the user to try again.