### PR TITLE
change CLI to use on_status_update= instead of w.get_unverified_key()

### DIFF
--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -12,6 +12,7 @@ from twisted.python import log
 from wormhole import __version__, create, input_with_completion
 
 from ..errors import TransferError
+from .._status import WormholeStatus, AllegedSharedKey, ConfirmedKey
 from ..transit import TransitReceiver
 from ..util import (bytes_to_dict, bytes_to_hexstr, dict_to_bytes,
                     estimate_free_space)
@@ -55,6 +56,9 @@ class Receiver:
         self._reactor = reactor
         self._tor = None
         self._transit_receiver = None
+        self._old_status = WormholeStatus()
+        self._slow_key_timer = None
+        self._slow_verification_timer = None
 
     def _msg(self, *args, **kwargs):
         print(*args, file=self.args.stderr, **kwargs)
@@ -80,6 +84,7 @@ class Receiver:
             self._reactor,
             tor=self._tor,
             timing=self.args.timing,
+            on_status_update=self._on_status,
         )
         if self.args.debug_state:
             w.debug_set_trace("recv", which=" ".join(self.args.debug_state), file=self.args.stdout)
@@ -118,6 +123,46 @@ class Receiver:
         d.addCallbacks(_good, _bad)
         yield d
 
+    def _on_slow_key(self):
+        print("Waiting for sender...", file=self.args.stderr)
+
+    def _start_on_slow_key_timer(self):
+        if not self._slow_key_timer:
+            self._slow_key_timer = self._reactor.callLater(KEY_TIMER, self._on_slow_key)
+
+    def _cancel_on_slow_key_timer(self):
+        if self._slow_key_timer and not self._slow_key_timer.called:
+            self._slow_key_timer.cancel()
+            self._slow_key_timer = None
+
+    def _on_slow_verification(self):
+        print("Key established, waiting for confirmation...", file=self.args.stderr)
+
+    def _start_on_slow_verification_timer(self):
+        if not self._slow_verification_timer:
+            self._slow_verification_timer = self._reactor.callLater(VERIFY_TIMER, self._on_slow_verification)
+
+    def _cancel_on_slow_verification_timer(self):
+        t = self._slow_verification_timer
+        if t and not t.called:
+            t.cancel()
+            self._slow_verification_timer = None
+
+    def _on_status(self, status):
+        if status.peer_key != self._old_status.peer_key:
+            match status.peer_key:
+                case AllegedSharedKey():
+                    # This fires when we connect to the server and see the
+                    # senders PAKE message. If we used set_code() in the
+                    # "human-selected offline codes" mode, then the sender
+                    # might not have even started yet, so this might not
+                    # fire for a while.
+                    self._cancel_on_slow_key_timer()
+                    self._start_on_slow_verification_timer()
+                case ConfirmedKey():
+                    self._cancel_on_slow_verification_timer()
+        self._old_status = status
+
     @inlineCallbacks
     def _go(self, w):
         welcome = yield w.get_welcome()
@@ -126,29 +171,9 @@ class Receiver:
 
         yield self._handle_code(w)
 
-        def on_slow_key():
-            print("Waiting for sender...", file=self.args.stderr)
+        # this prints a pacifier message unless we get a key quickly
+        self._start_on_slow_key_timer()
 
-        notify = self._reactor.callLater(KEY_TIMER, on_slow_key)
-        try:
-            # We wait here until we connect to the server and see the senders
-            # PAKE message. If we used set_code() in the "human-selected
-            # offline codes" mode, then the sender might not have even
-            # started yet, so we might be sitting here for a while. Because
-            # of that possibility, it's probably not appropriate to give up
-            # automatically after some timeout. The user can express their
-            # impatience by quitting the program with control-C.
-            yield w.get_unverified_key()
-        finally:
-            if not notify.called:
-                notify.cancel()
-
-        def on_slow_verification():
-            print(
-                "Key established, waiting for confirmation...",
-                file=self.args.stderr)
-
-        notify = self._reactor.callLater(VERIFY_TIMER, on_slow_verification)
         try:
             # We wait here until we've seen their VERSION message (which they
             # send after seeing our PAKE message, and has the side-effect of
@@ -164,8 +189,9 @@ class Receiver:
             # long.
             verifier_bytes = yield w.get_verifier()
         finally:
-            if not notify.called:
-                notify.cancel()
+            self._cancel_on_slow_key_timer()
+            self._cancel_on_slow_verification_timer()
+
         self._show_verifier(verifier_bytes)
 
         want_offer = True

--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -15,7 +15,7 @@ from twisted.python import log
 from wormhole import __version__, create
 
 from ..errors import TransferError, UnsendableFileError
-from .._status import WormholeStatus, ConsumedCode
+from .._status import WormholeStatus, ConsumedCode, AllegedSharedKey, ConfirmedKey
 from ..transit import TransitSender
 from ..util import bytes_to_dict, bytes_to_hexstr, dict_to_bytes
 from .welcome import handle_welcome
@@ -47,7 +47,8 @@ class Sender:
         self._timing = args.timing
         self._fd_to_send = None
         self._transit_sender = None
-        self._status = WormholeStatus()
+        self._old_status = WormholeStatus()
+        self._slow_verification_timer = None
 
     @inlineCallbacks
     def go(self):
@@ -102,10 +103,31 @@ class Sender:
         data_bytes = dict_to_bytes(data)
         w.send_message(data_bytes)
 
+    def _on_slow_verification(self):
+        print("Key established, waiting for confirmation...", file=self._args.stderr)
+
+    def _start_on_slow_verification_timer(self):
+        if not self._slow_verification_timer:
+            self._slow_verification_timer = self._reactor.callLater(VERIFY_TIMER, self._on_slow_verification)
+
+    def _cancel_on_slow_verification_timer(self):
+        t = self._slow_verification_timer
+        if t and not t.called:
+            t.cancel()
+            self._slow_verification_timer = None
+
     def _on_status(self, status):
-        if not isinstance(self._status.code, ConsumedCode) and isinstance(status.code, ConsumedCode):
-            print("Note: code has been consumed and can no longer be used.", file=self._args.stdout)
-        self._status = status
+        if status.code != self._old_status.code:
+            match status.code:
+                case ConsumedCode():
+                    print("Note: code has been consumed and can no longer be used.", file=self._args.stdout)
+        if status.peer_key != self._old_status.peer_key:
+            match status.peer_key:
+                case AllegedSharedKey():
+                    self._start_on_slow_verification_timer()
+                case ConfirmedKey():
+                    self._cancel_on_slow_verification_timer()
+        self._old_status = status
 
     @inlineCallbacks
     def _go(self, w):
@@ -152,20 +174,18 @@ class Sender:
         # flush stderr so the code is displayed immediately
         args.stderr.flush()
 
-        # We don't print a "waiting" message for get_unverified_key() here,
-        # even though we do that in cmd_receive.py, because it's not at all
-        # surprising to we waiting here for a long time. We'll sit in
-        # get_unverified_key() until the receiver has typed in the code and
+        # We don't print a "Waiting" message before AllegedSharedKey,
+        # even though we do that in cmd_receive.py, because it's not
+        # at all surprising to we waiting here for a long time. We'll
+        # sit quietly until the receiver has typed in the code and
         # their PAKE message makes it to us.
-        yield w.get_unverified_key()
+
+        # but once _on_status(AllegedSharedKey) signals receipt of the
+        # unverified key, we start a pacification-message timer that
+        # is cancelled when the key is verified (ConfirmedKey)
 
         # TODO: don't stall on w.get_verifier() unless they want it
-        def on_slow_connection():
-            print(
-                "Key established, waiting for confirmation...",
-                file=args.stderr)
 
-        notify = self._reactor.callLater(VERIFY_TIMER, on_slow_connection)
         try:
             # The usual sender-chooses-code sequence means the receiver's
             # PAKE should be followed immediately by their VERSION, so
@@ -177,8 +197,7 @@ class Sender:
             # after a while.
             verifier_bytes = yield w.get_verifier()  # might WrongPasswordError
         finally:
-            if not notify.called:
-                notify.cancel()
+            self._cancel_on_slow_verification_timer()
 
         if args.verify:
             # check_verifier() does a blocking call to input(), so stall for


### PR DESCRIPTION
I'm looking to remove the w.get_unverified_key() API, because future versions of the PAKE protocol will use a different key for the key-confirmation message, so the final key won't be available early enough to provide anything like an "unverified" key. Also, it wasn't a good idea to expose the raw key anyways.

This changes the "wormhole send" and "wormhole receive" tools to manage their "waiting.." timers with the the on_status_update= callback API instead of get_unverified_key().

refs #732