### PR TITLE
remove get_unverified_key() and friends, update tests and docs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,10 @@ User-visible changes in "magic-wormhole":
 ## Upcoming Release
 
 * (add release-notes here when making PRs)
+* **INCOMPATIBLE**: the method ``get_unverified_key()`` has been removed from the object returned by ``wormhole.create()``.
+  In addition, `wormhole_got_unverified_key()` of the Delegate object is no longer called.
+  Applications should use ``derive_key()`` to derive purpose-specific subkeys, after the wormhole is established.
+  A valid use of this method was to learn when we get the final key, which can now be accomplished using "status" API (via `on_status_update=` kwarg to ``wormhole.create()``.
 
 
 ## Release 0.24.0 (5-May-2026)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -440,16 +440,6 @@ Most applications will only use ``code``, ``received``, and ``close``.
    after ``w.set_code(code)`` is called. This is most useful after
    calling ``w.allocate_code()``, to show the generated code to the user
    so they can transcribe it to their peer.
--  key (``yield w.get_unverified_key()`` /
-   ``dg.wormhole_got_unverified_key(key)``): fired (with the raw master
-   SPAKE2 key) when the key-exchange process has completed and a
-   purported shared key is established. At this point we do not know
-   that anyone else actually shares this key: the peer may have used the
-   wrong code, or may have disappeared altogether. To wait for proof
-   that the key is shared, wait for ``get_verifier`` instead. This event
-   is really only useful for detecting that the initiating peer has
-   disconnected after leaving the initial PAKE message, to display a
-   pacifying message to the user.
 -  verifier (``verifier = yield w.get_verifier()`` /
    ``dg.wormhole_got_verifier(verifier)``: fired when the key-exchange
    process has completed and a valid VERSION message has arrived. The
@@ -756,9 +746,6 @@ Full API list
 +----------------------+----------------------+----------------------+
 | .                    | d=w.get_code()       | dg.wor               |
 |                      |                      | mhole_got_code(code) |
-+----------------------+----------------------+----------------------+
-| .                    | d=w.                 | dg.wormhole_got      |
-|                      | get_unverified_key() | _unverified_key(key) |
 +----------------------+----------------------+----------------------+
 | .                    | d=w.get_verifier()   | dg.wormhole_go       |
 |                      |                      | t_verifier(verifier) |

--- a/src/wormhole/_boss.py
+++ b/src/wormhole/_boss.py
@@ -105,6 +105,7 @@ class Boss:
         self._rx_dilate_seqnums = {}  # seqnum -> plaintext
 
         self._result = "empty"
+        self._key = None
 
     def _evolve_wormhole_status(self, **kwargs):
         # we have to track "the wormhole status" somewhere, because
@@ -396,11 +397,13 @@ class Boss:
 
     @m.output()
     def W_got_key(self, key):
+        self._key = key
         self._W.got_key(key)
 
     @m.output()
-    def D_got_key(self, key):
-        self._D.got_key(key)
+    def D_got_verified_key(self, plaintext):
+        assert self._key
+        self._D.got_verified_key(self._key)
 
     @m.output()
     def send_status_peer_key(self, key):
@@ -466,14 +469,14 @@ class Boss:
     S1_lonely.upon(crowded, enter=S3_closing, outputs=[close_crowded])
     S1_lonely.upon(close, enter=S3_closing, outputs=[close_lonely])
     S1_lonely.upon(send, enter=S1_lonely, outputs=[S_send])
-    S1_lonely.upon(got_key, enter=S1_lonely, outputs=[W_got_key, D_got_key, send_status_peer_key])
+    S1_lonely.upon(got_key, enter=S1_lonely, outputs=[W_got_key, send_status_peer_key])
     S1_lonely.upon(rx_error, enter=S3_closing, outputs=[close_error])
     S1_lonely.upon(error, enter=S4_closed, outputs=[W_close_with_error, send_status_closed])
 
     S2_happy.upon(rx_unwelcome, enter=S3_closing, outputs=[close_unwelcome])
     S2_happy.upon(got_verifier, enter=S2_happy, outputs=[W_got_verifier])
     S2_happy.upon(_got_phase, enter=S2_happy, outputs=[W_received])
-    S2_happy.upon(_got_version, enter=S2_happy, outputs=[process_version, send_status_confirmed_key])
+    S2_happy.upon(_got_version, enter=S2_happy, outputs=[process_version, D_got_verified_key, send_status_confirmed_key])
     S2_happy.upon(_got_dilate, enter=S2_happy, outputs=[D_received_dilate])
     S2_happy.upon(scared, enter=S3_closing, outputs=[close_scared])
     S2_happy.upon(crowded, enter=S3_closing, outputs=[close_crowded])

--- a/src/wormhole/_dilation/manager.py
+++ b/src/wormhole/_dilation/manager.py
@@ -1027,7 +1027,7 @@ class Dilator:
 
     # from Boss
 
-    def got_key(self, key):
+    def got_verified_key(self, key):
         # TODO: verify this happens before got_wormhole_versions, or add a gate
         # to tolerate either ordering
         purpose = b"dilation-v1"

--- a/src/wormhole/_interfaces.py
+++ b/src/wormhole/_interfaces.py
@@ -56,18 +56,6 @@ class IWormholeDelegate(Interface):
         to allocate one, or because one was set.
         """
 
-    def wormhole_got_unverified_key(key: bytes) -> None:  # XXX definitely bytes?
-        """
-        We have received the symmetric, secret key. It is "unverified"
-        because we have not yet successfully exchanged a message
-        confirming that the other side has the same key; the first
-        such message is the "versions" message.
-
-        It is also possible for the users to confirm that the same key
-        is being used by comparing the "verifier" strings (which are a
-        hash of the key).
-        """
-
     def wormhole_got_verifier(verifier: bytes) -> None:  # XXX bytes, or str?
         """
         A tagged hash of the secret key. If both sides compare their
@@ -260,21 +248,6 @@ class IDeferredWormhole(Interface):
         :rtype: ``Deferred[str]``
         """
 
-    def get_unverified_key():
-        """
-        Wait for key-exchange to occur, then return the raw unverified SPAKE2
-        key.  When this fires, we have not seen any evidence that anyone else
-        shares this key (nor have we seen evidence of a failed attack: e.g. a
-        payload encrypted with a different key).
-
-        This is only useful for testing, and for noticing a significant delay
-        between the key-agreement message and the subsequent key-verification
-        ("versions") message.
-
-        :return: the raw unverified SPAKE2 key
-        :rtype: ``Deferred[bytes]``
-        """
-
     def get_verifier():
         """
         Wait for key verification to occur, then return the verifier string.
@@ -329,7 +302,7 @@ class IDeferredWormhole(Interface):
 
         This must be called after the key has been established, so after any
         of
-        ``get_unverified_key()/get_verifier()/get_versions()/get_message()``
+        ``get_verifier()/get_versions()/get_message()``
         have fired.  ``derive_key()`` returns immediately, rather than
         returning a ``Deferred``.
 

--- a/src/wormhole/_key.py
+++ b/src/wormhole/_key.py
@@ -198,10 +198,7 @@ class _SortedKey:
         assert isinstance(msg2, bytes)
         with self._timing.add("pake2", waiting="crypto"):
             key = self._sp.finish(msg2)
-        # TODO: make B.got_key() an eventual send, since it will fire the
-        # user/application-layer get_unverified_key() Deferred, and if that
-        # calls back into other wormhole APIs, bad things will happen
-        self._B.got_key(key)
+        self._B.got_key(key) # unverified
         phase = "version"
         data_key = derive_phase_key(key, self._side, phase)
         plaintext = dict_to_bytes(self._versions)

--- a/src/wormhole/cli/cmd_receive.py
+++ b/src/wormhole/cli/cmd_receive.py
@@ -57,7 +57,9 @@ class Receiver:
         self._tor = None
         self._transit_receiver = None
         self._old_status = WormholeStatus()
+        self._KEY_TIMER = KEY_TIMER
         self._slow_key_timer = None
+        self._VERIFY_TIMER = VERIFY_TIMER
         self._slow_verification_timer = None
 
     def _msg(self, *args, **kwargs):
@@ -128,7 +130,7 @@ class Receiver:
 
     def _start_on_slow_key_timer(self):
         if not self._slow_key_timer:
-            self._slow_key_timer = self._reactor.callLater(KEY_TIMER, self._on_slow_key)
+            self._slow_key_timer = self._reactor.callLater(self._KEY_TIMER, self._on_slow_key)
 
     def _cancel_on_slow_key_timer(self):
         if self._slow_key_timer and not self._slow_key_timer.called:
@@ -140,7 +142,7 @@ class Receiver:
 
     def _start_on_slow_verification_timer(self):
         if not self._slow_verification_timer:
-            self._slow_verification_timer = self._reactor.callLater(VERIFY_TIMER, self._on_slow_verification)
+            self._slow_verification_timer = self._reactor.callLater(self._VERIFY_TIMER, self._on_slow_verification)
 
     def _cancel_on_slow_verification_timer(self):
         t = self._slow_verification_timer

--- a/src/wormhole/cli/cmd_send.py
+++ b/src/wormhole/cli/cmd_send.py
@@ -48,6 +48,7 @@ class Sender:
         self._fd_to_send = None
         self._transit_sender = None
         self._old_status = WormholeStatus()
+        self._VERIFY_TIMER = VERIFY_TIMER
         self._slow_verification_timer = None
 
     @inlineCallbacks
@@ -108,7 +109,7 @@ class Sender:
 
     def _start_on_slow_verification_timer(self):
         if not self._slow_verification_timer:
-            self._slow_verification_timer = self._reactor.callLater(VERIFY_TIMER, self._on_slow_verification)
+            self._slow_verification_timer = self._reactor.callLater(self._VERIFY_TIMER, self._on_slow_verification)
 
     def _cancel_on_slow_verification_timer(self):
         t = self._slow_verification_timer

--- a/src/wormhole/test/conftest.py
+++ b/src/wormhole/test/conftest.py
@@ -51,7 +51,8 @@ class Observer:
     def __call__(self, event_dict):
         is_error = event_dict.get('isError')
         if is_error:
-            self.failures.append(event_dict["failure"])
+            f = event_dict.get("failure") or event_dict.get("message")
+            self.failures.append(f)
 
     def flush(self, klass):
         flushed = [
@@ -70,7 +71,7 @@ class Observer:
         assert [] == self.failures
 
 
-@pytest.fixture
+@pytest.fixture(autouse=True)
 def observe_errors():
     observer = Observer()
     gc.collect()

--- a/src/wormhole/test/dilate/test_connect.py
+++ b/src/wormhole/test/dilate/test_connect.py
@@ -59,13 +59,13 @@ async def test1():
 
     d_left = manager.Dilator(reactor, eq, cooperator, ["ged"])
     d_left.wire(send_left, t_left)
-    d_left.got_key(key)
+    d_left.got_verified_key(key)
     d_left.got_wormhole_versions({"can-dilate": ["ged"]})
     send_left.dilator = d_left
 
     d_right = manager.Dilator(reactor, eq, cooperator, ["ged"])
     d_right.wire(send_right, t_right)
-    d_right.got_key(key)
+    d_right.got_verified_key(key)
     d_right.got_wormhole_versions({"can-dilate": ["ged"]})
     send_right.dilator = d_right
 

--- a/src/wormhole/test/dilate/test_manager.py
+++ b/src/wormhole/test/dilate/test_manager.py
@@ -71,7 +71,7 @@ def test_dilate_first():
     transit_key = object()
     with mock.patch("wormhole._dilation.manager.derive_key",
                     return_value=transit_key) as dk:
-        dil.got_key(key)
+        dil.got_verified_key(key)
     assert dk.mock_calls == [mock.call(key, b"dilation-v1", 32)]
     assert m.mock_calls == [mock.call.got_dilation_key(transit_key)]
     clear_mock_calls(m)
@@ -107,7 +107,7 @@ def test_dilate_later():
     transit_key = object()
     with mock.patch("wormhole._dilation.manager.derive_key",
                     return_value=transit_key) as dk:
-        dil.got_key(key)
+        dil.got_verified_key(key)
     assert dk.mock_calls == [mock.call(key, b"dilation-v1", 32)]
 
     wv = object()
@@ -143,7 +143,7 @@ async def test_peer_cannot_dilate():
     (dil, h) = make_dilator()
     eps = dil.dilate()
 
-    dil.got_key(b"\x01" * 32)
+    dil.got_verified_key(b"\x01" * 32)
     dil.got_wormhole_versions({})  # missing "can-dilate"
     f = mock.Mock()
     d = eps.connector_for("proto").connect(f)
@@ -157,7 +157,7 @@ async def test_disjoint_versions():
     (dil, h) = make_dilator()
     eps = dil.dilate()
 
-    dil.got_key(b"\x01" * 32)
+    dil.got_verified_key(b"\x01" * 32)
     dil.got_wormhole_versions({"can-dilate": ["-1"]})
     f = mock.Mock()
     d = eps.connector_for("proto").connect(f)

--- a/src/wormhole/test/test_cli.py
+++ b/src/wormhole/test/test_cli.py
@@ -599,32 +599,27 @@ async def _do_test(
                 receive_d = cmd_receive.receive(recv_cfg)
         else:
             KEY_TIMER = 0 if mode == "slow-sender-text" else 99999
-            rxw = []
-            with mock.patch.object(cmd_receive, "KEY_TIMER", KEY_TIMER):
+            VERIFY_TIMER = 0 if mode == "slow-text" else 99999
+            with (mock.patch.object(cmd_receive, "KEY_TIMER", KEY_TIMER),
+                  mock.patch.object(cmd_receive, "VERIFY_TIMER", VERIFY_TIMER),
+                  mock.patch.object(cmd_send, "VERIFY_TIMER", VERIFY_TIMER)):
                 send_d = cmd_send.send(send_cfg)
-                receive_d = cmd_receive.receive(recv_cfg, _debug_stash_wormhole=rxw)
-                # we need to keep KEY_TIMER patched until the receiver
-                # gets far enough to start the timer, which happens after
-                # the code is set
-                if mode == "slow-sender-text":
-                    await rxw[0].get_unverified_key()
+                receive_d = cmd_receive.receive(recv_cfg)
+                # both Sender and Receiver sample KEY/VERIFY_TIMER at creation
 
         # The sender might fail, leaving the receiver hanging, or vice
         # versa. Make sure we don't wait on one side exclusively
-        VERIFY_TIMER = 0 if mode == "slow-text" else 99999
-        with mock.patch.object(cmd_receive, "VERIFY_TIMER", VERIFY_TIMER):
-            with mock.patch.object(cmd_send, "VERIFY_TIMER", VERIFY_TIMER):
-                if mock_accept or verify:
-                    with mock.patch.object(builtins, 'input',
-                            return_value='yes') as i:
-                        await gatherResults([send_d, receive_d], True)
-                    if verify:
-                        s = i.mock_calls[0][1][0]
-                        mo = re.search(r'^Verifier (\w+)\. ok\?', s)
-                        assert mo, s
-                        sender_verifier = mo.group(1)
-                else:
-                    await gatherResults([send_d, receive_d], True)
+        if mock_accept or verify:
+            with mock.patch.object(builtins, 'input',
+                    return_value='yes') as i:
+                await gatherResults([send_d, receive_d], True)
+            if verify:
+                s = i.mock_calls[0][1][0]
+                mo = re.search(r'^Verifier (\w+)\. ok\?', s)
+                assert mo, s
+                sender_verifier = mo.group(1)
+        else:
+            await gatherResults([send_d, receive_d], True)
 
         if fake_tor:
             expected_endpoints = [("127.0.0.1", mailbox.port._realPortNumber, False)]

--- a/src/wormhole/test/test_machines.py
+++ b/src/wormhole/test/test_machines.py
@@ -1341,7 +1341,7 @@ def build_boss():
     b._RC = Dummy("rc", events, IRendezvousConnector, "start")
     b._C = Dummy("c", events, ICode, "allocate_code", "input_code",
                  "set_code")
-    b._D = Dummy("d", events, IDilator, "got_wormhole_versions", "got_key", _manager=None)
+    b._D = Dummy("d", events, IDilator, "got_wormhole_versions", "got_verified_key", _manager=None)
     return b, events
 
 def test_boss_basic():
@@ -1369,10 +1369,10 @@ def test_boss_basic():
     b.got_message("0", b"msg1")
     assert events == [
         ("w.got_key", b"key"),
-        ("d.got_key", b"key"),
         ("w.got_verifier", b"verifier"),
         ("d.got_wormhole_versions", {}),
         ("w.got_versions", {}),
+        ("d.got_verified_key", b"key"),
         ("w.received", b"msg1"),
     ]
     events[:] = []

--- a/src/wormhole/test/test_wormhole.py
+++ b/src/wormhole/test/test_wormhole.py
@@ -34,7 +34,6 @@ class Delegate:
     def __init__(self):
         self.welcome = None
         self.code = None
-        self.key = None
         self.verifier = None
         self.versions = None
         self.messages = []
@@ -45,9 +44,6 @@ class Delegate:
 
     def wormhole_got_code(self, code):
         self.code = code
-
-    def wormhole_got_unverified_key(self, key):
-        self.key = key
 
     def wormhole_got_verifier(self, verifier):
         self.verifier = verifier
@@ -61,6 +57,20 @@ class Delegate:
     def wormhole_closed(self, result):
         self.closed = result
 
+class DelegateWithOldMethod(Delegate):
+
+    def wormhole_got_unverified_key(self, key):
+        raise NotImplementedError("should not be called")
+
+
+@ensureDeferred
+async def test_delegated_old_method(reactor, mailbox, observe_errors):
+    dg = DelegateWithOldMethod()
+    wormhole.create(APPID, mailbox.url, reactor, delegate=dg)
+    flushed = observe_errors.flush(DeprecationWarning)
+    assert len(flushed) == 1
+    assert "wormhole_got_unverified_key has been removed" in str(flushed[0])
+
 
 @ensureDeferred
 async def test_delegated(reactor, mailbox):
@@ -73,7 +83,6 @@ async def test_delegated(reactor, mailbox):
     assert dg.code == "1-abc"
     w2 = wormhole.create(APPID, mailbox.url, reactor)
     w2.set_code(dg.code)
-    await poll_until(lambda: dg.key is not None)
     await poll_until(lambda: dg.verifier is not None)
     await poll_until(lambda: dg.versions is not None)
 
@@ -158,8 +167,9 @@ async def test_basic(reactor, mailbox):
     code = await w1.get_code()
     w2.set_code(code)
 
-    await w1.get_unverified_key()
-    await w2.get_unverified_key()
+    verifier1 = await w1.get_verifier()
+    verifier2 = await w2.get_verifier()
+    assert verifier1 == verifier2
 
     key1 = w1.derive_key("purpose", 16)
     assert len(key1) == 16
@@ -168,10 +178,6 @@ async def test_basic(reactor, mailbox):
         w1.derive_key(b"not unicode", 16)
     with pytest.raises(TypeError):
         w1.derive_key(12345, 16)
-
-    verifier1 = await w1.get_verifier()
-    verifier2 = await w2.get_verifier()
-    assert verifier1 == verifier2
 
     versions1 = await w1.get_versions()
     versions2 = await w2.get_versions()
@@ -368,8 +374,6 @@ async def test_closed(reactor, mailbox):
         await w1.get_code()
     assert f.value.args[0] == "happy"
     with pytest.raises(WormholeClosed):
-        await w1.get_unverified_key()
-    with pytest.raises(WormholeClosed):
         await w1.get_verifier()
     with pytest.raises(WormholeClosed):
         await w1.get_versions()
@@ -386,7 +390,6 @@ async def test_closed_idle(reactor):
     d_welcome = w1.get_welcome()
     assert not d_welcome.called
     d_code = w1.get_code()
-    d_key = w1.get_unverified_key()
     d_verifier = w1.get_verifier()
     d_versions = w1.get_versions()
     d_message = w1.get_message()
@@ -398,8 +401,6 @@ async def test_closed_idle(reactor):
         await d_welcome
     with pytest.raises(LonelyError):
         await d_code
-    with pytest.raises(LonelyError):
-        await d_key
     with pytest.raises(LonelyError):
         await d_verifier
     with pytest.raises(LonelyError):
@@ -424,14 +425,6 @@ async def test_wrong_password(reactor, mailbox):
     # message arrives.
     w1.send_message(b"should still work")
     w2.send_message(b"should still work")
-
-    key2 = await w2.get_unverified_key()  # should work
-    # w2 has just received w1.PAKE, and is about to send w2.VERSION
-    key1 = await w1.get_unverified_key()  # should work
-    # w1 has just received w2.PAKE, and is about to send w1.VERSION, and
-    # then will receive w2.VERSION. When it sees w2.VERSION, it will
-    # learn about the WrongPasswordError.
-    assert key1 != key2
 
     # API calls that wait (i.e. get) will errback. We collect all these
     # Deferreds early to exercise the wait-then-fail path
@@ -464,21 +457,16 @@ async def test_wrong_password(reactor, mailbox):
     with pytest.raises(WrongPasswordError):
         await d2_received
 
-    # and at this point, with the failure safely noticed by both sides,
-    # new get_unverified_key() calls should signal the failure, even
-    # before we close
+    # and at this point, with the failure safely noticed by both
+    # sides, new calls should immediately signal failure, even before
+    # we close
 
-    # any new calls in the error state should immediately fail
-    with pytest.raises(WrongPasswordError):
-        await w1.get_unverified_key()
     with pytest.raises(WrongPasswordError):
         await w1.get_verifier()
     with pytest.raises(WrongPasswordError):
         await w1.get_versions()
     with pytest.raises(WrongPasswordError):
         await w1.get_message()
-    with pytest.raises(WrongPasswordError):
-        await w2.get_unverified_key()
     with pytest.raises(WrongPasswordError):
         await w2.get_verifier()
     with pytest.raises(WrongPasswordError):
@@ -493,15 +481,11 @@ async def test_wrong_password(reactor, mailbox):
 
     # API calls should still get the error, not WormholeClosed
     with pytest.raises(WrongPasswordError):
-        await w1.get_unverified_key()
-    with pytest.raises(WrongPasswordError):
         await w1.get_verifier()
     with pytest.raises(WrongPasswordError):
         await w1.get_versions()
     with pytest.raises(WrongPasswordError):
         await w1.get_message()
-    with pytest.raises(WrongPasswordError):
-        await w2.get_unverified_key()
     with pytest.raises(WrongPasswordError):
         await w2.get_verifier()
     with pytest.raises(WrongPasswordError):
@@ -758,10 +742,8 @@ async def test_bad_dns(reactor):
     # that should have already received an error, when it tried to
     # resolve the bogus DNS name. All API calls will return an error.
 
-    e = await assertSCEFailure(eq, w.get_unverified_key(), ValueError)
-    assert isinstance(e, ValueError)
+    e = await assertSCEFailure(eq, w.get_code(), ValueError)
     assert str(e) == "invalid hostname: %%%.example.org"
-    await assertSCEFailure(eq, w.get_code(), ValueError)
     await assertSCEFailure(eq, w.get_verifier(), ValueError)
     await assertSCEFailure(eq, w.get_versions(), ValueError)
     await assertSCEFailure(eq, w.get_message(), ValueError)
@@ -783,12 +765,10 @@ async def test_no_connection(reactor):
     w = wormhole.create(APPID, f"ws://127.0.0.1:{port}/v1", reactor)
     # nothing is listening, but it will take a turn to discover that
     d1 = w.get_code()
-    d2 = w.get_unverified_key()
     d3 = w.get_verifier()
     d4 = w.get_versions()
     d5 = w.get_message()
     await assertSCE(d1, ConnectionRefusedError)
-    await assertSCE(d2, ConnectionRefusedError)
     await assertSCE(d3, ConnectionRefusedError)
     await assertSCE(d4, ConnectionRefusedError)
     await assertSCE(d5, ConnectionRefusedError)
@@ -802,12 +782,10 @@ async def test_all_deferreds(reactor):
     # nothing is listening, but it will take a turn to discover that
     w.allocate_code()
     d1 = w.get_code()
-    d2 = w.get_unverified_key()
     d3 = w.get_verifier()
     d4 = w.get_versions()
     d5 = w.get_message()
     await assertSCE(d1, ConnectionRefusedError)
-    await assertSCE(d2, ConnectionRefusedError)
     await assertSCE(d3, ConnectionRefusedError)
     await assertSCE(d4, ConnectionRefusedError)
     await assertSCE(d5, ConnectionRefusedError)

--- a/src/wormhole/wormhole.py
+++ b/src/wormhole/wormhole.py
@@ -2,7 +2,7 @@ import os
 import sys
 
 from attr import attrib, attrs
-from twisted.python import failure
+from twisted.python import failure, log
 from twisted.internet.task import Cooperator
 from zope.interface import implementer
 
@@ -104,8 +104,7 @@ class _DelegatedWormhole:
     def got_code(self, code):
         self._delegate.wormhole_got_code(code)
 
-    def got_key(self, key):
-        self._delegate.wormhole_got_unverified_key(key)
+    def got_key(self, key): # unverified
         self._key = key  # for derive_key()
 
     def got_verifier(self, verifier):
@@ -128,7 +127,6 @@ class _DeferredWormhole:
         self._welcome_observer = OneShotObserver(eq)
         self._code_observer = OneShotObserver(eq)
         self._key = None
-        self._key_observer = OneShotObserver(eq)
         self._verifier_observer = OneShotObserver(eq)
         self._version_observer = OneShotObserver(eq)
         self._received_observer = SequenceObserver(eq)
@@ -151,9 +149,6 @@ class _DeferredWormhole:
 
     def get_welcome(self):
         return self._welcome_observer.when_fired()
-
-    def get_unverified_key(self):
-        return self._key_observer.when_fired()
 
     def get_verifier(self):
         return self._verifier_observer.when_fired()
@@ -229,9 +224,8 @@ class _DeferredWormhole:
     def got_code(self, code):
         self._code_observer.fire_if_not_fired(code)
 
-    def got_key(self, key):
+    def got_key(self, key): # unverified
         self._key = key  # for derive_key()
-        self._key_observer.fire_if_not_fired(key)
 
     def got_verifier(self, verifier):
         self._verifier_observer.fire_if_not_fired(verifier)
@@ -257,7 +251,6 @@ class _DeferredWormhole:
             self._closed_observer.fire_if_not_fired(result)
         self._welcome_observer.error(f)
         self._code_observer.error(f)
-        self._key_observer.error(f)
         self._verifier_observer.error(f)
         self._version_observer.error(f)
         self._received_observer.fire(f)
@@ -283,6 +276,8 @@ def create(
     cooperator = Cooperator(scheduler=eq.eventually)
 
     if delegate:
+        if hasattr(delegate, "wormhole_got_unverified_key"):
+            log.err(DeprecationWarning("WARNING: wormhole_got_unverified_key has been removed, see #732"))
         w = _DelegatedWormhole(delegate)
     else:
         w = _DeferredWormhole(reactor, eq, _enable_dilate=bool(dilation))


### PR DESCRIPTION
wormhole.get_unverified_key() and
delegate.wormhole_got_unverified_key() were removed. If the delegate
has such a method, emit a log.err warning at creation time. The docs
and Interface definitions were updated to match.

Tests were updated to not use get_unverified_key(). This required
tweaks to cmd_send.py/cmd_receive.py (to sample KEY_TIMER earlier) and
the conftest.py fixtures (to properly capture log.err() even when it
is called with a string instead of an Exception).


<!-- readthedocs-preview magic-wormhole start -->
Please see the rendered documentation: https://magic-wormhole--733.org.readthedocs.build/en/733/
<!-- readthedocs-preview magic-wormhole end -->