### PR TITLE
Docs: Fix typo "Connction" in dilation-protocol.rst

### DIFF
--- a/docs/dilation-protocol.rst
+++ b/docs/dilation-protocol.rst
@@ -583,7 +583,7 @@ implementation (in the ``wormhole._dilation`` package):
 Internally, the overall endeavour is managed by the ``Manager`` object.
 For each generation, a single ``Connection`` object is created; this
 object manages the race between potential hints-based peer connections.
-A ``DilatedConnctionProtocol`` instance manages the Noise session
+A ``DilatedConnectionProtocol`` instance manages the Noise session
 itself.
 
 It knows via its ``_role`` attribute whether it is on the Leader or


### PR DESCRIPTION
Fix typo in dilation-protocol.rst: `Connction` to `Connection`

Note: I originally planned to include other typos corrections in this PR, but upon further review, they were not appropriate to change (acceptable alternative word spellings, or misspelled variables baked into the code).


<!-- readthedocs-preview magic-wormhole start -->
Please see the rendered documentation: https://magic-wormhole--735.org.readthedocs.build/en/735/
<!-- readthedocs-preview magic-wormhole end -->